### PR TITLE
Adding support for more 

### DIFF
--- a/ClangSharpPInvokeGenerator/Program.cs
+++ b/ClangSharpPInvokeGenerator/Program.cs
@@ -115,7 +115,7 @@ namespace ClangSharpPInvokeGenerator
             {
                 CXTranslationUnit translationUnit;
                 CXUnsavedFile[] unsavedFile = new CXUnsavedFile[0];
-                var translationUnitError = clang.parseTranslationUnit2(createIndex, file, arr, 3, unsavedFile, 0, 0, out translationUnit);
+                var translationUnitError = clang.parseTranslationUnit2(createIndex, file, arr, arr.Length, unsavedFile, 0, 0, out translationUnit);
 
                 if (translationUnitError != CXErrorCode.CXError_Success)
                 {

--- a/ClangSharpPInvokeGenerator/Program.cs
+++ b/ClangSharpPInvokeGenerator/Program.cs
@@ -18,6 +18,7 @@ namespace ClangSharpPInvokeGenerator
 
             var files = new List<string>();
             var includeDirs = new List<string>();
+            var defines = new List<string>();
             string outputFile = string.Empty;
             string @namespace = string.Empty;
             string libraryPath = string.Empty;
@@ -41,6 +42,11 @@ namespace ClangSharpPInvokeGenerator
                 if (string.Equals(match.Key, "--i") || string.Equals(match.Key, "--include"))
                 {
                     includeDirs.Add(match.Value);
+                }
+
+                if (string.Equals(match.Key, "--d") || string.Equals(match.Key, "--define"))
+                {
+                    defines.Add(match.Value);
                 }
 
                 if (string.Equals(match.Key, "--o") || string.Equals(match.Key, "--output"))
@@ -92,7 +98,7 @@ namespace ClangSharpPInvokeGenerator
 
             if (errorList.Any())
             {
-                Console.WriteLine("Usage: ClangPInvokeGenerator --file [fileLocation] --libraryPath [library.dll] --output [output.cs] --namespace [Namespace] --include [headerFileIncludeDirs] --excludeFunctions [func1,func2]");
+                Console.WriteLine("Usage: ClangPInvokeGenerator --file [fileLocation] --libraryPath [library.dll] --output [output.cs] --namespace [Namespace] --include [headerFileIncludeDirs] --define [compilerDefine] --excludeFunctions [func1,func2]");
                 foreach (var error in errorList)
                 {
                     Console.WriteLine(error);
@@ -108,6 +114,7 @@ namespace ClangSharpPInvokeGenerator
             string[] arr = { "-x", "c++" };
 
             arr = arr.Concat(includeDirs.Select(x => "-I" + x)).ToArray();
+            arr = arr.Concat(defines.Select(x => "-D" + x)).ToArray();
 
             List<CXTranslationUnit> translationUnits = new List<CXTranslationUnit>();
 

--- a/ClangSharpPInvokeGenerator/Program.cs
+++ b/ClangSharpPInvokeGenerator/Program.cs
@@ -19,12 +19,13 @@ namespace ClangSharpPInvokeGenerator
             var files = new List<string>();
             var includeDirs = new List<string>();
             var defines = new List<string>();
+            var additionalArgs = new List<string>();
             string outputFile = string.Empty;
             string @namespace = string.Empty;
             string libraryPath = string.Empty;
             string prefixStrip = string.Empty;
             string methodClassName = "Methods";
-            string excludeFunctions = "";
+            string excludeFunctions = string.Empty;
             string[] excludeFunctionsArray = null;
 
             foreach (KeyValuePair<string, string> match in matches)
@@ -47,6 +48,11 @@ namespace ClangSharpPInvokeGenerator
                 if (string.Equals(match.Key, "--d") || string.Equals(match.Key, "--define"))
                 {
                     defines.Add(match.Value);
+                }
+
+                if (string.Equals(match.Key, "--a") || string.Equals(match.Key, "--additional"))
+                {
+                    additionalArgs.Add(match.Value);
                 }
 
                 if (string.Equals(match.Key, "--o") || string.Equals(match.Key, "--output"))
@@ -98,7 +104,7 @@ namespace ClangSharpPInvokeGenerator
 
             if (errorList.Any())
             {
-                Console.WriteLine("Usage: ClangPInvokeGenerator --file [fileLocation] --libraryPath [library.dll] --output [output.cs] --namespace [Namespace] --include [headerFileIncludeDirs] --define [compilerDefine] --excludeFunctions [func1,func2]");
+                Console.WriteLine("Usage: ClangPInvokeGenerator --file [fileLocation] --libraryPath [library.dll] --output [output.cs] --namespace [Namespace] --include [headerFileIncludeDirs] --define [compilerDefine] --additional [compilerArg] --excludeFunctions [func1,func2]");
                 foreach (var error in errorList)
                 {
                     Console.WriteLine(error);
@@ -115,6 +121,7 @@ namespace ClangSharpPInvokeGenerator
 
             arr = arr.Concat(includeDirs.Select(x => "-I" + x)).ToArray();
             arr = arr.Concat(defines.Select(x => "-D" + x)).ToArray();
+            arr = arr.Concat(additionalArgs).ToArray();
 
             List<CXTranslationUnit> translationUnits = new List<CXTranslationUnit>();
 


### PR DESCRIPTION
This updates the ClangSharpPInvokeGenerator to support multiple include directories, specifying macro definitions, and passing of arbitrary arguments down.

This makes it much more powerful for parsing arbitrary C/C++ files.