### PR TITLE
Updating the traverser to support most of the operator opcodes.

### DIFF
--- a/ClangSharp.PInvokeGenerator.Test/FunctionDeclarationBodyImportTest.cs
+++ b/ClangSharp.PInvokeGenerator.Test/FunctionDeclarationBodyImportTest.cs
@@ -30,6 +30,87 @@ namespace ClangSharp.Test
             await ValidateGeneratedBindings(inputContents, expectedOutputContents);
         }
 
+        [Theory]
+        [InlineData("%")]
+        [InlineData("%=")]
+        [InlineData("&")]
+        [InlineData("&=")]
+        [InlineData("*")]
+        [InlineData("*=")]
+        [InlineData("+")]
+        [InlineData("+=")]
+        [InlineData("-")]
+        [InlineData("-=")]
+        [InlineData("/")]
+        [InlineData("/=")]
+        [InlineData("<<")]
+        [InlineData("<<=")]
+        [InlineData("=")]
+        [InlineData("==")]
+        [InlineData(">>")]
+        [InlineData(">>=")]
+        [InlineData("^")]
+        [InlineData("^=")]
+        [InlineData("|")]
+        [InlineData("|=")]
+        public async Task BinaryOperatorBasicTest(string opcode)
+        {
+            var inputContents = $@"int MyFunction(int x, int y)
+{{
+    return x {opcode} y;
+}}
+";
+
+            var expectedOutputContents = $@"namespace ClangSharp.Test
+{{
+    public static partial class Methods
+    {{
+        private const string libraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction(int x, int y)
+        {{
+            return x {opcode} y;
+        }}
+    }}
+}}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Theory]
+        [InlineData("!=")]
+        [InlineData("&&")]
+        [InlineData("<")]
+        [InlineData("<=")]
+        [InlineData(">")]
+        [InlineData(">=")]
+        [InlineData("||")]
+        public async Task BinaryOperatorBooleanTest(string opcode)
+        {
+            var inputContents = $@"bool MyFunction(bool x, bool y)
+{{
+    return x {opcode} y;
+}}
+";
+
+            var expectedOutputContents = $@"namespace ClangSharp.Test
+{{
+    public static partial class Methods
+    {{
+        private const string libraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static bool MyFunction(bool x, bool y)
+        {{
+            return x {opcode} y;
+        }}
+    }}
+}}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
         [Fact]
         public async Task CallFunctionTest()
         {
@@ -85,6 +166,143 @@ void MyFunction()
         }
     }
 }
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task UnaryOperatorAddrOfUnsafeTest()
+        {
+            var inputContents = @"int* MyFunction(int value)
+{
+    return &value;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static unsafe partial class Methods
+    {
+        private const string libraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int* MyFunction(int value)
+        {
+            return &value;
+        }
+    }
+}
+";
+
+            await ValidateUnsafeGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task UnaryOperatorDerefUnsafeTest()
+        {
+            var inputContents = @"int MyFunction(int* value)
+{
+    return *value;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static unsafe partial class Methods
+    {
+        private const string libraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction(int* value)
+        {
+            return *value;
+        }
+    }
+}
+";
+
+            await ValidateUnsafeGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task UnaryOperatorLogicalNotTest()
+        {
+            var inputContents = @"bool MyFunction(bool value)
+{
+    return !value;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string libraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static bool MyFunction(bool value)
+        {
+            return !value;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Theory]
+        [InlineData("++")]
+        [InlineData("--")]
+        public async Task UnaryOperatorPostfixTest(string opcode)
+        {
+            var inputContents = $@"int MyFunction(int value)
+{{
+    return value{opcode};
+}}
+";
+
+            var expectedOutputContents = $@"namespace ClangSharp.Test
+{{
+    public static partial class Methods
+    {{
+        private const string libraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction(int value)
+        {{
+            return value{opcode};
+        }}
+    }}
+}}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Theory]
+        [InlineData("+")]
+        [InlineData("++")]
+        [InlineData("-")]
+        [InlineData("--")]
+        [InlineData("~")]
+        public async Task UnaryOperatorPrefixTest(string opcode)
+        {
+            var inputContents = $@"int MyFunction(int value)
+{{
+    return {opcode}value;
+}}
+";
+
+            var expectedOutputContents = $@"namespace ClangSharp.Test
+{{
+    public static partial class Methods
+    {{
+        private const string libraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction(int value)
+        {{
+            return {opcode}value;
+        }}
+    }}
+}}
 ";
 
             await ValidateGeneratedBindings(inputContents, expectedOutputContents);

--- a/ClangSharp.PInvokeGenerator/Cursors/Exprs/CallExpr.cs
+++ b/ClangSharp.PInvokeGenerator/Cursors/Exprs/CallExpr.cs
@@ -9,8 +9,6 @@ namespace ClangSharp
         private readonly Expr[] _arguments;
         private readonly Lazy<Decl> _calleeDecl;
 
-        private Expr _callee;
-
         public CallExpr(CXCursor handle, Cursor parent) : base(handle, parent)
         {
             Debug.Assert(handle.Kind == CXCursorKind.CXCursor_CallExpr);

--- a/ClangSharp.PInvokeGenerator/Cursors/Exprs/CompoundAssignOperator.cs
+++ b/ClangSharp.PInvokeGenerator/Cursors/Exprs/CompoundAssignOperator.cs
@@ -1,44 +1,15 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 
 namespace ClangSharp
 {
-    internal class BinaryOperator : Expr
+    internal sealed class CompoundAssignOperator : BinaryOperator
     {
-        private readonly Lazy<string> _opcode;
-
-        private Expr _lhs;
-        private Expr _rhs;
-
-        public BinaryOperator(CXCursor handle, Cursor parent) : base(handle, parent)
+        public CompoundAssignOperator(CXCursor handle, Cursor parent) : base(handle, parent)
         {
-            _opcode = new Lazy<string>(GetOpcode);
+            Debug.Assert(handle.Kind == CXCursorKind.CXCursor_CompoundAssignOperator);
         }
 
-        public Expr LHS => _lhs;
-
-        public string Opcode => _opcode.Value;
-
-        public Expr RHS => _rhs;
-
-        protected override Expr GetOrAddExpr(CXCursor childHandle)
-        {
-            var expr = base.GetOrAddExpr(childHandle);
-
-            if (_lhs is null)
-            {
-                _lhs = expr;
-            }
-            else
-            {
-                Debug.Assert(_rhs is null);
-                _rhs = expr;
-            }
-
-            return expr;
-        }
-
-        protected virtual string GetOpcode()
+        protected override string GetOpcode()
         {
             var tokens = TranslationUnit.Tokenize(this);
 
@@ -60,25 +31,16 @@ namespace ClangSharp
 
                 switch (punctuation)
                 {
-                    case "!=":
-                    case "%":
-                    case "&":
-                    case "&&":
-                    case "*":
-                    case "+":
-                    case "-":
-                    case "/":
-                    case "<":
-                    case "<<":
-                    case "<=":
-                    case "=":
-                    case "==":
-                    case ">":
-                    case ">>":
-                    case ">=":
-                    case "^":
-                    case "|":
-                    case "||":
+                    case "%=":
+                    case "&=":
+                    case "*=":
+                    case "+=":
+                    case "-=":
+                    case "/=":
+                    case "<<=":
+                    case ">>=":
+                    case "^=":
+                    case "|=":
                     {
                         if (parenDepth == 0)
                         {

--- a/ClangSharp.PInvokeGenerator/Cursors/Exprs/Expr.cs
+++ b/ClangSharp.PInvokeGenerator/Cursors/Exprs/Expr.cs
@@ -69,6 +69,11 @@ namespace ClangSharp
                     return new BinaryOperator(handle, parent);
                 }
 
+                case CXCursorKind.CXCursor_CompoundAssignOperator:
+                {
+                    return new CompoundAssignOperator(handle, parent);
+                }
+
                 case CXCursorKind.CXCursor_ConditionalOperator:
                 {
                     return new ConditionalOperator(handle, parent);

--- a/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -1417,16 +1417,16 @@ namespace ClangSharp
                     _outputBuilder.Write("\", CallingConvention = CallingConvention.");
                     _outputBuilder.Write(GetCallingConventionName(functionDecl, type.CallingConv));
                     _outputBuilder.WriteLine(")]");
-                }
 
-                var marshalAttribute = GetMarshalAttribute(functionDecl, returnType);
+                    var marshalAttribute = GetMarshalAttribute(functionDecl, returnType);
 
-                if (!string.IsNullOrWhiteSpace(marshalAttribute))
-                {
-                    _outputBuilder.WriteIndented("[return: ");
-                    _outputBuilder.Write(marshalAttribute);
-                    _outputBuilder.Write(']');
-                    _outputBuilder.WriteLine();
+                    if (!string.IsNullOrWhiteSpace(marshalAttribute))
+                    {
+                        _outputBuilder.WriteIndented("[return: ");
+                        _outputBuilder.Write(marshalAttribute);
+                        _outputBuilder.Write(']');
+                        _outputBuilder.WriteLine();
+                    }
                 }
 
                 _outputBuilder.WriteIndented("public static");
@@ -1522,14 +1522,17 @@ namespace ClangSharp
 
         private void VisitParmVarDecl(ParmVarDecl parmVarDecl, Cursor parent, int index, int lastIndex)
         {
-            var marshalAttribute = GetMarshalAttribute(parmVarDecl, parmVarDecl.Type);
-
-            if (!string.IsNullOrWhiteSpace(marshalAttribute))
+            if ((parent is FunctionDecl functionDecl) && (functionDecl.Body is null))
             {
-                _outputBuilder.Write("[");
-                _outputBuilder.Write(marshalAttribute);
-                _outputBuilder.Write(']');
-                _outputBuilder.Write(' ');
+                var marshalAttribute = GetMarshalAttribute(parmVarDecl, parmVarDecl.Type);
+
+                if (!string.IsNullOrWhiteSpace(marshalAttribute))
+                {
+                    _outputBuilder.Write("[");
+                    _outputBuilder.Write(marshalAttribute);
+                    _outputBuilder.Write(']');
+                    _outputBuilder.Write(' ');
+                }
             }
 
             var parmModifier = GetParmModifier(parmVarDecl, parmVarDecl.Type);


### PR DESCRIPTION
For unary operators, this should support everything except `__real`, `__imag`, `__extension__` and `_co_await`.

For binary operators, this should support everything except pointer-to-member operators (`.*` and `->*`), the spaceship operator (`<=>`), and comma (`,`).

Tests for ternary operators and cast operations will be added in a future PR.