### PR TITLE
Adding some additional fixups allow LLVMSharp to be regenerated

### DIFF
--- a/ClangSharpPInvokeGenerator/CXCursorExtensions.cs
+++ b/ClangSharpPInvokeGenerator/CXCursorExtensions.cs
@@ -205,6 +205,31 @@ namespace ClangSharpPInvokeGenerator
 
             switch (name)
             {
+                case "int8_t":
+                {
+                    return "sbyte";
+                }
+
+                case "int16_t":
+                {
+                    return "short";
+                }
+
+                case "int32_t":
+                {
+                    return "int";
+                }
+
+                case "int64_t":
+                {
+                    return "long";
+                }
+
+                case "intptr_t":
+                {
+                    return "IntPtr";
+                }
+
                 case "size_t":
                 {
                     return "IntPtr";
@@ -213,6 +238,31 @@ namespace ClangSharpPInvokeGenerator
                 case "time_t":
                 {
                     return "long";
+                }
+
+                case "uint8_t":
+                {
+                    return "byte";
+                }
+
+                case "uint16_t":
+                {
+                    return "ushort";
+                }
+
+                case "uint32_t":
+                {
+                    return "uint";
+                }
+
+                case "uint64_t":
+                {
+                    return "ulong";
+                }
+
+                case "uintptr_t":
+                {
+                    return "UIntPtr";
                 }
             }
 

--- a/ClangSharpPInvokeGenerator/CXTypeExtensions.cs
+++ b/ClangSharpPInvokeGenerator/CXTypeExtensions.cs
@@ -41,9 +41,11 @@ namespace ClangSharpPInvokeGenerator
                 case CXTypeKind.CXType_Long:
                 case CXTypeKind.CXType_LongLong:
                 case CXTypeKind.CXType_Double:
+                case CXTypeKind.CXType_Record:
                 case CXTypeKind.CXType_Enum:
                 case CXTypeKind.CXType_Typedef:
                 case CXTypeKind.CXType_ConstantArray:
+                case CXTypeKind.CXType_IncompleteArray:
                 {
                     return string.Empty;
                 }
@@ -81,6 +83,7 @@ namespace ClangSharpPInvokeGenerator
                 case CXTypeKind.CXType_LongLong:
                 case CXTypeKind.CXType_Double:
                 case CXTypeKind.CXType_Pointer:
+                case CXTypeKind.CXType_Record:
                 case CXTypeKind.CXType_Enum:
                 case CXTypeKind.CXType_Typedef:
                 case CXTypeKind.CXType_FunctionProto:
@@ -118,6 +121,11 @@ namespace ClangSharpPInvokeGenerator
                 case CXTypeKind.CXType_Void:
                 {
                     return "void";
+                }
+
+                case CXTypeKind.CXType_Bool:
+                {
+                    return "bool";
                 }
 
                 case CXTypeKind.CXType_UShort:
@@ -190,6 +198,7 @@ namespace ClangSharpPInvokeGenerator
                 }
 
                 case CXTypeKind.CXType_ConstantArray:
+                case CXTypeKind.CXType_IncompleteArray:
                 {
                     return type.GetNameForElementType(cursor, type.ElementType);
                 }
@@ -227,6 +236,7 @@ namespace ClangSharpPInvokeGenerator
                     switch (cursor.Kind)
                     {
                         case CXCursorKind.CXCursor_FieldDecl:
+                        case CXCursorKind.CXCursor_FunctionDecl:
                         {
                             return "IntPtr";
                         }
@@ -269,6 +279,11 @@ namespace ClangSharpPInvokeGenerator
                             return "string";
                         }
 
+                        case CXCursorKind.CXCursor_TypedefDecl:
+                        {
+                            return "string";
+                        }
+
                         default:
                         {
                             Unhandled(pointeeType, cursor);
@@ -288,6 +303,7 @@ namespace ClangSharpPInvokeGenerator
                         }
 
                         case CXCursorKind.CXCursor_ParmDecl:
+                        case CXCursorKind.CXCursor_TypedefDecl:
                         {
                             return pointeeType.Declaration.GetTypedefDeclName();
                         }
@@ -335,6 +351,7 @@ namespace ClangSharpPInvokeGenerator
                 case CXTypeKind.CXType_Enum:
                 case CXTypeKind.CXType_Typedef:
                 case CXTypeKind.CXType_ConstantArray:
+                case CXTypeKind.CXType_IncompleteArray:
                 {
                     return string.Empty;
                 }
@@ -369,6 +386,7 @@ namespace ClangSharpPInvokeGenerator
                     return string.Empty;
                 }
 
+                case CXTypeKind.CXType_UChar:
                 case CXTypeKind.CXType_UShort:
                 case CXTypeKind.CXType_UInt:
                 case CXTypeKind.CXType_ULong:

--- a/ClangSharpPInvokeGenerator/CursorVisitor.cs
+++ b/ClangSharpPInvokeGenerator/CursorVisitor.cs
@@ -160,6 +160,11 @@ namespace ClangSharpPInvokeGenerator
                     return Handle(VisitTypeRef, cursor, parent, data);
                 }
 
+                case CXCursorKind.CXCursor_CompoundStmt:
+                {
+                    return CXChildVisitResult.CXChildVisit_Continue;
+                }
+
                 case CXCursorKind.CXCursor_UnexposedAttr:
                 {
                     return Handle(VisitUnexposedAttr, cursor, parent, data);
@@ -263,6 +268,21 @@ namespace ClangSharpPInvokeGenerator
                 case CXCursorKind.CXCursor_UnexposedDecl:
                 {
                     return Handle(VisitUnexposedDecl, cursor, parent, data);
+                }
+
+                case CXCursorKind.CXCursor_StructDecl:
+                {
+                    return Handle(VisitStructDecl, cursor, parent, data);
+                }
+
+                case CXCursorKind.CXCursor_EnumDecl:
+                {
+                    return Handle(VisitEnumDecl, cursor, parent, data);
+                }
+
+                case CXCursorKind.CXCursor_TypedefDecl:
+                {
+                    return Handle(VisitTypedefDecl, cursor, parent, data);
                 }
 
                 default:

--- a/ClangSharpPInvokeGenerator/CursorWriter.cs
+++ b/ClangSharpPInvokeGenerator/CursorWriter.cs
@@ -391,8 +391,8 @@ namespace ClangSharpPInvokeGenerator
                         Write(' ');
                         Write(typeName);
                         Write(' ');
-                        WriteLine("Value");
-                        Write(';');
+                        Write("Value");
+                        WriteLine(';');
                     }
                     WriteBlockEnd();
                     WriteLine();

--- a/ClangSharpPInvokeGenerator/CursorWriter.cs
+++ b/ClangSharpPInvokeGenerator/CursorWriter.cs
@@ -355,6 +355,50 @@ namespace ClangSharpPInvokeGenerator
 
             switch (underlyingType.kind)
             {
+                case CXTypeKind.CXType_Bool:
+                case CXTypeKind.CXType_UShort:
+                case CXTypeKind.CXType_UInt:
+                case CXTypeKind.CXType_ULong:
+                case CXTypeKind.CXType_ULongLong:
+                case CXTypeKind.CXType_Short:
+                case CXTypeKind.CXType_Int:
+                case CXTypeKind.CXType_Long:
+                case CXTypeKind.CXType_LongLong:
+                case CXTypeKind.CXType_Double:
+                {
+                    WriteIndented("public partial struct");
+                    Write(' ');
+                    WriteLine(cursor.GetTypedefDeclName());
+                    WriteBlockStart();
+                    {
+                        var typeName = underlyingType.GetName(cursor);
+
+                        WriteIndented("public");
+                        Write(' ');
+                        Write(cursor.GetTypedefDeclName());
+                        Write('(');
+                        Write(typeName);
+                        Write(' ');
+                        Write("value");
+                        WriteLine(')');
+                        WriteBlockStart();
+                        {
+                            WriteIndentedLine("Value = value;");
+                        }
+                        WriteBlockEnd();
+                        WriteLine();
+                        WriteIndented("public");
+                        Write(' ');
+                        Write(typeName);
+                        Write(' ');
+                        WriteLine("Value");
+                        Write(';');
+                    }
+                    WriteBlockEnd();
+                    WriteLine();
+                    return true;
+                }
+
                 case CXTypeKind.CXType_Pointer:
                 {
                     return BeginHandleTypedefDeclForPointer(cursor, parent, underlyingType.PointeeType);
@@ -366,6 +410,7 @@ namespace ClangSharpPInvokeGenerator
                     return false;
                 }
 
+                case CXTypeKind.CXType_Typedef:
                 case CXTypeKind.CXType_Elaborated:
                 {
                     return BeginHandleTypedefDecl(cursor, parent, underlyingType.CanonicalType);

--- a/ClangSharpPInvokeGenerator/Program.cs
+++ b/ClangSharpPInvokeGenerator/Program.cs
@@ -133,7 +133,7 @@ namespace ClangSharpPInvokeGenerator
 
                 if (translationUnitError != CXErrorCode.CXError_Success)
                 {
-                    Console.WriteLine("Error: " + translationUnitError);
+                    Console.WriteLine($"Error: '{translationUnitError}' for '{file}'.");
                     var numDiagnostics = translationUnit.NumDiagnostics;
 
                     for (uint i = 0; i < numDiagnostics; ++i)
@@ -185,7 +185,7 @@ namespace ClangSharpPInvokeGenerator
                     sw.WriteLine();
 
                     functionDeclWriter.PrefixStrip = prefixStrip;
-                    functionDeclWriter.ExcludeFunctionsArray = excludeFunctionsArray;
+                    functionDeclWriter.ExcludeFunctionsArray = excludeFunctionsArray ?? Array.Empty<string>();
 
                     foreach (var tu in translationUnits)
                     {


### PR DESCRIPTION
Ran the binding generator over LLVMSharp after #34 was merged. Found a few places that weren't covered yet.