### PR TITLE
 Fixing some issues in the writer and how parmCount is tracked

### DIFF
--- a/ClangSharp/Generated.cs
+++ b/ClangSharp/Generated.cs
@@ -27,18 +27,18 @@ namespace ClangSharp
 
     public partial struct CXFileUniqueID
     {
-        public ulong data0;public ulong data1;public ulong data2;
+        public ulong data0; public ulong data1; public ulong data2;
     }
 
     public partial struct CXSourceLocation
     {
-        public IntPtr ptr_data0;public IntPtr ptr_data1;
+        public IntPtr ptr_data0; public IntPtr ptr_data1;
         public uint int_data;
     }
 
     public partial struct CXSourceRange
     {
-        public IntPtr ptr_data0;public IntPtr ptr_data1;
+        public IntPtr ptr_data0; public IntPtr ptr_data1;
         public uint begin_int_data;
         public uint end_int_data;
     }
@@ -66,7 +66,7 @@ namespace ClangSharp
     {
         public CXCursorKind kind;
         public int xdata;
-        public IntPtr data0;public IntPtr data1;public IntPtr data2;
+        public IntPtr data0; public IntPtr data1; public IntPtr data2;
     }
 
     public partial struct CXPlatformAvailability
@@ -86,12 +86,12 @@ namespace ClangSharp
     public partial struct CXType
     {
         public CXTypeKind kind;
-        public IntPtr data0;public IntPtr data1;
+        public IntPtr data0; public IntPtr data1;
     }
 
     public partial struct CXToken
     {
-        public uint int_data0;public uint int_data1;public uint int_data2;public uint int_data3;
+        public uint int_data0; public uint int_data1; public uint int_data2; public uint int_data3;
         public IntPtr ptr_data;
     }
 
@@ -115,7 +115,7 @@ namespace ClangSharp
 
     public partial struct CXIdxLoc
     {
-        public IntPtr ptr_data0;public IntPtr ptr_data1;
+        public IntPtr ptr_data0; public IntPtr ptr_data1;
         public uint int_data;
     }
 

--- a/ClangSharpPInvokeGenerator/AttachedFunctionDeclData.cs
+++ b/ClangSharpPInvokeGenerator/AttachedFunctionDeclData.cs
@@ -1,0 +1,19 @@
+﻿using System.Diagnostics;
+
+namespace ClangSharpPInvokeGenerator
+{
+    public struct AttachedFunctionDeclData
+    {
+        public AttachedFunctionDeclData(int parmCount)
+        {
+            Debug.Assert(parmCount != -1);
+
+            ParmCount = parmCount;
+            RemainingParmCount = parmCount;
+        }
+
+        public int ParmCount { get; }
+
+        public int RemainingParmCount { get; set; }
+    }
+}


### PR DESCRIPTION
This resolves a few more issues in the writer (such as missing spaces), fixes how parmCount is tracked to make it simpler to compute the correct paramIndex, and changes how `GetTypedefDeclName` resolves the underlying name to return.