### PR TITLE
Adding some tests validating we skip tag declarations that aren't definitions

### DIFF
--- a/ClangSharp.PInvokeGenerator.Test/EnumDeclarationTest.cs
+++ b/ClangSharp.PInvokeGenerator.Test/EnumDeclarationTest.cs
@@ -86,5 +86,48 @@ namespace ClangSharp.Test
 
             await ValidateGeneratedBindings(inputContents, expectedOutputContents);
         }
+
+        [Fact]
+        public async Task SkipNoDefinitionTest()
+        {
+            var inputContents = "typedef enum MyEnum MyEnum;";
+
+            var expectedOutputContents = $@"namespace ClangSharp.Test
+{{
+    public enum MyEnum
+    {{
+    }}
+}}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task SkipNonDefinitionTest()
+        {
+            var inputContents = $@"typedef enum MyEnum MyEnum;
+
+enum MyEnum
+{{
+    MyEnum_Value0,
+    MyEnum_Value1,
+    MyEnum_Value2,
+}};
+";
+
+            var expectedOutputContents = $@"namespace ClangSharp.Test
+{{
+    public enum MyEnum
+    {{
+        MyEnum_Value0,
+        MyEnum_Value1,
+        MyEnum_Value2,
+    }}
+}}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
     }
 }

--- a/ClangSharp.PInvokeGenerator.Test/StructDeclarationTest.cs
+++ b/ClangSharp.PInvokeGenerator.Test/StructDeclarationTest.cs
@@ -91,6 +91,58 @@ namespace ClangSharp.Test
             await ValidateGeneratedBindings(inputContents, expectedOutputContents);
         }
 
+        [Fact]
+        public async Task SkipNoDefinitionTest()
+        {
+            var inputContents = "typedef struct MyStruct MyStruct;";
+
+            var expectedOutputContents = $@"namespace ClangSharp.Test
+{{
+    public partial struct MyStruct
+    {{
+    }}
+}}
+";
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Theory]
+        [InlineData("unsigned char", "byte")]
+        [InlineData("double", "double")]
+        [InlineData("short", "short")]
+        [InlineData("int", "int")]
+        [InlineData("long long", "long")]
+        [InlineData("char", "sbyte")]
+        [InlineData("float", "float")]
+        [InlineData("unsigned short", "ushort")]
+        [InlineData("unsigned int", "uint")]
+        [InlineData("unsigned long long", "ulong")]
+        public async Task SkipNonDefinitionTest(string nativeType, string expectedManagedType)
+        {
+            var inputContents = $@"typedef struct MyStruct MyStruct;
+
+struct MyStruct
+{{
+    {nativeType} r;
+    {nativeType} g;
+    {nativeType} b;
+}};
+";
+
+            var expectedOutputContents = $@"namespace ClangSharp.Test
+{{
+    public partial struct MyStruct
+    {{
+        public {expectedManagedType} r;
+        public {expectedManagedType} g;
+        public {expectedManagedType} b;
+    }}
+}}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
         [Theory]
         [InlineData("unsigned char", "byte")]
         [InlineData("double", "double")]

--- a/ClangSharp.PInvokeGenerator/Cursors/Decls/CXXRecordDecl.cs
+++ b/ClangSharp.PInvokeGenerator/Cursors/Decls/CXXRecordDecl.cs
@@ -18,8 +18,8 @@ namespace ClangSharp
         public CXXRecordDecl(CXCursor handle, Cursor parent) : base(handle, parent)
         {
             _specializedTemplate = new Lazy<Cursor>(() => {
-                var cursor = TranslationUnit.GetOrCreateCursor(handle.SpecializedCursorTemplate, () => Create(handle.SpecializedCursorTemplate, this));
-                cursor.Visit(clientData: default);
+                var cursor = TranslationUnit.GetOrCreateCursor(Handle.SpecializedCursorTemplate, () => Create(Handle.SpecializedCursorTemplate, this));
+                cursor?.Visit(clientData: default);
                 return cursor;
             });
         }

--- a/ClangSharp.PInvokeGenerator/Cursors/Decls/Decl.cs
+++ b/ClangSharp.PInvokeGenerator/Cursors/Decls/Decl.cs
@@ -163,27 +163,21 @@ namespace ClangSharp
         }
 
         private readonly List<Attr> _attributes = new List<Attr>();
-        private readonly Lazy<Cursor> _canonical;
-        private readonly Lazy<Cursor> _definition;
+        private readonly Lazy<Decl> _canonical;
         private readonly Lazy<Cursor> _lexicalParent;
 
         protected Decl(CXCursor handle, Cursor parent) : base(handle, parent)
         {
             Debug.Assert(handle.IsDeclaration);
 
-            _canonical = new Lazy<Cursor>(() => {
-                var cursor = TranslationUnit.GetOrCreateCursor(handle.CanonicalCursor, () => Create(handle.CanonicalCursor, this));
-                cursor.Visit(clientData: default);
-                return cursor;
-            });
-            _definition = new Lazy<Cursor>(() => {
-                var cursor = TranslationUnit.GetOrCreateCursor(Handle.Definition, () => Create(Handle.Definition, this));
-                cursor.Visit(clientData: default);
-                return cursor;
+            _canonical = new Lazy<Decl>(() => {
+                var cursor = TranslationUnit.GetOrCreateCursor(Handle.CanonicalCursor, () => Create(Handle.CanonicalCursor, this));
+                cursor?.Visit(clientData: default);
+                return (Decl)cursor;
             });
             _lexicalParent = new Lazy<Cursor>(() => {
                 var cursor = TranslationUnit.GetOrCreateCursor(Handle.LexicalParent, () => Create(Handle.LexicalParent, this));
-                cursor.Visit(clientData: default);
+                cursor?.Visit(clientData: default);
                 return cursor;
             });
         }
@@ -196,19 +190,15 @@ namespace ClangSharp
 
         public string BriefCommentText => Handle.BriefCommentText.ToString();
 
-        public Cursor Canonical => _canonical.Value;
+        public Decl Canonical => _canonical.Value;
 
         public CXSourceRange CommentRange => Handle.CommentRange;
-
-        public Cursor Definition => _definition.Value;
 
         public int ExceptionSpecificationType => Handle.ExceptionSpecificationType;
 
         public bool HasAttrs => Handle.HasAttrs;
 
         public bool IsCanonical => Handle.IsCanonical;
-
-        public bool IsDefinition => Handle.IsDefinition;
 
         public bool IsInvalid => Handle.IsInvalidDeclaration;
 

--- a/ClangSharp.PInvokeGenerator/Cursors/Decls/FunctionDecl.cs
+++ b/ClangSharp.PInvokeGenerator/Cursors/Decls/FunctionDecl.cs
@@ -30,8 +30,8 @@ namespace ClangSharp
             _returnType = new Lazy<Type>(() => TranslationUnit.GetOrCreateType(Handle.ResultType, () => Type.Create(Handle.ResultType, TranslationUnit)));
 
             _specializedTemplate = new Lazy<Cursor>(() => {
-                var cursor = TranslationUnit.GetOrCreateCursor(handle.SpecializedCursorTemplate, () => Create(handle.SpecializedCursorTemplate, this));
-                cursor.Visit(clientData: default);
+                var cursor = TranslationUnit.GetOrCreateCursor(Handle.SpecializedCursorTemplate, () => Create(Handle.SpecializedCursorTemplate, this));
+                cursor?.Visit(clientData: default);
                 return cursor;
             });
         }

--- a/ClangSharp.PInvokeGenerator/Cursors/Decls/RedeclarableTemplateDecl.cs
+++ b/ClangSharp.PInvokeGenerator/Cursors/Decls/RedeclarableTemplateDecl.cs
@@ -9,8 +9,8 @@ namespace ClangSharp
         protected RedeclarableTemplateDecl(CXCursor handle, Cursor parent) : base(handle, parent)
         {
             _specializedTemplate = new Lazy<Cursor>(() => {
-                var cursor = TranslationUnit.GetOrCreateCursor(handle.SpecializedCursorTemplate, () => Create(handle.SpecializedCursorTemplate, this));
-                cursor.Visit(clientData: default);
+                var cursor = TranslationUnit.GetOrCreateCursor(Handle.SpecializedCursorTemplate, () => Create(Handle.SpecializedCursorTemplate, this));
+                cursor?.Visit(clientData: default);
                 return cursor;
             });
         }

--- a/ClangSharp.PInvokeGenerator/Cursors/Decls/TagDecl.cs
+++ b/ClangSharp.PInvokeGenerator/Cursors/Decls/TagDecl.cs
@@ -1,18 +1,29 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace ClangSharp
 {
     internal class TagDecl : TypeDecl
     {
         private readonly List<Decl> _declarations = new List<Decl>();
+        private readonly Lazy<TagDecl> _definition;
 
         protected TagDecl(CXCursor handle, Cursor parent) : base(handle, parent)
         {
+            _definition = new Lazy<TagDecl>(() => {
+                var cursor = TranslationUnit.GetOrCreateCursor(Handle.Definition, () => Create(Handle.Definition, this));
+                cursor?.Visit(clientData: default);
+                return (TagDecl)cursor;
+            });
         }
+
+        public IReadOnlyList<Decl> Declarations => _declarations;
+
+        public TagDecl Definition => _definition.Value;
 
         public bool IsAnonymous => Handle.IsAnonymous;
 
-        public IReadOnlyList<Decl> Declarations => _declarations;
+        public bool IsDefinition => Handle.IsDefinition;
 
         protected override Decl GetOrAddDecl(CXCursor childHandle)
         {

--- a/ClangSharp.PInvokeGenerator/Cursors/Decls/UsingDecl.cs
+++ b/ClangSharp.PInvokeGenerator/Cursors/Decls/UsingDecl.cs
@@ -12,8 +12,8 @@ namespace ClangSharp
             Debug.Assert(handle.Kind == CXCursorKind.CXCursor_UsingDeclaration);
 
             _referenced = new Lazy<Cursor>(() => {
-                var cursor = TranslationUnit.GetOrCreateCursor(handle.Referenced, () => Create(handle.Referenced, this));
-                cursor.Visit(clientData: default);
+                var cursor = TranslationUnit.GetOrCreateCursor(Handle.Referenced, () => Create(Handle.Referenced, this));
+                cursor?.Visit(clientData: default);
                 return cursor;
             });
         }

--- a/ClangSharp.PInvokeGenerator/Cursors/Decls/VarDecl.cs
+++ b/ClangSharp.PInvokeGenerator/Cursors/Decls/VarDecl.cs
@@ -9,8 +9,8 @@ namespace ClangSharp
         public VarDecl(CXCursor handle, Cursor parent) : base(handle, parent)
         {
             _specializedTemplate = new Lazy<Cursor>(() => {
-                var cursor = TranslationUnit.GetOrCreateCursor(handle.SpecializedCursorTemplate, () => Create(handle.SpecializedCursorTemplate, this));
-                cursor.Visit(clientData: default);
+                var cursor = TranslationUnit.GetOrCreateCursor(Handle.SpecializedCursorTemplate, () => Create(Handle.SpecializedCursorTemplate, this));
+                cursor?.Visit(clientData: default);
                 return cursor;
             });
         }

--- a/ClangSharp.PInvokeGenerator/Cursors/Exprs/CallExpr.cs
+++ b/ClangSharp.PInvokeGenerator/Cursors/Exprs/CallExpr.cs
@@ -26,8 +26,8 @@ namespace ClangSharp
 
             _referenced = new Lazy<Cursor>(() =>
             {
-                var cursor = TranslationUnit.GetOrCreateCursor(handle.Referenced, () => Create(handle.Referenced, this));
-                cursor.Visit(clientData: default);
+                var cursor = TranslationUnit.GetOrCreateCursor(Handle.Referenced, () => Create(Handle.Referenced, this));
+                cursor?.Visit(clientData: default);
                 return cursor;
             });
         }

--- a/ClangSharp.PInvokeGenerator/Cursors/Exprs/DeclRefExpr.cs
+++ b/ClangSharp.PInvokeGenerator/Cursors/Exprs/DeclRefExpr.cs
@@ -12,8 +12,8 @@ namespace ClangSharp
             Debug.Assert(handle.Kind == CXCursorKind.CXCursor_DeclRefExpr);
 
             _decl = new Lazy<ValueDecl>(() => {
-                var cursor = TranslationUnit.GetOrCreateCursor(handle.Referenced, () => ClangSharp.Decl.Create(handle.Referenced, this));
-                cursor.Visit(clientData: default);
+                var cursor = TranslationUnit.GetOrCreateCursor(Handle.Referenced, () => ClangSharp.Decl.Create(Handle.Referenced, this));
+                cursor?.Visit(clientData: default);
                 return (ValueDecl)cursor;
             });
         }

--- a/ClangSharp.PInvokeGenerator/Cursors/Exprs/Expr.cs
+++ b/ClangSharp.PInvokeGenerator/Cursors/Exprs/Expr.cs
@@ -146,8 +146,8 @@ namespace ClangSharp
             Debug.Assert(handle.IsExpression);
 
             _definition = new Lazy<Cursor>(() => {
-                var cursor = TranslationUnit.GetOrCreateCursor(handle.Definition, () => Create(handle.Definition, this));
-                cursor.Visit(clientData: default);
+                var cursor = TranslationUnit.GetOrCreateCursor(Handle.Definition, () => Create(Handle.Definition, this));
+                cursor?.Visit(clientData: default);
                 return cursor;
             });
             _type = new Lazy<Type>(() => TranslationUnit.GetOrCreateType(Handle.Type, () => Type.Create(Handle.Type, TranslationUnit)));

--- a/ClangSharp.PInvokeGenerator/Cursors/Exprs/SizeOfPackExpr.cs
+++ b/ClangSharp.PInvokeGenerator/Cursors/Exprs/SizeOfPackExpr.cs
@@ -12,8 +12,8 @@ namespace ClangSharp
             Debug.Assert(handle.Kind == CXCursorKind.CXCursor_SizeOfPackExpr);
 
             _referenced = new Lazy<Cursor>(() => {
-                var cursor = TranslationUnit.GetOrCreateCursor(handle.Referenced, () => Create(handle.Referenced, this));
-                cursor.Visit(clientData: default);
+                var cursor = TranslationUnit.GetOrCreateCursor(Handle.Referenced, () => Create(Handle.Referenced, this));
+                cursor?.Visit(clientData: default);
                 return cursor;
             });
         }

--- a/ClangSharp.PInvokeGenerator/Cursors/Refs/Ref.cs
+++ b/ClangSharp.PInvokeGenerator/Cursors/Refs/Ref.cs
@@ -57,13 +57,13 @@ namespace ClangSharp
             Debug.Assert(handle.IsReference);
 
             _definition = new Lazy<Cursor>(() => {
-                var cursor = TranslationUnit.GetOrCreateCursor(handle.Definition, () => Create(handle.Definition, this));
-                cursor.Visit(clientData: default);
+                var cursor = TranslationUnit.GetOrCreateCursor(Handle.Definition, () => Create(Handle.Definition, this));
+                cursor?.Visit(clientData: default);
                 return cursor;
             });
             _referenced = new Lazy<Cursor>(() => {
-                var cursor = TranslationUnit.GetOrCreateCursor(handle.Referenced, () => Create(handle.Referenced, this));
-                cursor.Visit(clientData: default);
+                var cursor = TranslationUnit.GetOrCreateCursor(Handle.Referenced, () => Create(Handle.Referenced, this));
+                cursor?.Visit(clientData: default);
                 return cursor;
             });
             _type = new Lazy<Type>(() => TranslationUnit.GetOrCreateType(Handle.Type, () => Type.Create(Handle.Type, TranslationUnit)));

--- a/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -79,7 +79,7 @@ namespace ClangSharp
                 emitNamespaceDeclaration = false;
             }
 
-            if (!_config.GenerateMultipleFiles)
+            if (!_config.GenerateMultipleFiles && _outputBuilderFactory.OutputBuilders.Any())
             {
                 var outputPath = _config.OutputLocation;
                 var (stream, leaveStreamOpen) = _outputStreamFactory(outputPath);
@@ -1500,6 +1500,17 @@ namespace ClangSharp
 
         private void VisitTagDecl(TagDecl tagDecl, Cursor parent)
         {
+            if (!tagDecl.IsDefinition && (tagDecl.Definition != null))
+            {
+                // We don't want to generate bindings for anything
+                // that is not itself a definition and that has a
+                // definition that can be resolved. This ensures we
+                // still generate bindings for things which are used
+                // as opaque handles, but which aren't ever defined.
+
+                return;
+            }
+
             if (tagDecl is RecordDecl recordDecl)
             {
                 VisitRecordDecl(recordDecl, parent);

--- a/ClangSharp.PInvokeGenerator/Types/Type.cs
+++ b/ClangSharp.PInvokeGenerator/Types/Type.cs
@@ -28,14 +28,14 @@ namespace ClangSharp
 
             translationUnit.AddVisitedType(this);
 
-            _canonicalType = new Lazy<Type>(() => translationUnit.GetOrCreateType(handle.CanonicalType, () => Create(handle.CanonicalType, translationUnit)));
-            _elementType = new Lazy<Type>(() => translationUnit.GetOrCreateType(handle.ElementType, () => Create(handle.ElementType, translationUnit)));
-            _modifierType = new Lazy<Type>(() => translationUnit.GetOrCreateType(handle.ModifierType, () => Create(handle.ModifierType, translationUnit)));
-            _pointeeType = new Lazy<Type>(() => translationUnit.GetOrCreateType(handle.PointeeType, () => Create(handle.PointeeType, translationUnit)));
-            _resultType = new Lazy<Type>(() => translationUnit.GetOrCreateType(handle.ResultType, () => Create(handle.ResultType, translationUnit)));
+            _canonicalType = new Lazy<Type>(() => translationUnit.GetOrCreateType(Handle.CanonicalType, () => Create(Handle.CanonicalType, translationUnit)));
+            _elementType = new Lazy<Type>(() => translationUnit.GetOrCreateType(Handle.ElementType, () => Create(Handle.ElementType, translationUnit)));
+            _modifierType = new Lazy<Type>(() => translationUnit.GetOrCreateType(Handle.ModifierType, () => Create(Handle.ModifierType, translationUnit)));
+            _pointeeType = new Lazy<Type>(() => translationUnit.GetOrCreateType(Handle.PointeeType, () => Create(Handle.PointeeType, translationUnit)));
+            _resultType = new Lazy<Type>(() => translationUnit.GetOrCreateType(Handle.ResultType, () => Create(Handle.ResultType, translationUnit)));
 
             _declarationCursor = new Lazy<Decl>(() => {
-                var cursor = translationUnit.GetOrCreateCursor(handle.Declaration, () => Cursor.Create(handle.Declaration, translationUnit));
+                var cursor = translationUnit.GetOrCreateCursor(Handle.Declaration, () => Cursor.Create(Handle.Declaration, translationUnit));
                 cursor?.Visit(clientData: default);
                 return (Decl)cursor;
             });


### PR DESCRIPTION
This fixes up the binding generation and adds corresponding tests validating that we will skip over any tag declarations which aren't actual definitions, but that we still emit any binding when no definition can be resolved.

This ensures that we still get a usable struct when we have opaque handles being defined, but also ensures we don't get any empty definition when that binding can be generated properly (either later as part of the same pass or by generating bindings over a separate header file).