### PR TITLE
Add return MarshalAs attribute

### DIFF
--- a/ClangSharpPInvokeGenerator/Extensions.cs
+++ b/ClangSharpPInvokeGenerator/Extensions.cs
@@ -20,7 +20,10 @@
                 switch (pointee.kind)
                 {
                     case CXTypeKind.CXType_Char_S:
+                    case CXTypeKind.CXType_WChar:
+                    {
                         return true;
+                    }
                 }
             }
 
@@ -118,7 +121,28 @@
             var functionName = clang.getCursorSpelling(cursor).ToString();
             var resultType = clang.getCursorResultType(cursor);
 
+
             tw.WriteLine("        [DllImport(libraryPath, EntryPoint = \"" + functionName + "\", CallingConvention = " + functionType.CallingConventionSpelling() + ")]");
+
+            //If return type is string then we'll add  a MarshalAs
+            if (resultType.IsPtrToConstChar())
+            {
+                var pointee = clang.getPointeeType(resultType);
+                switch (pointee.kind)
+                {
+                    case CXTypeKind.CXType_Char_S:
+                    {
+                        tw.WriteLine("        [return: MarshalAs(UnmanagedType.LPStr)]");
+                        break;
+                    }
+                    case CXTypeKind.CXType_WChar:
+                    {
+                        tw.WriteLine("        [return: MarshalAs(UnmanagedType.LPWStr)]");
+                        break;
+                    }
+                }
+            }
+
             tw.Write("        public static extern ");
 
             ReturnTypeHelper(resultType, tw);

--- a/ClangSharpPInvokeGenerator/Extensions.cs
+++ b/ClangSharpPInvokeGenerator/Extensions.cs
@@ -121,7 +121,6 @@
             var functionName = clang.getCursorSpelling(cursor).ToString();
             var resultType = clang.getCursorResultType(cursor);
 
-
             tw.WriteLine("        [DllImport(libraryPath, EntryPoint = \"" + functionName + "\", CallingConvention = " + functionType.CallingConventionSpelling() + ")]");
 
             //If return type is string then we'll add  a MarshalAs

--- a/Generated.cs
+++ b/Generated.cs
@@ -1251,6 +1251,7 @@ namespace ClangSharp
         private const string libraryPath = "libclang";
 
         [DllImport(libraryPath, EntryPoint = "clang_getCString", CallingConvention = CallingConvention.Cdecl)]
+        [return: MarshalAs(UnmanagedType.LPStr)]
         public static extern string getCString(CXString @string);
 
         [DllImport(libraryPath, EntryPoint = "clang_disposeString", CallingConvention = CallingConvention.Cdecl)]
@@ -1473,6 +1474,7 @@ namespace ClangSharp
         public static extern uint defaultReparseOptions(CXTranslationUnit @TU);
 
         [DllImport(libraryPath, EntryPoint = "clang_getTUResourceUsageName", CallingConvention = CallingConvention.Cdecl)]
+        [return: MarshalAs(UnmanagedType.LPStr)]
         public static extern string getTUResourceUsageName(CXTUResourceUsageKind @kind);
 
         [DllImport(libraryPath, EntryPoint = "clang_getCXTUResourceUsage", CallingConvention = CallingConvention.Cdecl)]
@@ -2013,6 +2015,7 @@ namespace ClangSharp
         public static extern double EvalResult_getAsDouble(CXEvalResult @E);
 
         [DllImport(libraryPath, EntryPoint = "clang_EvalResult_getAsStr", CallingConvention = CallingConvention.Cdecl)]
+        [return: MarshalAs(UnmanagedType.LPStr)]
         public static extern string EvalResult_getAsStr(CXEvalResult @E);
 
         [DllImport(libraryPath, EntryPoint = "clang_EvalResult_dispose", CallingConvention = CallingConvention.Cdecl)]


### PR DESCRIPTION
For params the `MarshalAs` attribute is applied, this applies it for the `return param` as well.

Currently only for strings