### PR TITLE
Updating ClangSharp to support generating bindings for basic function bodies.

### DIFF
--- a/ClangSharp.PInvokeGenerator.Test/FunctionDeclarationBodyImportTest.cs
+++ b/ClangSharp.PInvokeGenerator.Test/FunctionDeclarationBodyImportTest.cs
@@ -1,0 +1,93 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ClangSharp.Test
+{
+    public sealed class FunctionDeclarationBodyImportTest : PInvokeGeneratorTest
+    {
+        [Fact]
+        public async Task BasicTest()
+        {
+            var inputContents = @"void MyFunction()
+{
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string libraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static void MyFunction()
+        {
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task CallFunctionTest()
+        {
+            var inputContents = @"void MyCalledFunction()
+{
+}
+
+void MyFunction()
+{
+    MyCalledFunction();
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string libraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static void MyCalledFunction()
+        {
+        }
+
+        public static void MyFunction()
+        {
+            MyCalledFunction();
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task ReturnIntegerTest()
+        {
+            var inputContents = @"int MyFunction()
+{
+    return -1;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string libraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction()
+        {
+            return -1;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+    }
+}

--- a/ClangSharp.PInvokeGenerator.Test/FunctionDeclarationDllImportTest.cs
+++ b/ClangSharp.PInvokeGenerator.Test/FunctionDeclarationDllImportTest.cs
@@ -1,0 +1,30 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace ClangSharp.Test
+{
+    public sealed class FunctionDeclarationDllImportTest : PInvokeGeneratorTest
+    {
+        [Fact]
+        public async Task BasicTest()
+        {
+            var inputContents = @"void MyFunction();";
+
+            var expectedOutputContents = @"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string libraryPath = ""ClangSharpPInvokeGenerator"";
+
+        [DllImport(libraryPath, EntryPoint = ""MyFunction"", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void MyFunction();
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+    }
+}

--- a/ClangSharp.PInvokeGenerator.Test/PInvokeGeneratorTest.cs
+++ b/ClangSharp.PInvokeGenerator.Test/PInvokeGeneratorTest.cs
@@ -11,8 +11,7 @@ namespace ClangSharp.Test
         protected const string DefaultLibraryPath = "ClangSharpPInvokeGenerator";
         protected const string DefaultNamespaceName = "ClangSharp.Test";
 
-        protected const CXTranslationUnit_Flags DefaultTranslationUnitFlags = CXTranslationUnit_Flags.CXTranslationUnit_SkipFunctionBodies          // Don't traverse function bodies
-                                                                            | CXTranslationUnit_Flags.CXTranslationUnit_IncludeAttributedTypes      // Include attributed types in CXType
+        protected const CXTranslationUnit_Flags DefaultTranslationUnitFlags = CXTranslationUnit_Flags.CXTranslationUnit_IncludeAttributedTypes      // Include attributed types in CXType
                                                                             | CXTranslationUnit_Flags.CXTranslationUnit_VisitImplicitAttributes;    // Implicit attributes should be visited
 
         protected static readonly string[] DefaultClangCommandLineArgs = new string[]

--- a/ClangSharp.PInvokeGenerator/Cursors/Decls/FunctionDecl.cs
+++ b/ClangSharp.PInvokeGenerator/Cursors/Decls/FunctionDecl.cs
@@ -36,6 +36,8 @@ namespace ClangSharp
             });
         }
 
+        public Stmt Body => _body;
+
         public IReadOnlyList<Decl> Declarations => _declarations;
 
         public string DisplayName => Handle.DisplayName.ToString();

--- a/ClangSharp.PInvokeGenerator/Cursors/Stmts/CompoundStmt.cs
+++ b/ClangSharp.PInvokeGenerator/Cursors/Stmts/CompoundStmt.cs
@@ -1,12 +1,31 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace ClangSharp
 {
     internal sealed class CompoundStmt : Stmt
     {
+        private readonly List<Stmt> _body = new List<Stmt>();
+
         public CompoundStmt(CXCursor handle, Cursor parent) : base(handle, parent)
         {
             Debug.Assert(handle.Kind == CXCursorKind.CXCursor_CompoundStmt);
+        }
+
+        public IReadOnlyList<Stmt> Body => _body;
+
+        protected override Expr GetOrAddExpr(CXCursor childHandle)
+        {
+            var expr = base.GetOrAddExpr(childHandle);
+            _body.Add(expr);
+            return expr;
+        }
+
+        protected override Stmt GetOrAddStmt(CXCursor childHandle)
+        {
+            var stmt = base.GetOrAddStmt(childHandle);
+            _body.Add(stmt);
+            return stmt;
         }
     }
 }

--- a/ClangSharp.PInvokeGenerator/Cursors/Stmts/ReturnStmt.cs
+++ b/ClangSharp.PInvokeGenerator/Cursors/Stmts/ReturnStmt.cs
@@ -4,9 +4,23 @@ namespace ClangSharp
 {
     internal sealed class ReturnStmt : Stmt
     {
+        private Expr _retValue;
+
         public ReturnStmt(CXCursor handle, Cursor parent) : base(handle, parent)
         {
             Debug.Assert(handle.Kind == CXCursorKind.CXCursor_ReturnStmt);
+        }
+
+        public Expr RetValue => _retValue;
+
+        protected override Expr GetOrAddExpr(CXCursor childHandle)
+        {
+            var expr = base.GetOrAddExpr(childHandle);
+
+            Debug.Assert(_retValue is null);
+            _retValue = expr;
+
+            return expr;
         }
     }
 }

--- a/ClangSharpPInvokeGenerator/Program.cs
+++ b/ClangSharpPInvokeGenerator/Program.cs
@@ -110,7 +110,6 @@ namespace ClangSharp
 
             var translationFlags = CXTranslationUnit_Flags.CXTranslationUnit_None;
 
-            translationFlags |= CXTranslationUnit_Flags.CXTranslationUnit_SkipFunctionBodies;                   // Don't traverse function bodies
             translationFlags |= CXTranslationUnit_Flags.CXTranslationUnit_IncludeAttributedTypes;               // Include attributed types in CXType
             translationFlags |= CXTranslationUnit_Flags.CXTranslationUnit_VisitImplicitAttributes;              // Implicit attributes should be visited
 


### PR DESCRIPTION
This updates ClangSharp to recognize and generate equivalent C# code when it encounters a function body. This is useful for some limited scenarios, such as in LLVM, where you have a non-exported function that you still want to be able to consume from C# code.