### PR TITLE
 Adding more extensions to expose APIs in an object oriented manner.

### DIFF
--- a/ClangSharp.Test/TranslationUnit.cs
+++ b/ClangSharp.Test/TranslationUnit.cs
@@ -36,5 +36,35 @@ namespace ClangSharp.Test
                 Directory.Delete(dir, true);
             }
         }
+
+        [Theory]
+        [InlineData("basic")]
+        [InlineData("example with spaces")]
+        [InlineData("♫")]
+        public void BasicWrapper(string name)
+        {
+            // Create a unique directory
+            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(dir);
+
+            try
+            {
+                // Create a file with the right name
+                var file = new FileInfo(Path.Combine(dir, name + ".c"));
+                File.WriteAllText(file.FullName, "int main() { return 0; }");
+
+                var index = CXIndex.Create();
+                var translationUnit = CXTranslationUnit.Parse(index, file.FullName, Array.Empty<string>(), Array.Empty<CXUnsavedFile>(), CXTranslationUnit_Flags.CXTranslationUnit_None);
+                var clangFile = translationUnit.GetFile(file.FullName);
+                var clangFileName = clangFile.Name;
+                var clangFileNameString = clangFileName.CString;
+
+                Assert.Equal(file.FullName, clangFileNameString);
+            }
+            finally
+            {
+                Directory.Delete(dir, true);
+            }
+        }
     }
 }

--- a/ClangSharp/ClangSharp.csproj
+++ b/ClangSharp/ClangSharp.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 

--- a/ClangSharp/Extensions/CXComment.cs
+++ b/ClangSharp/Extensions/CXComment.cs
@@ -1,0 +1,73 @@
+﻿namespace ClangSharp
+{
+    public partial struct CXComment
+    {
+        public CXString BlockCommandComment_CommandName => clang.BlockCommandComment_getCommandName(this);
+
+        public uint BlockCommandComment_NumArgs => clang.BlockCommandComment_getNumArgs(this);
+
+        public CXComment BlockCommandComment_Paragraph => clang.BlockCommandComment_getParagraph(this);
+
+        public CXString FullComment_AsHtml => clang.FullComment_getAsHTML(this);
+
+        public CXString FullComment_AsXml => clang.FullComment_getAsXML(this);
+
+        public uint HtmlStartTag_NumAttrs => clang.HTMLStartTag_getNumAttrs(this);
+
+        public bool HtmlStartTagComment_IsSelfClosing => clang.HTMLStartTagComment_isSelfClosing(this) != 0;
+
+        public CXString HtmlTagComment_AsString => clang.HTMLTagComment_getAsString(this);
+
+        public CXString HtmlTagComment_TagName => clang.HTMLTagComment_getTagName(this);
+
+        public CXString InlineCommandComment_CommandName => clang.InlineCommandComment_getCommandName(this);
+
+        public uint InlineCommandComment_NumArgs => clang.InlineCommandComment_getNumArgs(this);
+
+        public CXCommentInlineCommandRenderKind InlineCommandComment_RenderKind => clang.InlineCommandComment_getRenderKind(this);
+
+        public bool InlineContentComment_HasTrailingNewline => clang.InlineContentComment_hasTrailingNewline(this) != 0;
+
+        public bool IsWhitesapce => clang.Comment_isWhitespace(this) != 0;
+
+        public CXCommentKind Kind => clang.Comment_getKind(this);
+
+        public uint NumChildren => clang.Comment_getNumChildren(this);
+
+        public CXCommentParamPassDirection ParamCommandComment_Direction => clang.ParamCommandComment_getDirection(this);
+
+        public bool ParamCommandComment_IsDirectionExplicit => clang.ParamCommandComment_isDirectionExplicit(this) != 0;
+
+        public bool ParamCommandComment_IsParamIndexValid => clang.ParamCommandComment_isParamIndexValid(this) != 0;
+
+        public uint ParamCommandComment_ParamIndex => clang.ParamCommandComment_getParamIndex(this);
+
+        public CXString ParamCommandComment_ParamName => clang.ParamCommandComment_getParamName(this);
+
+        public CXString TextComment_Text => clang.TextComment_getText(this);
+
+        public uint TParamCommandComment_Depth => clang.TParamCommandComment_getDepth(this);
+
+        public CXString TParamCommandComment_ParamName => clang.TParamCommandComment_getParamName(this);
+
+        public bool TParamCommandComment_IsParamPositionValid => clang.TParamCommandComment_isParamPositionValid(this) != 0;
+
+        public CXString VerbatimBlockLineComment_Text => clang.VerbatimBlockLineComment_getText(this);
+
+        public CXString VerbatimLineComment_Text => clang.VerbatimLineComment_getText(this);
+
+        public CXString BlockCommandComment_GetArgText(uint index) => clang.BlockCommandComment_getArgText(this, index);
+
+        public CXComment GetChild(uint index) => clang.Comment_getChild(this, index);
+
+        public CXTranslationUnit GetTranslationUnit() => new CXTranslationUnit(TranslationUnit);
+
+        public CXString HtmlStartTag_GetAttrName(uint index) => clang.HTMLStartTag_getAttrName(this, index);
+
+        public CXString HtmlStartTag_GetAttrValue(uint index) => clang.HTMLStartTag_getAttrValue(this, index);
+
+        public CXString InlineCommandComment_GetArgText(uint index) => clang.InlineCommandComment_getArgText(this, index);
+
+        public uint TParamCommandComment_GetIndex(uint depth) => clang.TParamCommandComment_getIndex(this, depth);
+    }
+}

--- a/ClangSharp/Extensions/CXCompletionString.cs
+++ b/ClangSharp/Extensions/CXCompletionString.cs
@@ -1,0 +1,25 @@
+﻿namespace ClangSharp
+{
+    public partial struct CXCompletionString
+    {
+        public CXAvailabilityKind Availability => clang.getCompletionAvailability(this);
+
+        public CXString BriefComment => clang.getCompletionBriefComment(this);
+
+        public uint NumAnnotations => clang.getCompletionNumAnnotations(this);
+
+        public uint NumChunks => clang.getNumCompletionChunks(this);
+
+        public uint Priority => clang.getCompletionPriority(this);
+
+        public CXString GetAnnotation(uint index) => clang.getCompletionAnnotation(this, index);
+
+        public CXCompletionString GetChunkCompletionString(uint index) => clang.getCompletionChunkCompletionString(this, index);
+
+        public CXCompletionChunkKind GetChunkKind(uint index) => clang.getCompletionChunkKind(this, index);
+
+        public CXString GetChunkText(uint index) => clang.getCompletionChunkText(this, index);
+
+        public CXString GetParent(ref CXCursorKind kind) => clang.getCompletionParent(this, ref kind);
+    }
+}

--- a/ClangSharp/Extensions/CXCursor.cs
+++ b/ClangSharp/Extensions/CXCursor.cs
@@ -6,44 +6,215 @@ namespace ClangSharp
     {
         public static CXCursor Null => clang.getNullCursor();
 
+        public CXAvailabilityKind Availability => clang.getCursorAvailability(this);
+
+        public CXString BriefCommentText => clang.Cursor_getBriefCommentText(this);
+
+        public CXCursor CanonicalCursor => clang.getCanonicalCursor(this);
+
         public CXSourceRange CommentRange => clang.Cursor_getCommentRange(this);
 
-        public CXType EnumDeclIntegerType => clang.getEnumDeclIntegerType(this);
+        public CXCompletionString CompletionString => clang.getCursorCompletionString(this);
+
+        public CX_CXXAccessSpecifier CXXAccessSpecifier => clang.getCXXAccessSpecifier(this);
+
+        public bool CXXConstructor_IsConvertingConstructor => clang.CXXConstructor_isConvertingConstructor(this) != 0;
+
+        public bool CXXConstructor_IsCopyConstructor => clang.CXXConstructor_isCopyConstructor(this) != 0;
+
+        public bool CXXConstructor_IsDefaultConstructor => clang.CXXConstructor_isDefaultConstructor(this) != 0;
+
+        public bool CXXConstructor_IsMoveConstructor => clang.CXXConstructor_isMoveConstructor(this) != 0;
+
+        public bool CXXField_IsMutable => clang.CXXField_isMutable(this) != 0;
+
+        public unsafe ref CXStringSet CXXManglings => ref *(CXStringSet*)clang.Cursor_getCXXManglings(this);
+
+        public bool CXXMethod_IsConst => clang.CXXMethod_isConst(this) != 0;
+
+        public bool CXXMethod_IsDefaulted => clang.CXXMethod_isDefaulted(this) != 0;
+
+        public bool CXXMethod_IsPureVirtual => clang.CXXMethod_isPureVirtual(this) != 0;
+
+        public bool CXXMethod_IsStatic => clang.CXXMethod_isStatic(this) != 0;
+
+        public bool CXXMethod_IsVirtual => clang.CXXMethod_isVirtual(this) != 0;
+
+        public bool CXXRecord_IsAbstract => clang.CXXRecord_isAbstract(this) != 0;
+
+        public CXString DeclObjCTypeEncoding => clang.getDeclObjCTypeEncoding(this);
+
+        public CXCursor Definition => clang.getCursorDefinition(this);
+
+        public CXString DisplayName => clang.getCursorDisplayName(this);
+
+        public ulong EnumConstantDeclUnsignedValue => clang.getEnumConstantDeclUnsignedValue(this);
+
+        public long EnumConstantDeclValue => clang.getEnumConstantDeclValue(this);
+
+        public CXType EnumDecl_IntegerType => clang.getEnumDeclIntegerType(this);
+
+        public bool EnumDecl_IsScoped => clang.EnumDecl_isScoped(this) != 0;
+
+        public CXEvalResult Evaluate => clang.Cursor_Evaluate(this);
+
+        public int ExceptionSpecificationType => clang.getCursorExceptionSpecificationType(this);
 
         public CXSourceRange Extent => clang.getCursorExtent(this);
 
+        public int FieldDeclBitWidth => clang.getFieldDeclBitWidth(this);
+
+        public bool HasAttrs => clang.Cursor_hasAttrs(this) != 0;
+
         public CXType IBOutletCollectionType => clang.getIBOutletCollectionType(this);
+
+        public CXFile IncludedFile => clang.getIncludedFile(this);
+
+        public bool IsAnonymous => clang.Cursor_isAnonymous(this) != 0;
+
+        public bool IsAttribute => clang.isAttribute(Kind) != 0;
+
+        public bool IsBitField => clang.Cursor_isBitField(this) != 0;
+
+        public bool IsDeclaration => clang.isDeclaration(Kind) != 0;
+
+        public bool IsDefinition => clang.isCursorDefinition(this) != 0;
+
+        public bool IsDynamicCall => clang.Cursor_isDynamicCall(this) != 0;
+
+        public bool IsExpression => clang.isExpression(Kind) != 0;
+
+        public bool IsFunctionInlined => clang.Cursor_isFunctionInlined(this) != 0;
+
+        public bool IsInvalid => clang.isInvalid(Kind) != 0;
+
+        public bool IsInvalidDeclaration => clang.isInvalidDeclaration(this) != 0;
 
         public bool IsNull => clang.Cursor_isNull(this) != 0;
 
+        public bool IsMacroBuiltIn => clang.Cursor_isMacroBuiltin(this) != 0;
+
+        public bool IsMacroFunctionLike => clang.Cursor_isMacroFunctionLike(this) != 0;
+
+        public bool IsObjCOptional => clang.Cursor_isObjCOptional(this) != 0;
+
+        public bool IsPreProcessing => clang.isPreprocessing(Kind) != 0;
+
+        public bool IsReference => clang.isReference(Kind) != 0;
+
+        public bool IsStatement => clang.isStatement(Kind) != 0;
+
+        public bool IsTranslationUnit => clang.isTranslationUnit(Kind) != 0;
+
+        public bool IsUnexposed => clang.isUnexposed(Kind) != 0;
+
+        public bool IsVariadic => clang.Cursor_isVariadic(this) != 0;
+
+        public bool IsVirtualBase => clang.isVirtualBase(this) != 0;
+
         public CXCursorKind Kind => clang.getCursorKind(this);
+
+        public CXString KindSpelling => clang.getCursorKindSpelling(Kind);
+
+        public CXLanguageKind Language => clang.getCursorLanguage(this);
+
+        public CXCursor LexicalParent => clang.getCursorLexicalParent(this);
+
+        public CXLinkageKind Linkage => clang.getCursorLinkage(this);
 
         public CXSourceLocation Location => clang.getCursorLocation(this);
 
-        public CXType TypedefDeclUnderlyingType => clang.getTypedefDeclUnderlyingType(this);
+        public CXString Mangling => clang.Cursor_getMangling(this);
+
+        public CXModule Module => clang.Cursor_getModule(this);
+
+        public int NumArguments => clang.Cursor_getNumArguments(this);
+
+        public uint NumOverloadedDecls => clang.getNumOverloadedDecls(this);
+
+        public int NumTemplateArguments => clang.Cursor_getNumTemplateArguments(this);
+
+        public CXObjCDeclQualifierKind ObjCDeclQualifiers => (CXObjCDeclQualifierKind)clang.Cursor_getObjCDeclQualifiers(this);
+
+        public unsafe ref CXStringSet ObjCManglings => ref *(CXStringSet*)clang.Cursor_getObjCManglings(this);
+
+        public CXString ObjCPropertyGetterName => clang.Cursor_getObjCPropertyGetterName(this);
+
+        public CXString ObjCPropertySetterName => clang.Cursor_getObjCPropertySetterName(this);
+
+        public int ObjCSelectorIndex => clang.Cursor_getObjCSelectorIndex(this);
+
+        public long OffsetOfField => clang.Cursor_getOffsetOfField(this);
+
+        public CXComment ParsedComment => clang.Cursor_getParsedComment(this);
+
+        public CXString RawCommentText => clang.Cursor_getRawCommentText(this);
 
         public CXType RecieverType => clang.Cursor_getReceiverType(this);
 
+        public CXCursor Referenced => clang.getCursorReferenced(this);
+
         public CXType ResultType => clang.getCursorResultType(this);
 
+        public CXCursor SemanticParent => clang.getCursorSemanticParent(this);
+
+        public CXCursor SpecializedCursorTemplate => clang.getSpecializedCursorTemplate(this);
+
         public CXString Spelling => clang.getCursorSpelling(this);
+
+        public CX_StorageClass StorageClass => clang.Cursor_getStorageClass(this);
+
+        public CXCursorKind TemplateCursorKind => clang.getTemplateCursorKind(this);
+
+        public CXTLSKind TlsKind => clang.getCursorTLSKind(this);
 
         public CXTranslationUnit TranslationUnit => clang.Cursor_getTranslationUnit(this);
 
         public CXType Type => clang.getCursorType(this);
 
+        public CXType TypedefDeclUnderlyingType => clang.getTypedefDeclUnderlyingType(this);
+
+        public CXString UnifiedSymbolResolution => clang.getCursorUSR(this);
+
+        public CXVisibilityKind Visibility => clang.getCursorVisibility(this);
+
         public override bool Equals(object obj) => (obj is CXCursor other) && Equals(other);
 
         public bool Equals(CXCursor other) => clang.equalCursors(this, other) != 0;
 
+        public CXResult FindReferenceInFile(CXFile file, CXCursorAndRangeVisitor visitor) => clang.findReferencesInFile(this, file, visitor);
+
+        public CXCursor GetArgument(uint index) => clang.Cursor_getArgument(this, index);
+
         public override int GetHashCode() => (int)clang.hashCursor(this);
+
+        public bool GetIsExternalSymbol(out CXString language, out CXString definedIn, out bool isGenerated)
+        {
+            var result = clang.Cursor_isExternalSymbol(this, out language, out definedIn, out uint isGeneratedOut);
+            isGenerated = isGeneratedOut != 0;
+            return result != 0;
+        }
+
+        public CXObjCPropertyAttrKind GetObjCPropertyAttributes(uint reserved) => (CXObjCPropertyAttrKind)clang.Cursor_getObjCPropertyAttributes(this, reserved);
+
+        public CXCursor GetOverloadedDecl(uint index) => clang.getOverloadedDecl(this, index);
+
+        public int GetPlatformAvailability(out bool alwaysDeprecated, out CXString deprecatedMessage, out bool alwaysUnavailable, out CXString unavailableMessage, CXPlatformAvailability[] availability) => clang.getCursorPlatformAvailability(this, out alwaysDeprecated, out deprecatedMessage, out alwaysUnavailable, out unavailableMessage, availability, availability.Length);
 
         public CXSourceRange GetReferenceNameRange(CXNameRefFlags nameFlags, uint pieceIndex) => clang.getCursorReferenceNameRange(this, (uint)nameFlags, pieceIndex);
 
-        public CXType GetTemplateArgumentType(uint i) => clang.Cursor_getTemplateArgumentType(this, i);
-
         public CXSourceRange GetSpellingNameRange(uint pieceIndex, uint options) => clang.Cursor_getSpellingNameRange(this, pieceIndex, options);
 
+        public CXTemplateArgumentKind GetTemplateArgumentKind(uint i) => clang.Cursor_getTemplateArgumentKind(this, i);
+
+        public CXType GetTemplateArgumentType(uint i) => clang.Cursor_getTemplateArgumentType(this, i);
+
+        public ulong GetTemplateArgumentUnsignedValue(uint i) => clang.Cursor_getTemplateArgumentUnsignedValue(this, i);
+
+        public long GetTemplateArgumentValue(uint i) => clang.Cursor_getTemplateArgumentValue(this, i);
+
         public override string ToString() => Spelling.ToString();
+
+        public CXChildVisitResult VisitChildren(CXCursorVisitor visitor, CXClientData clientData) => (CXChildVisitResult)clang.visitChildren(this, visitor, clientData);
     }
 }

--- a/ClangSharp/Extensions/CXEvalResult.cs
+++ b/ClangSharp/Extensions/CXEvalResult.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace ClangSharp
+{
+    public partial struct CXEvalResult : IDisposable
+    {
+        public double AsDouble => clang.EvalResult_getAsDouble(this);
+
+        public int AsInt => clang.EvalResult_getAsInt(this);
+
+        public long AsLongLong => clang.EvalResult_getAsLongLong(this);
+
+        public string AsStr => clang.EvalResult_getAsStr(this);
+
+        public ulong AsUnsigned => clang.EvalResult_getAsUnsigned(this);
+
+        public bool IsUnsignedInt => clang.EvalResult_isUnsignedInt(this) != 0;
+
+        public CXEvalResultKind Kind => clang.EvalResult_getKind(this);
+
+        public void Dispose() => clang.EvalResult_dispose(this);
+    }
+}

--- a/ClangSharp/Extensions/CXFile.cs
+++ b/ClangSharp/Extensions/CXFile.cs
@@ -12,13 +12,7 @@ namespace ClangSharp
 
         public bool Equals(CXFile other) => clang.File_isEqual(this, other) != 0;
 
-        public string GetContents(CXTranslationUnit translationUnit, out ulong size) => clang.getFileContents(translationUnit, this, out size);
-
-        public CXSourceLocation GetLocation(CXTranslationUnit translationUnit, uint line, uint column) => clang.getLocation(translationUnit, this, line, column);
-
-        public CXSourceLocation GetLocationForOffset(CXTranslationUnit translationUnit, uint offset) => clang.getLocationForOffset(translationUnit, this, offset);
-
-        public bool IsMultipleIncludeGuarded(CXTranslationUnit translationUnit) => clang.isFileMultipleIncludeGuarded(translationUnit, this) != 0;
+        public bool GetUniqueId(out CXFileUniqueID id) => clang.getFileUniqueID(this, out id) != 0;
 
         public override string ToString() => Name.ToString();
 

--- a/ClangSharp/Extensions/CXIndex.cs
+++ b/ClangSharp/Extensions/CXIndex.cs
@@ -4,7 +4,7 @@ namespace ClangSharp
 {
     public partial struct CXIndex : IDisposable
     {
-        public CXIndex Create(bool excludeDeclarationsFromPch = false, bool displayDiagnostics = false) => clang.createIndex(excludeDeclarationsFromPch ? 1 : 0, displayDiagnostics ? 1 : 0);
+        public static CXIndex Create(bool excludeDeclarationsFromPch = false, bool displayDiagnostics = false) => clang.createIndex(excludeDeclarationsFromPch ? 1 : 0, displayDiagnostics ? 1 : 0);
 
         public CXGlobalOptFlags GlobalOptions
         {

--- a/ClangSharp/Extensions/CXModule.cs
+++ b/ClangSharp/Extensions/CXModule.cs
@@ -1,0 +1,19 @@
+﻿namespace ClangSharp
+{
+    public partial struct CXModule
+    {
+        public CXFile AstFile => clang.Module_getASTFile(this);
+
+        public CXString FullName => clang.Module_getFullName(this);
+
+        public bool IsSystem => clang.Module_isSystem(this) != 0;
+
+        public CXString Name => clang.Module_getName(this);
+
+        public CXModule Parent => clang.Module_getParent(this);
+
+        public uint GetNumTopLevelHeaders(CXTranslationUnit translationUnit) => clang.Module_getNumTopLevelHeaders(translationUnit, this);
+
+        public CXFile GetTopLevelHeader(CXTranslationUnit translationUnit, uint index) => clang.Module_getTopLevelHeader(translationUnit, this, index);
+    }
+}

--- a/ClangSharp/Extensions/CXPlatformAvailability.cs
+++ b/ClangSharp/Extensions/CXPlatformAvailability.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace ClangSharp
+{
+    public partial struct CXPlatformAvailability : IDisposable
+    {
+        public void Dispose() => clang.disposeCXPlatformAvailability(ref this);
+    }
+}

--- a/ClangSharp/Extensions/CXSourceRangeList.cs
+++ b/ClangSharp/Extensions/CXSourceRangeList.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace ClangSharp
+{
+    public partial struct CXSourceRangeList : IDisposable, IReadOnlyCollection<CXSourceRange>
+    {
+        public unsafe CXSourceRange this[uint index] => ((CXSourceRange*)ranges)[index];
+
+        public int Count => (int)count;
+
+        public void Dispose() => clang.disposeSourceRangeList(ref this);
+
+        public IEnumerator<CXSourceRange> GetEnumerator()
+        {
+            var count = (uint)Count;
+
+            for (var index = 0u; index < count; index++)
+            {
+                yield return this[index];
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/ClangSharp/Extensions/CXStringSet.cs
+++ b/ClangSharp/Extensions/CXStringSet.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace ClangSharp
+{
+    public partial struct CXStringSet : IDisposable, IReadOnlyCollection<CXString>
+    {
+        public unsafe CXString this[uint index] => ((CXString*)Strings)[index];
+
+        int IReadOnlyCollection<CXString>.Count => (int)Count;
+
+        public void Dispose() => clang.disposeStringSet(ref this);
+
+        public IEnumerator<CXString> GetEnumerator()
+        {
+            var count = (uint)Count;
+
+            for (var index = 0u; index < count; index++)
+            {
+                yield return this[index];
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/ClangSharp/Extensions/CXTUResourceUsage.cs
+++ b/ClangSharp/Extensions/CXTUResourceUsage.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace ClangSharp
+{
+    public partial struct CXTUResourceUsage : IDisposable, IReadOnlyCollection<CXTUResourceUsageEntry>
+    {
+        public unsafe CXTUResourceUsageEntry this[uint index] => ((CXTUResourceUsageEntry*)entries)[index];
+
+        public int Count => (int)numEntries;
+
+        public void Dispose() => clang.disposeCXTUResourceUsage(this);
+
+        public IEnumerator<CXTUResourceUsageEntry> GetEnumerator()
+        {
+            var count = (uint)Count;
+
+            for (var index = 0u; index < count; index++)
+            {
+                yield return this[index];
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/ClangSharp/Extensions/CXTUResourceUsageEntry.cs
+++ b/ClangSharp/Extensions/CXTUResourceUsageEntry.cs
@@ -1,0 +1,7 @@
+﻿namespace ClangSharp
+{
+    public partial struct CXTUResourceUsageEntry
+    {
+        public string Name => clang.getTUResourceUsageName(kind);
+    }
+}

--- a/ClangSharp/Extensions/CXTargetInfo.cs
+++ b/ClangSharp/Extensions/CXTargetInfo.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace ClangSharp
+{
+    public partial struct CXTargetInfo : IDisposable
+    {
+        public int PointerWidth => clang.TargetInfo_getPointerWidth(this);
+
+        public CXString Triple => clang.TargetInfo_getTriple(this);
+
+        public void Dispose() => clang.TargetInfo_dispose(this);
+    }
+}

--- a/ClangSharp/Extensions/CXToken.cs
+++ b/ClangSharp/Extensions/CXToken.cs
@@ -1,0 +1,13 @@
+﻿namespace ClangSharp
+{
+    public partial struct CXToken
+    {
+        public CXTokenKind Kind => clang.getTokenKind(this);
+
+        public CXSourceRange GetExtent(CXTranslationUnit translationUnit) => clang.getTokenExtent(translationUnit, this);
+
+        public CXSourceLocation GetLocation(CXTranslationUnit translationUnit) => clang.getTokenLocation(translationUnit, this);
+
+        public CXString GetSpelling(CXTranslationUnit translationUnit) => clang.getTokenSpelling(translationUnit, this);
+    }
+}

--- a/ClangSharp/Extensions/CXTranslationUnit.cs
+++ b/ClangSharp/Extensions/CXTranslationUnit.cs
@@ -26,9 +26,21 @@ namespace ClangSharp
 
         public uint NumDiagnostics => clang.getNumDiagnostics(this);
 
+        public CXTUResourceUsage ResourceUsage => clang.getCXTUResourceUsage(this);
+
         public CXString Spelling => clang.getTranslationUnitSpelling(this);
 
+        public CXTargetInfo TargetInfo => clang.getTranslationUnitTargetInfo(this);
+
+        public void AnnotateTokens(CXToken[] tokens, CXCursor[] cursors) => clang.annotateTokens(this, tokens, (uint)tokens.Length, cursors);
+
         public void Dispose() => clang.disposeTranslationUnit(this);
+
+        public void DisposeTokens(CXToken[] tokens) => clang.disposeTokens(this, tokens, (uint)tokens.Length);
+
+        public CXResult FindIncludesInFile(CXFile file, CXCursorAndRangeVisitor visitor) => clang.findIncludesInFile(this, file, visitor);
+
+        public unsafe ref CXSourceRangeList GetAllSkippedRanges() => ref *(CXSourceRangeList*)clang.getAllSkippedRanges(this);
 
         public CXCursor GetCursor(CXSourceLocation location) => clang.getCursor(this, location);
 
@@ -36,12 +48,31 @@ namespace ClangSharp
 
         public CXFile GetFile(string fileName) => clang.getFile(this, fileName);
 
+        public string GetFileContents(CXFile file, out ulong size) => clang.getFileContents(this, file, out size);
+
+        public void GetInclusions(CXInclusionVisitor visitor, CXClientData clientData) => clang.getInclusions(this, visitor, clientData);
+
+        public CXSourceLocation GetLocation(CXFile file, uint line, uint column) => clang.getLocation(this, file, line, column);
+
+        public CXSourceLocation GetLocationForOffset(CXFile file, uint offset) => clang.getLocationForOffset(this, file, offset);
+
+        public CXModule GetModuleForFile(CXFile file) => clang.getModuleForFile(this, file);
+
+        public unsafe ref CXSourceRangeList GetSkippedRanges(CXFile file) => ref *(CXSourceRangeList*)clang.getSkippedRanges(this, file);
+
+        public unsafe ref CXToken GetToken(CXSourceLocation sourceLocation) => ref *(CXToken*)clang.getToken(this, sourceLocation);
+
+        public bool IsFileMultipleIncludeGuarded(CXFile file) => clang.isFileMultipleIncludeGuarded(this, file) != 0;
+
         public CXErrorCode Reparse(CXUnsavedFile[] unsavedFiles, CXReparse_Flags options) => (CXErrorCode)clang.reparseTranslationUnit(this, (uint)unsavedFiles.Length, unsavedFiles, (uint)options);
 
         public CXSaveError Save(string fileName, CXSaveTranslationUnit_Flags options) => (CXSaveError)clang.saveTranslationUnit(this, fileName, (uint)options);
 
         public bool Suspend() => clang.suspendTranslationUnit(this) != 0;
 
+        public void Tokenize(CXSourceRange sourceRange, out CXToken[] tokens) => clang.tokenize(this, sourceRange, out tokens, out _);
+
         public override string ToString() => Spelling.ToString();
+
     }
 }

--- a/ClangSharp/Extensions/CXType.cs
+++ b/ClangSharp/Extensions/CXType.cs
@@ -86,6 +86,6 @@ namespace ClangSharp
 
         public override string ToString() => Spelling.ToString();
 
-        public uint VisitFields(CXFieldVisitor visitor, CXClientData clientData) => clang.Type_visitFields(this, visitor, clientData);
+        public CXVisitorResult VisitFields(CXFieldVisitor visitor, CXClientData clientData) => (CXVisitorResult)clang.Type_visitFields(this, visitor, clientData);
     }
 }

--- a/ClangSharp/Generated.Custom.cs
+++ b/ClangSharp/Generated.Custom.cs
@@ -216,6 +216,30 @@ namespace ClangSharp
             }
         }
 
+        [DllImport(libraryPath, EntryPoint = "clang_disposeSourceRangeList", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void disposeSourceRangeList(ref CXSourceRangeList @ranges);
+
+        [DllImport(libraryPath, EntryPoint = "clang_annotateTokens", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void annotateTokens(CXTranslationUnit @TU, [MarshalAs(UnmanagedType.LPArray)] CXToken[] @Tokens, uint @NumTokens, [MarshalAs(UnmanagedType.LPArray)] CXCursor[] @Cursors);
+
+        [DllImport(libraryPath, EntryPoint = "clang_disposeTokens", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void disposeTokens(CXTranslationUnit @TU, [MarshalAs(UnmanagedType.LPArray)] CXToken[] @Tokens, uint @NumTokens);
+
+        [DllImport(libraryPath, EntryPoint = "clang_tokenize", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void tokenize(CXTranslationUnit @TU, CXSourceRange @Range, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] out CXToken[] @Tokens, out uint @NumTokens);
+
+        [DllImport(libraryPath, EntryPoint = "clang_disposeStringSet", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void disposeStringSet(ref CXStringSet @set);
+
+        [DllImport(libraryPath, EntryPoint = "clang_getCompletionParent", CallingConvention = CallingConvention.Cdecl)]
+        public static extern CXString getCompletionParent(CXCompletionString @completion_string, ref CXCursorKind @kind);
+
+        [DllImport(libraryPath, EntryPoint = "clang_disposeCXPlatformAvailability", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void disposeCXPlatformAvailability(ref CXPlatformAvailability @availability);
+
+        [DllImport(libraryPath, EntryPoint = "clang_getCursorPlatformAvailability", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int getCursorPlatformAvailability(CXCursor @cursor, [MarshalAs(UnmanagedType.Bool)] out bool @always_deprecated, out CXString @deprecated_message, [MarshalAs(UnmanagedType.Bool)] out bool @always_unavailable, out CXString @unavailable_message, [MarshalAs(UnmanagedType.LPArray)] CXPlatformAvailability[] @availability, int @availability_size);
+
         [DllImport(libraryPath, EntryPoint = "clang_createTranslationUnitFromSourceFile", CallingConvention = CallingConvention.Cdecl)]
         private static extern CXTranslationUnit createTranslationUnitFromSourceFile(CXIndex @CIdx, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(StringMarshaler))] string @source_filename, int @num_clang_command_line_args, string[] @clang_command_line_args, uint @num_unsaved_files, [MarshalAs(UnmanagedType.LPArray)] _CXUnsavedFile[] @unsaved_files);
 

--- a/ClangSharp/Generated.cs
+++ b/ClangSharp/Generated.cs
@@ -1460,9 +1460,6 @@ namespace ClangSharp
         [DllImport(libraryPath, EntryPoint = "clang_disposeString", CallingConvention = CallingConvention.Cdecl)]
         public static extern void disposeString(CXString @string);
 
-        [DllImport(libraryPath, EntryPoint = "clang_disposeStringSet", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void disposeStringSet(out CXStringSet @set);
-
         [DllImport(libraryPath, EntryPoint = "clang_getBuildSessionTimestamp", CallingConvention = CallingConvention.Cdecl)]
         public static extern ulong getBuildSessionTimestamp();
 
@@ -1595,9 +1592,6 @@ namespace ClangSharp
 
         [DllImport(libraryPath, EntryPoint = "clang_getAllSkippedRanges", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr getAllSkippedRanges(CXTranslationUnit @tu);
-
-        [DllImport(libraryPath, EntryPoint = "clang_disposeSourceRangeList", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void disposeSourceRangeList(out CXSourceRangeList @ranges);
 
         [DllImport(libraryPath, EntryPoint = "clang_getNumDiagnosticsInSet", CallingConvention = CallingConvention.Cdecl)]
         public static extern uint getNumDiagnosticsInSet(CXDiagnosticSet @Diags);
@@ -1773,12 +1767,6 @@ namespace ClangSharp
 
         [DllImport(libraryPath, EntryPoint = "clang_getCursorAvailability", CallingConvention = CallingConvention.Cdecl)]
         public static extern CXAvailabilityKind getCursorAvailability(CXCursor @cursor);
-
-        [DllImport(libraryPath, EntryPoint = "clang_getCursorPlatformAvailability", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int getCursorPlatformAvailability(CXCursor @cursor, out int @always_deprecated, out CXString @deprecated_message, out int @always_unavailable, out CXString @unavailable_message, out CXPlatformAvailability @availability, int @availability_size);
-
-        [DllImport(libraryPath, EntryPoint = "clang_disposeCXPlatformAvailability", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void disposeCXPlatformAvailability(out CXPlatformAvailability @availability);
 
         [DllImport(libraryPath, EntryPoint = "clang_getCursorLanguage", CallingConvention = CallingConvention.Cdecl)]
         public static extern CXLanguageKind getCursorLanguage(CXCursor @cursor);
@@ -2221,15 +2209,6 @@ namespace ClangSharp
         [DllImport(libraryPath, EntryPoint = "clang_getTokenExtent", CallingConvention = CallingConvention.Cdecl)]
         public static extern CXSourceRange getTokenExtent(CXTranslationUnit @param0, CXToken @param1);
 
-        [DllImport(libraryPath, EntryPoint = "clang_tokenize", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void tokenize(CXTranslationUnit @TU, CXSourceRange @Range, out IntPtr @Tokens, out uint @NumTokens);
-
-        [DllImport(libraryPath, EntryPoint = "clang_annotateTokens", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void annotateTokens(CXTranslationUnit @TU, out CXToken @Tokens, uint @NumTokens, out CXCursor @Cursors);
-
-        [DllImport(libraryPath, EntryPoint = "clang_disposeTokens", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void disposeTokens(CXTranslationUnit @TU, out CXToken @Tokens, uint @NumTokens);
-
         [DllImport(libraryPath, EntryPoint = "clang_getCursorKindSpelling", CallingConvention = CallingConvention.Cdecl)]
         public static extern CXString getCursorKindSpelling(CXCursorKind @Kind);
 
@@ -2265,9 +2244,6 @@ namespace ClangSharp
 
         [DllImport(libraryPath, EntryPoint = "clang_getCompletionAnnotation", CallingConvention = CallingConvention.Cdecl)]
         public static extern CXString getCompletionAnnotation(CXCompletionString @completion_string, uint @annotation_number);
-
-        [DllImport(libraryPath, EntryPoint = "clang_getCompletionParent", CallingConvention = CallingConvention.Cdecl)]
-        public static extern CXString getCompletionParent(CXCompletionString @completion_string, out CXCursorKind @kind);
 
         [DllImport(libraryPath, EntryPoint = "clang_getCompletionBriefComment", CallingConvention = CallingConvention.Cdecl)]
         public static extern CXString getCompletionBriefComment(CXCompletionString @completion_string);

--- a/ClangSharpPInvokeGenerator/ClangSharpPInvokeGenerator.csproj
+++ b/ClangSharpPInvokeGenerator/ClangSharpPInvokeGenerator.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
     <ProjectReference Include="..\ClangSharp\ClangSharp.csproj" />
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <Target Name="GenerateClangSharp">
-    <Exec Command="dotnet run --m clang --p clang_ --namespace ClangSharp --output ../ClangSharp/Generated.cs --libraryPath $(LibClangName) --include $(LLVMIncludePath) --file $(LLVMIncludePath)/clang-c/Index.h --file $(LLVMIncludePath)/clang-c/CXString.h --file $(LLVMIncludePath)/clang-c/Documentation.h --file $(LLVMIncludePath)/clang-c/CXErrorCode.h --file $(LLVMIncludePath)/clang-c/BuildSystem.h --file $(LLVMIncludePath)/clang-c/CXCompilationDatabase.h --excludeFunctions clang_index_getClientEntity,clang_index_setClientEntity,clang_createTranslationUnitFromSourceFile,clang_parseTranslationUnit,clang_parseTranslationUnit2,clang_parseTranslationUnit2FullArgv,clang_reparseTranslationUnit,clang_codeCompleteAt,clang_indexSourceFile,clang_indexSourceFileFullArgv" />
+    <Exec Command="dotnet run --m clang --p clang_ --namespace ClangSharp --output ../ClangSharp/Generated.cs --libraryPath $(LibClangName) --include $(LLVMIncludePath) --file $(LLVMIncludePath)/clang-c/Index.h --file $(LLVMIncludePath)/clang-c/CXString.h --file $(LLVMIncludePath)/clang-c/Documentation.h --file $(LLVMIncludePath)/clang-c/CXErrorCode.h --file $(LLVMIncludePath)/clang-c/BuildSystem.h --file $(LLVMIncludePath)/clang-c/CXCompilationDatabase.h --excludeFunctions clang_index_getClientEntity,clang_index_setClientEntity,clang_createTranslationUnitFromSourceFile,clang_parseTranslationUnit,clang_parseTranslationUnit2,clang_parseTranslationUnit2FullArgv,clang_reparseTranslationUnit,clang_codeCompleteAt,clang_indexSourceFile,clang_indexSourceFileFullArgv,clang_disposeSourceRangeList,clang_annotateTokens,clang_annotateTokens,clang_disposeTokens,clang_tokenize,clang_disposeStringSet,clang_getCompletionParent,clang_disposeCXPlatformAvailability,clang_getCursorPlatformAvailability" />
   </Target>
 
 </Project>

--- a/ClangSharpPInvokeGenerator/ForwardDeclarationVisitor.cs
+++ b/ClangSharpPInvokeGenerator/ForwardDeclarationVisitor.cs
@@ -23,7 +23,7 @@ namespace ClangSharpPInvokeGenerator
                 return CXChildVisitResult.CXChildVisit_Continue;
             }
 
-            if (clang.equalCursors(cursor, this.beginningCursor) != 0)
+            if (cursor.Equals(beginningCursor))
             {
                 this.beginningCursorReached = true;
                 return CXChildVisitResult.CXChildVisit_Continue;

--- a/ClangSharpPInvokeGenerator/FunctionVisitor.cs
+++ b/ClangSharpPInvokeGenerator/FunctionVisitor.cs
@@ -37,12 +37,12 @@ namespace ClangSharpPInvokeGenerator
                 return CXChildVisitResult.CXChildVisit_Continue;
             }
 
-            CXCursorKind curKind = clang.getCursorKind(cursor);
+            CXCursorKind curKind = cursor.kind;
 
             // look only at function decls
             if (curKind == CXCursorKind.CXCursor_FunctionDecl)
             {
-                var functionName = clang.getCursorSpelling(cursor).ToString();
+                var functionName = cursor.Spelling.ToString();
 
                 if (this.visitedFunctions.Contains(functionName))
                 {

--- a/ClangSharpPInvokeGenerator/StructVisitor.cs
+++ b/ClangSharpPInvokeGenerator/StructVisitor.cs
@@ -29,18 +29,18 @@ namespace ClangSharpPInvokeGenerator
                 return CXChildVisitResult.CXChildVisit_Continue;
             }
 
-            CXCursorKind curKind = clang.getCursorKind(cursor);
+            CXCursorKind curKind = cursor.Kind;
             if (curKind == CXCursorKind.CXCursor_StructDecl)
             {
                 this.fieldPosition = 0;
-                var structName = clang.getCursorSpelling(cursor).ToString();
+                var structName = cursor.Spelling.ToString();
 
                 // struct names can be empty, and so we visit its sibling to find the name
                 if (string.IsNullOrEmpty(structName))
                 {
                     var forwardDeclaringVisitor = new ForwardDeclarationVisitor(cursor);
-                    clang.visitChildren(clang.getCursorSemanticParent(cursor), forwardDeclaringVisitor.Visit, new CXClientData(IntPtr.Zero));
-                    structName = clang.getCursorSpelling(forwardDeclaringVisitor.ForwardDeclarationCursor).ToString();
+                    cursor.SemanticParent.VisitChildren(forwardDeclaringVisitor.Visit, new CXClientData(IntPtr.Zero));
+                    structName = forwardDeclaringVisitor.ForwardDeclarationCursor.Spelling.ToString();
 
                     if (string.IsNullOrEmpty(structName))
                     {
@@ -54,7 +54,7 @@ namespace ClangSharpPInvokeGenerator
                     this.IndentedWriteLine("{");
 
                     this.indentLevel++;
-                    clang.visitChildren(cursor, this.Visit, new CXClientData(IntPtr.Zero));
+                    cursor.VisitChildren(Visit, new CXClientData(IntPtr.Zero));
                     this.indentLevel--;
 
                     this.IndentedWriteLine("}");
@@ -68,7 +68,7 @@ namespace ClangSharpPInvokeGenerator
 
             if (curKind == CXCursorKind.CXCursor_FieldDecl)
             {
-                var fieldName = clang.getCursorSpelling(cursor).ToString();
+                var fieldName = cursor.Spelling.ToString();
                 if (string.IsNullOrEmpty(fieldName))
                 {
                     fieldName = "field" + this.fieldPosition; // what if they have fields called field*? :)


### PR DESCRIPTION
This is a continuation of https://github.com/Microsoft/ClangSharp/pull/31. It ports a good number of additional APIs and adds a simple test covering the new OOP extensions. It also moves ClangSharpPInvokeGenerator to use the OOP extensions exclusively (both to clean it up and to validate things are exposed correctly).

After this is merged, the following methods still need to be made available: [todo.txt](https://github.com/Microsoft/ClangSharp/files/3110051/todo.txt). I'm going to log a tracking issue for them, however, as I think they can be handled separately and aren't going to be targeted as much.
