### PR TITLE
Adding some more improvements to the PInvokeGenerator

### DIFF
--- a/ClangSharp.PInvokeGenerator.Test/PInvokeGeneratorTest.cs
+++ b/ClangSharp.PInvokeGenerator.Test/PInvokeGeneratorTest.cs
@@ -37,7 +37,7 @@ namespace ClangSharp.Test
                 var unsavedInputFile = CXUnsavedFile.Create(DefaultInputFileName, inputContents);
                 var config = new PInvokeGeneratorConfiguration(DefaultLibraryPath, DefaultNamespaceName, Path.GetRandomFileName(), configOptions, excludedNames, methodClassName: null, methodPrefixToStrip: null, remappedNames);
 
-                using (var pinvokeGenerator = new PInvokeGenerator(config, ((path) => (outputStream, leaveOpen: true))))
+                using (var pinvokeGenerator = new PInvokeGenerator(config, (path) => outputStream))
                 using (var translationUnitHandle = CXTranslationUnit.Parse(pinvokeGenerator.IndexHandle, DefaultInputFileName, DefaultClangCommandLineArgs, new CXUnsavedFile[] { unsavedInputFile }, DefaultTranslationUnitFlags))
                 {
                     pinvokeGenerator.GenerateBindings(translationUnitHandle);

--- a/ClangSharp.PInvokeGenerator.Test/StructDeclarationTest.cs
+++ b/ClangSharp.PInvokeGenerator.Test/StructDeclarationTest.cs
@@ -62,6 +62,78 @@ namespace ClangSharp.Test
         [InlineData("unsigned short", "ushort")]
         [InlineData("unsigned int", "uint")]
         [InlineData("unsigned long long", "ulong")]
+        public async Task FixedSizedBufferNonPrimitiveTest(string nativeType, string expectedManagedType)
+        {
+            var inputContents = $@"struct MyStruct
+{{
+    {nativeType} value;
+}};
+
+struct MyOtherStruct
+{{
+    MyStruct c[3];
+}};
+";
+
+            var expectedOutputContents = $@"namespace ClangSharp.Test
+{{
+    public partial struct MyStruct
+    {{
+        public {expectedManagedType} value;
+    }}
+
+    public partial struct MyOtherStruct
+    {{
+        public MyStruct c0; public MyStruct c1; public MyStruct c2;
+    }}
+}}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Theory]
+        [InlineData("unsigned char", "byte")]
+        [InlineData("double", "double")]
+        [InlineData("short", "short")]
+        [InlineData("int", "int")]
+        [InlineData("long long", "long")]
+        [InlineData("char", "sbyte")]
+        [InlineData("float", "float")]
+        [InlineData("unsigned short", "ushort")]
+        [InlineData("unsigned int", "uint")]
+        [InlineData("unsigned long long", "ulong")]
+        public async Task FixedSizedBufferPrimitiveTest(string nativeType, string expectedManagedType)
+        {
+            var inputContents = $@"struct MyStruct
+{{
+    {nativeType} c[3];
+}};
+";
+
+            var expectedOutputContents = $@"namespace ClangSharp.Test
+{{
+    public partial struct MyStruct
+    {{
+        public {expectedManagedType} c0; public {expectedManagedType} c1; public {expectedManagedType} c2;
+    }}
+}}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Theory]
+        [InlineData("unsigned char", "byte")]
+        [InlineData("double", "double")]
+        [InlineData("short", "short")]
+        [InlineData("int", "int")]
+        [InlineData("long long", "long")]
+        [InlineData("char", "sbyte")]
+        [InlineData("float", "float")]
+        [InlineData("unsigned short", "ushort")]
+        [InlineData("unsigned int", "uint")]
+        [InlineData("unsigned long long", "ulong")]
         public async Task NestedTest(string nativeType, string expectedManagedType)
         {
             var inputContents = $@"struct MyStruct
@@ -216,6 +288,89 @@ struct MyStruct
 ";
 
             await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Theory]
+        [InlineData("unsigned char", "byte")]
+        [InlineData("double", "double")]
+        [InlineData("short", "short")]
+        [InlineData("int", "int")]
+        [InlineData("long long", "long")]
+        [InlineData("char", "sbyte")]
+        [InlineData("float", "float")]
+        [InlineData("unsigned short", "ushort")]
+        [InlineData("unsigned int", "uint")]
+        [InlineData("unsigned long long", "ulong")]
+        public async Task UnsafeFixedSizedBufferNonPrimitiveTest(string nativeType, string expectedManagedType)
+        {
+            var inputContents = $@"struct MyStruct
+{{
+    {nativeType} value;
+}};
+
+struct MyOtherStruct
+{{
+    MyStruct c[3];
+}};
+";
+
+            var expectedOutputContents = $@"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    public unsafe partial struct MyStruct
+    {{
+        public {expectedManagedType} value;
+    }}
+
+    public unsafe partial struct MyOtherStruct
+    {{
+        public _c_e__FixedBuffer c;
+
+        public partial struct _c_e__FixedBuffer
+        {{
+            private MyStruct e0;
+            private MyStruct e1;
+            private MyStruct e2;
+
+            public ref MyStruct this[int index] => ref MemoryMarshal.CreateSpan(ref e0, 3)[index];
+        }}
+    }}
+}}
+";
+
+            await ValidateUnsafeGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Theory]
+        [InlineData("unsigned char", "byte")]
+        [InlineData("double", "double")]
+        [InlineData("short", "short")]
+        [InlineData("int", "int")]
+        [InlineData("long long", "long")]
+        [InlineData("char", "sbyte")]
+        [InlineData("float", "float")]
+        [InlineData("unsigned short", "ushort")]
+        [InlineData("unsigned int", "uint")]
+        [InlineData("unsigned long long", "ulong")]
+        public async Task UnsafeFixedSizedBufferPrimitiveTest(string nativeType, string expectedManagedType)
+        {
+            var inputContents = $@"struct MyStruct
+{{
+    {nativeType} c[3];
+}};
+";
+
+            var expectedOutputContents = $@"namespace ClangSharp.Test
+{{
+    public unsafe partial struct MyStruct
+    {{
+        public fixed {expectedManagedType} c[3];
+    }}
+}}
+";
+
+            await ValidateUnsafeGeneratedBindings(inputContents, expectedOutputContents);
         }
 
         [Theory]

--- a/ClangSharp.PInvokeGenerator.Test/VarDeclarationTest.cs
+++ b/ClangSharp.PInvokeGenerator.Test/VarDeclarationTest.cs
@@ -1,0 +1,37 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace ClangSharp.Test
+{
+    public sealed class VarDeclarationTest : PInvokeGeneratorTest
+    {
+        [Theory]
+        [InlineData("unsigned char", "byte")]
+        [InlineData("double", "double")]
+        [InlineData("short", "short")]
+        [InlineData("int", "int")]
+        [InlineData("long long", "long")]
+        [InlineData("char", "sbyte")]
+        [InlineData("float", "float")]
+        [InlineData("unsigned short", "ushort")]
+        [InlineData("unsigned int", "uint")]
+        [InlineData("unsigned long long", "ulong")]
+        public async Task BasicTest(string nativeType, string expectedManagedType)
+        {
+            var inputContents = $@"{nativeType} MyVariable;";
+
+            var expectedOutputContents = $@"namespace ClangSharp.Test
+{{
+    public static partial class Methods
+    {{
+        private const string libraryPath = ""ClangSharpPInvokeGenerator"";
+
+        // public static extern {expectedManagedType} MyVariable;
+    }}
+}}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+    }
+}

--- a/ClangSharp.PInvokeGenerator/Cursors/Decls/RecordDecl.cs
+++ b/ClangSharp.PInvokeGenerator/Cursors/Decls/RecordDecl.cs
@@ -4,6 +4,7 @@ namespace ClangSharp
 {
     internal class RecordDecl : TagDecl
     {
+        private readonly List<FieldDecl> _constantArrays = new List<FieldDecl>();
         private readonly List<FieldDecl> _fields = new List<FieldDecl>();
 
         public RecordDecl(CXCursor handle, Cursor parent) : base(handle, parent)
@@ -16,6 +17,8 @@ namespace ClangSharp
 
         public bool IsUnion => Kind == CXCursorKind.CXCursor_UnionDecl;
 
+        public IReadOnlyList<FieldDecl> ConstantArrays => _constantArrays;
+
         public IReadOnlyList<FieldDecl> Fields => _fields;
 
         protected override Decl GetOrAddDecl(CXCursor childHandle)
@@ -24,6 +27,10 @@ namespace ClangSharp
 
             if (decl is FieldDecl fieldDecl)
             {
+                if (fieldDecl.Type.Kind == CXTypeKind.CXType_ConstantArray)
+                {
+                    _constantArrays.Add(fieldDecl);
+                }
                 _fields.Add(fieldDecl);
             }
 

--- a/ClangSharp.PInvokeGenerator/Extensions/IReadOnlyListExtensions.cs
+++ b/ClangSharp.PInvokeGenerator/Extensions/IReadOnlyListExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+namespace ClangSharp
+{
+    internal static class IReadOnlyListExtensions
+    {
+        public static int IndexOf<T>(this IReadOnlyList<T> self, T value)
+        {
+            var comparer = EqualityComparer<T>.Default;
+
+            for (int i = 0; i < self.Count; i++)
+            {
+                if (comparer.Equals(self[i], value))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+    }
+}

--- a/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -1250,7 +1250,12 @@ namespace ClangSharp
 
         private void VisitDecl(Decl decl, Cursor parent)
         {
-            if (decl is NamedDecl namedDecl)
+            if (decl is AccessSpecDecl accessSpecDecl)
+            {
+                // Access specifications are also exposed as a queryable property
+                // on the declarations they impact, so we don't need to do anything
+            }
+            else if (decl is NamedDecl namedDecl)
             {
                 VisitNamedDecl(namedDecl, parent);
             }

--- a/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -1766,7 +1766,7 @@ namespace ClangSharp
 
                         for (int i = 0; i < type.NumElements; i++)
                         {
-                            _outputBuilder.WriteIndented("public");
+                            _outputBuilder.WriteIndented("private");
                             _outputBuilder.Write(' ');
                             _outputBuilder.Write(typeName);
                             _outputBuilder.Write(' ');

--- a/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -2007,7 +2007,18 @@ namespace ClangSharp
             }
             else
             {
-                AddDiagnostic(DiagnosticLevel.Error, $"Unsupported variable declaration: '{varDecl.KindSpelling}'. Generated bindings may be incomplete.", varDecl);
+                var name = GetRemappedCursorName(varDecl);
+
+                StartUsingOutputBuilder(_config.MethodClassName);
+                {
+                    _outputBuilder.WriteIndented("// public static extern");
+                    _outputBuilder.Write(' ');
+                    _outputBuilder.Write(GetRemappedTypeName(varDecl, varDecl.Type));
+                    _outputBuilder.Write(' ');
+                    _outputBuilder.Write(EscapeName(name));
+                    _outputBuilder.WriteLine(';');
+                }
+                StopUsingOutputBuilder();
             }
         }
 


### PR DESCRIPTION
This fixes the PInvokeGeneartor to handle single-file generation properly (namely, it was emitting using directives in the wrong place and overwriting the stream for each processed output builder).

This updates the PInvokeGenerator to emit a comment for variable declarations. Ideally this would be hooked up to the NativeLibraryLoader APIs, but that involves unsafe code and might need to be opt-in.

This also adds some tests for the fixed-sized buffer support and improves the codegen when the user has opted into unsafe code.