### PR TITLE
Cleanup how the PInvokeGenerator handles CXType and resolves names

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/Cursors/Decls/EnumDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Cursors/Decls/EnumDecl.cs
@@ -1,4 +1,3 @@
-﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -7,17 +6,16 @@ namespace ClangSharp
     internal sealed class EnumDecl : TagDecl
     {
         private readonly List<EnumConstantDecl> _enumerators = new List<EnumConstantDecl>();
-        private readonly Lazy<Type> _integerType;
 
         public EnumDecl(CXCursor handle, Cursor parent) : base(handle, parent)
         {
             Debug.Assert(handle.Kind == CXCursorKind.CXCursor_EnumDecl);
-            _integerType = new Lazy<Type>(() => TranslationUnit.GetOrCreateType(Handle.EnumDecl_IntegerType, () => Type.Create(Handle.EnumDecl_IntegerType, TranslationUnit)));
+            IntegerType = TranslationUnit.GetOrCreateType(Handle.EnumDecl_IntegerType, () => Type.Create(Handle.EnumDecl_IntegerType, TranslationUnit));
         }
 
         public IReadOnlyList<EnumConstantDecl> Enumerators => _enumerators;
 
-        public Type IntegerType => _integerType.Value;
+        public Type IntegerType { get; }
 
         public bool IsScoped => Handle.EnumDecl_IsScoped;
 

--- a/sources/ClangSharp.PInvokeGenerator/Cursors/Decls/FunctionDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Cursors/Decls/FunctionDecl.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -9,7 +9,6 @@ namespace ClangSharp
     {
         private readonly List<Decl> _declarations = new List<Decl>();
         private readonly ParmVarDecl[] _parameters;
-        private readonly Lazy<Type> _returnType;
         private readonly Lazy<Cursor> _specializedTemplate;
 
         private Stmt _body;
@@ -27,7 +26,7 @@ namespace ClangSharp
                 parmVarDecl.Visit(clientData: default);
             }
 
-            _returnType = new Lazy<Type>(() => TranslationUnit.GetOrCreateType(Handle.ResultType, () => Type.Create(Handle.ResultType, TranslationUnit)));
+            ReturnType = TranslationUnit.GetOrCreateType(Handle.ResultType, () => Type.Create(Handle.ResultType, TranslationUnit));
 
             _specializedTemplate = new Lazy<Cursor>(() => {
                 var cursor = TranslationUnit.GetOrCreateCursor(Handle.SpecializedCursorTemplate, () => Create(Handle.SpecializedCursorTemplate, this));
@@ -41,6 +40,8 @@ namespace ClangSharp
         public IReadOnlyList<Decl> Declarations => _declarations;
 
         public string DisplayName => Handle.DisplayName.ToString();
+
+        public FunctionType FunctionType => (FunctionType)Type;
 
         public bool HasDllExport => HasAttrs && Attributes.Any((attr) => attr is DLLExport);
 
@@ -56,7 +57,7 @@ namespace ClangSharp
 
         public IReadOnlyList<ParmVarDecl> Parameters => _parameters;
 
-        public Type ReturnType => _returnType.Value;
+        public Type ReturnType { get; }
 
         public Cursor SpecializedTemplate => _specializedTemplate.Value;
 

--- a/sources/ClangSharp.PInvokeGenerator/Cursors/Decls/FunctionTemplateDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Cursors/Decls/FunctionTemplateDecl.cs
@@ -1,18 +1,15 @@
-﻿using System;
 using System.Diagnostics;
 
 namespace ClangSharp
 {
     internal sealed class FunctionTemplateDecl : RedeclarableTemplateDecl
     {
-        private readonly Lazy<Type> _type;
-
         public FunctionTemplateDecl(CXCursor handle, Cursor parent) : base(handle, parent)
         {
             Debug.Assert(handle.Kind == CXCursorKind.CXCursor_FunctionTemplate);
-            _type = new Lazy<Type>(() => TranslationUnit.GetOrCreateType(Handle.Type, () => Type.Create(Handle.Type, TranslationUnit)));
+            Type = TranslationUnit.GetOrCreateType(Handle.Type, () => Type.Create(Handle.Type, TranslationUnit));
         }
 
-        public Type Type => _type.Value;
+        public Type Type { get; }
     }
 }

--- a/sources/ClangSharp.PInvokeGenerator/Cursors/Decls/TypeDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Cursors/Decls/TypeDecl.cs
@@ -1,16 +1,12 @@
-﻿using System;
-
 namespace ClangSharp
 {
     internal class TypeDecl : NamedDecl
     {
-        private readonly Lazy<Type> _type;
-
         protected TypeDecl(CXCursor handle, Cursor parent) : base(handle, parent)
         {
-            _type = new Lazy<Type>(() => TranslationUnit.GetOrCreateType(Handle.Type, () => Type.Create(Handle.Type, TranslationUnit)));
+            Type = TranslationUnit.GetOrCreateType(Handle.Type, () => Type.Create(Handle.Type, TranslationUnit));
         }
 
-        public Type Type => _type.Value;
+        public Type Type { get; }
     }
 }

--- a/sources/ClangSharp.PInvokeGenerator/Cursors/Decls/TypedefNameDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Cursors/Decls/TypedefNameDecl.cs
@@ -1,16 +1,12 @@
-﻿using System;
-
 namespace ClangSharp
 {
     internal class TypedefNameDecl : TypeDecl
     {
-        private readonly Lazy<Type> _underlyingType;
-
         protected TypedefNameDecl(CXCursor handle, Cursor parent) : base(handle, parent)
         {
-            _underlyingType = new Lazy<Type>(() => TranslationUnit.GetOrCreateType(Handle.TypedefDeclUnderlyingType, () => Type.Create(Handle.TypedefDeclUnderlyingType, TranslationUnit)));
+            UnderlyingType = TranslationUnit.GetOrCreateType(Handle.TypedefDeclUnderlyingType, () => Type.Create(Handle.TypedefDeclUnderlyingType, TranslationUnit));
         }
 
-        public Type UnderlyingType => _underlyingType.Value;
+        public Type UnderlyingType { get; }
     }
 }

--- a/sources/ClangSharp.PInvokeGenerator/Cursors/Decls/ValueDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Cursors/Decls/ValueDecl.cs
@@ -1,16 +1,12 @@
-﻿using System;
-
 namespace ClangSharp
 {
     internal class ValueDecl : NamedDecl
     {
-        private readonly Lazy<Type> _type;
-
         protected ValueDecl(CXCursor handle, Cursor parent) : base(handle, parent)
         {
-            _type = new Lazy<Type>(() => TranslationUnit.GetOrCreateType(Handle.Type, () => Type.Create(Handle.Type, TranslationUnit)));
+            Type = TranslationUnit.GetOrCreateType(Handle.Type, () => Type.Create(Handle.Type, TranslationUnit));
         }
 
-        public Type Type => _type.Value;
+        public Type Type { get; }
     }
 }

--- a/sources/ClangSharp.PInvokeGenerator/Cursors/Exprs/Expr.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Cursors/Exprs/Expr.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 
 namespace ClangSharp
@@ -144,7 +144,6 @@ namespace ClangSharp
         }
 
         private readonly Lazy<Cursor> _definition;
-        private readonly Lazy<Type> _type;
 
         protected Expr(CXCursor handle, Cursor parent) : base(handle, parent)
         {
@@ -155,14 +154,15 @@ namespace ClangSharp
                 cursor?.Visit(clientData: default);
                 return cursor;
             });
-            _type = new Lazy<Type>(() => TranslationUnit.GetOrCreateType(Handle.Type, () => Type.Create(Handle.Type, TranslationUnit)));
+
+            Type = TranslationUnit.GetOrCreateType(Handle.Type, () => Type.Create(Handle.Type, TranslationUnit));
         }
 
         public Cursor Definition => _definition.Value;
 
         public bool IsDynamicCall => Handle.IsDynamicCall;
 
-        public Type Type => _type.Value;
+        public Type Type { get; }
 
         protected override void ValidateVisit(ref CXCursor handle)
         {

--- a/sources/ClangSharp.PInvokeGenerator/Cursors/Refs/Ref.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Cursors/Refs/Ref.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 
 namespace ClangSharp
@@ -50,7 +50,6 @@ namespace ClangSharp
 
         private readonly Lazy<Cursor> _definition;
         private readonly Lazy<Cursor> _referenced;
-        private readonly Lazy<Type> _type;
 
         protected Ref(CXCursor handle, Cursor parent) : base(handle, parent)
         {
@@ -66,13 +65,14 @@ namespace ClangSharp
                 cursor?.Visit(clientData: default);
                 return cursor;
             });
-            _type = new Lazy<Type>(() => TranslationUnit.GetOrCreateType(Handle.Type, () => Type.Create(Handle.Type, TranslationUnit)));
+
+            Type = TranslationUnit.GetOrCreateType(Handle.Type, () => Type.Create(Handle.Type, TranslationUnit));
         }
 
         public Cursor Definition => _definition.Value;
 
         public Cursor Referenced => _referenced.Value;
 
-        public Type Type => _type.Value;
+        public Type Type { get; }
     }
 }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -80,6 +80,8 @@ namespace ClangSharp
                 {
                     using (var sw = new StreamWriter(stream, DefaultStreamWriterEncoding, DefaultStreamWriterBufferSize, leaveStreamOpen))
                     {
+                        sw.NewLine = "\n";
+
                         foreach (var usingDirective in usingDirectives)
                         {
                             sw.Write("using");
@@ -123,6 +125,7 @@ namespace ClangSharp
 
                 using (var sw = new StreamWriter(stream, DefaultStreamWriterEncoding, DefaultStreamWriterBufferSize, leaveStreamOpen))
                 {
+                    sw.NewLine = "\n";
                     sw.WriteLine('}');
                 }
             }
@@ -214,6 +217,8 @@ namespace ClangSharp
 
             using (var sw = new StreamWriter(stream, DefaultStreamWriterEncoding, DefaultStreamWriterBufferSize, leaveStreamOpen))
             {
+                sw.NewLine = "\n";
+
                 if (outputBuilder.UsingDirectives.Any() && _config.GenerateMultipleFiles)
                 {
                     foreach (var usingDirective in outputBuilder.UsingDirectives)

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -468,105 +468,31 @@ namespace ClangSharp
 
         private string GetCursorName(NamedDecl namedDecl)
         {
-            var name = string.Empty;
+            var name = namedDecl.Name;
 
-            if (namedDecl is TagDecl tagDecl)
+            if (string.IsNullOrWhiteSpace(name))
             {
-                name = namedDecl.Spelling;
-
-                if (tagDecl.IsAnonymous)
+                if (namedDecl is TypeDecl typeDecl)
                 {
-                    namedDecl.Location.GetFileLocation(out var file, out var _, out var _, out var offset);
-                    var fileName = Path.GetFileNameWithoutExtension(file.Name.ToString());
-                    name = $"__Anonymous{tagDecl.Type.KindSpelling}_{fileName}_{offset}";
-                    AddDiagnostic(DiagnosticLevel.Info, $"Anonymous declaration found in '{nameof(GetCursorName)}'. Falling back to '{name}'.'", namedDecl);
+                    if ((typeDecl is TagDecl tagDecl) && tagDecl.IsAnonymous)
+                    {
+                        namedDecl.Location.GetFileLocation(out var file, out var _, out var _, out var offset);
+                        var fileName = Path.GetFileNameWithoutExtension(file.Name.ToString());
+                        name = $"__Anonymous{tagDecl.Type.KindSpelling}_{fileName}_{offset}";
+                        AddDiagnostic(DiagnosticLevel.Info, $"Anonymous declaration found in '{nameof(GetCursorName)}'. Falling back to '{name}'.'", namedDecl);
+                    }
+                    else
+                    {
+                        name = GetTypeName(namedDecl, typeDecl.Type);
+                    }
                 }
-                else if (string.IsNullOrWhiteSpace(name))
-                {
-                    name = GetTypeName(namedDecl, tagDecl.Type);
-                }
-            }
-            else
-            {
-                name = namedDecl.Spelling;
-
-                if ((namedDecl is ParmVarDecl parmVarDecl) && string.IsNullOrWhiteSpace(name))
+                else if (namedDecl is ParmVarDecl)
                 {
                     name = "param";
                 }
-                else if (namedDecl is TypedefDecl typedefDecl)
+                else
                 {
-                    switch (name)
-                    {
-                        case "int8_t":
-                        {
-                            return "sbyte";
-                        }
-
-                        case "int16_t":
-                        {
-                            return "short";
-                        }
-
-                        case "int32_t":
-                        {
-                            return "int";
-                        }
-
-                        case "int64_t":
-                        {
-                            return "long";
-                        }
-
-                        case "intptr_t":
-                        {
-                            _outputBuilder.AddUsingDirective("System");
-                            return "IntPtr";
-                        }
-
-                        case "size_t":
-                        case "SIZE_T":
-                        {
-                            _outputBuilder.AddUsingDirective("System");
-                            return "IntPtr";
-                        }
-
-                        case "time_t":
-                        {
-                            return "long";
-                        }
-
-                        case "uint8_t":
-                        {
-                            return "byte";
-                        }
-
-                        case "uint16_t":
-                        {
-                            return "ushort";
-                        }
-
-                        case "uint32_t":
-                        {
-                            return "uint";
-                        }
-
-                        case "uint64_t":
-                        {
-                            return "ulong";
-                        }
-
-                        case "uintptr_t":
-                        {
-                            _outputBuilder.AddUsingDirective("System");
-                            return "UIntPtr";
-                        }
-
-                        default:
-                        {
-                            return GetCursorName(typedefDecl, typedefDecl.UnderlyingType);
-                        }
-                    }
+                    AddDiagnostic(DiagnosticLevel.Error, $"Unsupported anonymous named declaration: '{namedDecl.KindSpelling}'.", namedDecl);
                 }
             }
 
@@ -574,63 +500,7 @@ namespace ClangSharp
             return name;
         }
 
-        private string GetCursorName(TypedefDecl typedefDecl, Type underlyingType)
-        {
-            switch (underlyingType.Kind)
-            {
-                case CXTypeKind.CXType_Bool:
-                case CXTypeKind.CXType_Char_U:
-                case CXTypeKind.CXType_UChar:
-                case CXTypeKind.CXType_UShort:
-                case CXTypeKind.CXType_UInt:
-                case CXTypeKind.CXType_ULong:
-                case CXTypeKind.CXType_ULongLong:
-                case CXTypeKind.CXType_Char_S:
-                case CXTypeKind.CXType_SChar:
-                case CXTypeKind.CXType_WChar:
-                case CXTypeKind.CXType_Short:
-                case CXTypeKind.CXType_Int:
-                case CXTypeKind.CXType_Long:
-                case CXTypeKind.CXType_LongLong:
-                case CXTypeKind.CXType_Float:
-                case CXTypeKind.CXType_Double:
-                case CXTypeKind.CXType_Pointer:
-                {
-                    var name = typedefDecl.Spelling;
-
-                    if (_config.GenerateUnsafeCode || string.IsNullOrWhiteSpace(name))
-                    {
-                        name = GetTypeName(typedefDecl, underlyingType);
-                    }
-
-                    Debug.Assert(!string.IsNullOrWhiteSpace(name));
-                    return name;
-                }
-
-                case CXTypeKind.CXType_Record:
-                case CXTypeKind.CXType_Enum:
-                {
-                    var name = GetTypeName(typedefDecl, underlyingType);
-                    Debug.Assert(!string.IsNullOrWhiteSpace(name));
-                    return name;
-                }
-
-                case CXTypeKind.CXType_Typedef:
-                case CXTypeKind.CXType_Elaborated:
-                {
-                    return GetCursorName(typedefDecl, underlyingType.CanonicalType);
-                }
-
-                default:
-                {
-                    var name = typedefDecl.Spelling;
-                    AddDiagnostic(DiagnosticLevel.Warning, $"Unsupported underlying type: '{underlyingType.KindSpelling}'. Falling back to '{name}'.", typedefDecl);
-                    return name;
-                }
-            }
-        }
-
-        private string GetMarshalAttribute(Decl decl, Type type)
+        private string GetMarshalAttribute(NamedDecl namedDecl, Type type)
         {
             if (_config.GenerateUnsafeCode)
             {
@@ -671,23 +541,24 @@ namespace ClangSharp
                 case CXTypeKind.CXType_Pointer:
                 {
                     var pointerType = (PointerType)type;
-                    return GetMarshalAttributeForPointeeType(decl, pointerType.PointeeType);
+                    return GetMarshalAttributeForPointeeType(namedDecl, pointerType.PointeeType);
                 }
 
                 case CXTypeKind.CXType_Elaborated:
                 {
-                    return GetMarshalAttribute(decl, type.CanonicalType);
+                    var elaboratedType = (ElaboratedType)type;
+                    return GetMarshalAttribute(namedDecl, elaboratedType.NamedType);
                 }
 
                 default:
                 {
-                    AddDiagnostic(DiagnosticLevel.Warning, $"Unsupported type: '{type.KindSpelling}'. Falling back to no marshalling.", decl);
+                    AddDiagnostic(DiagnosticLevel.Warning, $"Unsupported type: '{type.KindSpelling}'. Falling back to no marshalling.", namedDecl);
                     return string.Empty;
                 }
             }
         }
 
-        private string GetMarshalAttributeForPointeeType(Decl decl, Type pointeeType)
+        private string GetMarshalAttributeForPointeeType(NamedDecl namedDecl, Type pointeeType)
         {
             Debug.Assert(!_config.GenerateUnsafeCode);
 
@@ -729,18 +600,19 @@ namespace ClangSharp
 
                 case CXTypeKind.CXType_Elaborated:
                 {
-                    return GetMarshalAttributeForPointeeType(decl, pointeeType.CanonicalType);
+                    var elaboratedType = (ElaboratedType)pointeeType;
+                    return GetMarshalAttributeForPointeeType(namedDecl, elaboratedType.NamedType);
                 }
 
                 default:
                 {
-                    AddDiagnostic(DiagnosticLevel.Warning, $"Unsupported pointee type: '{pointeeType.KindSpelling}'. Falling back to no marshalling.", decl);
+                    AddDiagnostic(DiagnosticLevel.Warning, $"Unsupported pointee type: '{pointeeType.KindSpelling}'. Falling back to no marshalling.", namedDecl);
                     return string.Empty;
                 }
             }
         }
 
-        private string GetParmModifier(Decl decl, Type type)
+        private string GetParmModifier(NamedDecl namedDecl, Type type)
         {
             if (_config.GenerateUnsafeCode)
             {
@@ -776,7 +648,7 @@ namespace ClangSharp
                 case CXTypeKind.CXType_Pointer:
                 {
                     var pointerType = (PointerType)type;
-                    return GetParmModifierForPointeeType(decl, pointerType.PointeeType);
+                    return GetParmModifierForPointeeType(namedDecl, pointerType.PointeeType);
                 }
 
                 case CXTypeKind.CXType_ConstantArray:
@@ -787,18 +659,19 @@ namespace ClangSharp
 
                 case CXTypeKind.CXType_Elaborated:
                 {
-                    return GetParmModifier(decl, type.CanonicalType);
+                    var elaboratedType = (ElaboratedType)type;
+                    return GetParmModifier(namedDecl, elaboratedType.NamedType);
                 }
 
                 default:
                 {
-                    AddDiagnostic(DiagnosticLevel.Warning, $"Unsupported type: '{type.KindSpelling}'. Falling back to no parameter modifier.", decl);
+                    AddDiagnostic(DiagnosticLevel.Warning, $"Unsupported type: '{type.KindSpelling}'. Falling back to no parameter modifier.", namedDecl);
                     return string.Empty;
                 }
             }
         }
 
-        private string GetParmModifierForPointeeType(Decl decl, Type pointeeType)
+        private string GetParmModifierForPointeeType(NamedDecl namedDecl, Type pointeeType)
         {
             Debug.Assert(!_config.GenerateUnsafeCode);
 
@@ -834,14 +707,20 @@ namespace ClangSharp
                 }
 
                 case CXTypeKind.CXType_Typedef:
+                {
+                    var typedefType = (TypedefType)pointeeType;
+                    return GetParmModifierForPointeeType(namedDecl, typedefType.UnderlyingType);
+                }
+
                 case CXTypeKind.CXType_Elaborated:
                 {
-                    return GetParmModifierForPointeeType(decl, pointeeType.CanonicalType);
+                    var elaboratedType = (ElaboratedType)pointeeType;
+                    return GetParmModifierForPointeeType(namedDecl, elaboratedType.NamedType);
                 }
 
                 default:
                 {
-                    AddDiagnostic(DiagnosticLevel.Warning, $"Unsupported pointee type: '{pointeeType.KindSpelling}'. Falling back to no parameter modifier.", decl);
+                    AddDiagnostic(DiagnosticLevel.Warning, $"Unsupported pointee type: '{pointeeType.KindSpelling}'. Falling back to no parameter modifier.", namedDecl);
                     return string.Empty;
                 }
             }
@@ -850,309 +729,336 @@ namespace ClangSharp
         private string GetRemappedCursorName(NamedDecl namedDecl)
         {
             var name = GetCursorName(namedDecl);
+            return GetRemappedName(name);
+        }
 
+        private string GetRemappedName(string name)
+        {
             if (!_config.RemappedNames.TryGetValue(name, out string remappedName))
             {
                 remappedName = name;
             }
 
-            return remappedName;
-        }
-
-        private string GetRemappedTypeName(Decl decl, Type type)
-        {
-            var name = GetTypeName(decl, type);
-
-            if (!_config.RemappedNames.TryGetValue(name, out string remappedName))
+            if (remappedName.Equals("IntPtr") || remappedName.Equals("UIntPtr"))
             {
-                remappedName = name;
+                _outputBuilder.AddUsingDirective("System");
             }
 
             return remappedName;
         }
 
-        private string GetTypeName(Decl decl, Type type)
+        private string GetRemappedTypeName(NamedDecl namedDecl, Type type)
         {
-            switch (type.Kind)
-            {
-                case CXTypeKind.CXType_Void:
-                {
-                    return "void";
-                }
-
-                case CXTypeKind.CXType_Bool:
-                {
-                    return "bool";
-                }
-
-                case CXTypeKind.CXType_Char_U:
-                case CXTypeKind.CXType_UChar:
-                {
-                    return "byte";
-                }
-
-                case CXTypeKind.CXType_UShort:
-                {
-                    return "ushort";
-                }
-
-                case CXTypeKind.CXType_UInt:
-                {
-                    return "uint";
-                }
-
-                case CXTypeKind.CXType_ULong:
-                {
-                    return "uint";
-                }
-
-                case CXTypeKind.CXType_ULongLong:
-                {
-                    return "ulong";
-                }
-
-                case CXTypeKind.CXType_Char_S:
-                case CXTypeKind.CXType_SChar:
-                {
-                    return "sbyte";
-                }
-
-                case CXTypeKind.CXType_WChar:
-                {
-                    return "char";
-                }
-
-                case CXTypeKind.CXType_Short:
-                {
-                    return "short";
-                }
-
-                case CXTypeKind.CXType_Int:
-                {
-                    return "int";
-                }
-
-                case CXTypeKind.CXType_Long:
-                {
-                    return "int";
-                }
-
-                case CXTypeKind.CXType_LongLong:
-                {
-                    return "long";
-                }
-
-                case CXTypeKind.CXType_Float:
-                {
-                    return "float";
-                }
-
-                case CXTypeKind.CXType_Double:
-                {
-                    return "double";
-                }
-
-                case CXTypeKind.CXType_Pointer:
-                {
-                    var pointerType = (PointerType)type;
-                    return GetTypeNameForPointeeType(decl, pointerType.PointeeType);
-                }
-
-                case CXTypeKind.CXType_LValueReference:
-                {
-                    var referenceType = (ReferenceType)type;
-                    return GetTypeNameForPointeeType(decl, referenceType.PointeeType);
-                }
-
-                case CXTypeKind.CXType_Record:
-                case CXTypeKind.CXType_Enum:
-                case CXTypeKind.CXType_FunctionProto:
-                {
-                    var name = type.Spelling;
-                    Debug.Assert(!string.IsNullOrWhiteSpace(name));
-                    return name;
-                }
-
-                case CXTypeKind.CXType_Typedef:
-                {
-                    var typedefType = (TypedefType)type;
-                    return GetCursorName(typedefType.Decl);
-                }
-
-                case CXTypeKind.CXType_Elaborated:
-                {
-                    return GetTypeName(decl, type.CanonicalType);
-                }
-
-                case CXTypeKind.CXType_ConstantArray:
-                case CXTypeKind.CXType_IncompleteArray:
-                {
-                    var arrayType = (ArrayType)type;
-                    return GetTypeName(decl, arrayType.ElementType);
-                }
-
-                default:
-                {
-                    var name = type.Spelling;
-                    AddDiagnostic(DiagnosticLevel.Warning, $"Unsupported type: '{type.KindSpelling}'. Falling back '{name}'.", decl);
-                    return name;
-                }
-            }
+            var name = GetTypeName(namedDecl, type);
+            return GetRemappedName(name);
         }
 
-        private string GetTypeNameForPointeeType(Decl decl, Type pointeeType)
+        private string GetTypeName(NamedDecl namedDecl, Type type)
         {
-            switch (pointeeType.Kind)
+            var name = type.Spelling;
+
+            if (type is ArrayType arrayType)
             {
-                case CXTypeKind.CXType_Void:
+                name = GetTypeName(namedDecl, arrayType.ElementType);
+            }
+            else if (type is BuiltinType)
+            {
+                switch (type.Kind)
                 {
-                    if (_config.GenerateUnsafeCode)
+                    case CXTypeKind.CXType_Void:
                     {
-                        return "void*";
+                        name = "void";
+                        break;
                     }
 
-                    _outputBuilder.AddUsingDirective("System");
-                    return "IntPtr";
-                }
-
-                case CXTypeKind.CXType_UChar:
-                case CXTypeKind.CXType_UShort:
-                case CXTypeKind.CXType_UInt:
-                case CXTypeKind.CXType_ULong:
-                case CXTypeKind.CXType_ULongLong:
-                case CXTypeKind.CXType_SChar:
-                case CXTypeKind.CXType_Short:
-                case CXTypeKind.CXType_Int:
-                case CXTypeKind.CXType_Long:
-                case CXTypeKind.CXType_LongLong:
-                case CXTypeKind.CXType_Float:
-                case CXTypeKind.CXType_Double:
-                case CXTypeKind.CXType_Pointer:
-                case CXTypeKind.CXType_Record:
-                case CXTypeKind.CXType_Enum:
-                case CXTypeKind.CXType_Typedef:
-                {
-                    switch (decl.Kind)
+                    case CXTypeKind.CXType_Bool:
                     {
-                        case CXCursorKind.CXCursor_FieldDecl:
-                        case CXCursorKind.CXCursor_FunctionDecl:
-                        {
-                            var name = "IntPtr";
-
-                            if (_config.GenerateUnsafeCode)
-                            {
-                                name = GetTypeName(decl, pointeeType);
-                                name += '*';
-                            }
-                            else
-                            {
-                                _outputBuilder.AddUsingDirective("System");
-                            }
-
-                            return name;
-                        }
-
-                        case CXCursorKind.CXCursor_ParmDecl:
-                        {
-                            var name = GetTypeName(decl, pointeeType);
-
-                            if (_config.GenerateUnsafeCode)
-                            {
-                                name += '*';
-                            }
-                            return name;
-                        }
-
-                        case CXCursorKind.CXCursor_TypedefDecl:
-                        {
-                            var typedefDecl = (TypedefDecl)decl;
-                            var underlyingType = typedefDecl.UnderlyingType;
-
-                            if ((underlyingType is PointerType pointerType) && (pointerType.PointeeType is FunctionProtoType))
-                            {
-                                goto case CXCursorKind.CXCursor_FunctionDecl;
-                            }
-
-                            var tagType = (TagType)pointeeType;
-                            var name = GetRemappedCursorName(tagType.Decl); ;
-
-                            if (_config.GenerateUnsafeCode)
-                            {
-                                name += '*';
-                            }
-                            return name;
-                        }
-
-                        default:
-                        {
-                            var name = "IntPtr";
-                            AddDiagnostic(DiagnosticLevel.Warning, $"Unsupported declaration: '{decl.KindSpelling}'. Falling back '{name}'.", decl);
-                            return string.Empty;
-                        }
+                        name = "bool";
+                        break;
                     }
-                }
 
-                case CXTypeKind.CXType_Char_U:
-                case CXTypeKind.CXType_Char_S:
-                {
-                    switch (decl.Kind)
+                    case CXTypeKind.CXType_Char_U:
+                    case CXTypeKind.CXType_UChar:
                     {
-                        case CXCursorKind.CXCursor_FieldDecl:
-                        case CXCursorKind.CXCursor_FunctionDecl:
-                        {
-                            return _config.GenerateUnsafeCode ? "byte*" : "string";
-                        }
-
-                        case CXCursorKind.CXCursor_ParmDecl:
-                        {
-                            if (GetParmModifier(decl, ((ParmVarDecl)decl).Type).Equals("out"))
-                            {
-                                Debug.Assert(!_config.GenerateUnsafeCode);
-                                _outputBuilder.AddUsingDirective("System");
-                                return "IntPtr";
-                            }
-
-                            return _config.GenerateUnsafeCode ? "byte*" : "string";
-                        }
-
-                        case CXCursorKind.CXCursor_TypedefDecl:
-                        {
-                            return _config.GenerateUnsafeCode ? "byte*" : "string";
-                        }
-
-                        default:
-                        {
-                            var name = "IntPtr";
-                            AddDiagnostic(DiagnosticLevel.Warning, $"Unsupported declaration: '{decl.KindSpelling}'. Falling back '{name}'.", decl);
-                            return string.Empty;
-                        }
+                        name = "byte";
+                        break;
                     }
-                }
 
-                case CXTypeKind.CXType_FunctionProto:
-                {
-                    _outputBuilder.AddUsingDirective("System");
-                    return "IntPtr";
-                }
+                    case CXTypeKind.CXType_UShort:
+                    {
+                        name = "ushort";
+                        break;
+                    }
 
-                case CXTypeKind.CXType_Elaborated:
-                {
-                    return GetTypeNameForPointeeType(decl, pointeeType.CanonicalType);
-                }
+                    case CXTypeKind.CXType_UInt:
+                    {
+                        name = "uint";
+                        break;
+                    }
 
-                case CXTypeKind.CXType_Attributed:
-                {
-                    var attributedType = (AttributedType)pointeeType;
-                    return GetTypeNameForPointeeType(decl, attributedType.ModifiedType);
-                }
+                    case CXTypeKind.CXType_ULong:
+                    {
+                        name = "uint";
+                        break;
+                    }
 
-                default:
-                {
-                    var name = "IntPtr";
-                    AddDiagnostic(DiagnosticLevel.Warning, $"Unsupported pointee type: '{pointeeType.KindSpelling}'. Falling back '{name}'.", decl);
-                    return string.Empty;
+                    case CXTypeKind.CXType_ULongLong:
+                    {
+                        name = "ulong";
+                        break;
+                    }
+
+                    case CXTypeKind.CXType_Char_S:
+                    case CXTypeKind.CXType_SChar:
+                    {
+                        name = "sbyte";
+                        break;
+                    }
+
+                    case CXTypeKind.CXType_WChar:
+                    {
+                        name = "char";
+                        break;
+                    }
+
+                    case CXTypeKind.CXType_Short:
+                    {
+                        name = "short";
+                        break;
+                    }
+
+                    case CXTypeKind.CXType_Int:
+                    {
+                        name = "int";
+                        break;
+                    }
+
+                    case CXTypeKind.CXType_Long:
+                    {
+                        name = "int";
+                        break;
+                    }
+
+                    case CXTypeKind.CXType_LongLong:
+                    {
+                        name = "long";
+                        break;
+                    }
+
+                    case CXTypeKind.CXType_Float:
+                    {
+                        name = "float";
+                        break;
+                    }
+
+                    case CXTypeKind.CXType_Double:
+                    {
+                        name = "double";
+                        break;
+                    }
+
+                    default:
+                    {
+                        AddDiagnostic(DiagnosticLevel.Warning, $"Unsupported builtin type: '{type.KindSpelling}'. Falling back '{name}'.", namedDecl);
+                        break;
+                    }
                 }
             }
+            else if (type is ElaboratedType elaboratedType)
+            {
+                name = GetTypeName(namedDecl, elaboratedType.NamedType);
+            }
+            else if (type is PointerType pointerType)
+            {
+                name = GetTypeNameForPointeeType(namedDecl, pointerType.PointeeType);
+            }
+            else if (type is ReferenceType referenceType)
+            {
+                name = GetTypeNameForPointeeType(namedDecl, referenceType.PointeeType);
+            }
+            else if (type is TypedefType typedefType)
+            {
+                if (!_config.GenerateUnsafeCode)
+                {
+                    name = GetTypeNameForUnderlyingType(namedDecl, typedefType.UnderlyingType);
+
+                    if (string.IsNullOrWhiteSpace(name))
+                    {
+                        name = GetRemappedCursorName(typedefType.Decl);
+                    }
+                }
+
+                switch (name)
+                {
+                    case "int8_t":
+                    {
+                        name = "sbyte";
+                        break;
+                    }
+
+                    case "int16_t":
+                    {
+                        name = "short";
+                        break;
+                    }
+
+                    case "int32_t":
+                    {
+                        name = "int";
+                        break;
+                    }
+
+                    case "int64_t":
+                    case "time_t":
+                    {
+                        name = "long";
+                        break;
+                    }
+
+                    case "intptr_t":
+                    case "ptrdiff_t":
+                    {
+                        name = "IntPtr";
+                        break;
+                    }
+
+                    case "size_t":
+                    case "uintptr_t":
+                    {
+                        name = "UIntPtr";
+                        break;
+                    }
+
+                    case "uint8_t":
+                    {
+                        name = "byte";
+                        break;
+                    }
+
+                    case "uint16_t":
+                    {
+                        name = "ushort";
+                        break;
+                    }
+
+                    case "uint32_t":
+                    {
+                        name = "uint";
+                        break;
+                    }
+
+                    case "uint64_t":
+                    {
+                        name = "ulong";
+                        break;
+                    }
+
+                    default:
+                    {
+                        if (_config.GenerateUnsafeCode)
+                        {
+                            name = GetTypeName(namedDecl, typedefType.UnderlyingType);
+                        }
+                        break;
+                    }
+                }
+            }
+            else if (!(type is FunctionType) && !(type is TagType))
+            {
+                AddDiagnostic(DiagnosticLevel.Warning, $"Unsupported type: '{type.KindSpelling}'. Falling back '{name}'.", namedDecl);
+            }
+
+            Debug.Assert(!string.IsNullOrWhiteSpace(name));
+            return name;
+        }
+
+        private string GetTypeNameForPointeeType(NamedDecl namedDecl, Type pointeeType)
+        {
+            string name;
+
+            if (pointeeType is FunctionType)
+            {
+                name = "IntPtr";
+            }
+            else if (_config.GenerateUnsafeCode)
+            {
+                name = GetTypeName(namedDecl, pointeeType);
+                name += '*';
+            }
+            else if (pointeeType is AttributedType attributedType)
+            {
+                name = GetTypeNameForPointeeType(namedDecl, attributedType.ModifiedType);
+            }
+            else if (pointeeType is BuiltinType)
+            {
+                switch (pointeeType.Kind)
+                {
+                    case CXTypeKind.CXType_Void:
+                    {
+                        name = "IntPtr";
+                        break;
+                    }
+
+                    case CXTypeKind.CXType_Char_U:
+                    case CXTypeKind.CXType_Char_S:
+                    {
+                        if ((namedDecl is ParmVarDecl parmVarDecl) && (GetParmModifier(namedDecl, parmVarDecl.Type).Equals("out")))
+                        {
+                            name = "IntPtr";
+                        }
+                        else
+                        {
+                            name = "string";
+                        }
+                        break;
+                    }
+
+                    default:
+                    {
+                        name = (namedDecl is ParmVarDecl) ? GetTypeName(namedDecl, pointeeType) : "IntPtr";
+                        break;
+                    }
+                }
+            }
+            else if (pointeeType is ElaboratedType elaboratedType)
+            {
+                name = GetTypeNameForPointeeType(namedDecl, elaboratedType.NamedType);
+            }
+            else if (namedDecl is ParmVarDecl)
+            {
+                name = GetTypeName(namedDecl, pointeeType);
+            }
+            else
+            {
+                name = "IntPtr";
+            }
+
+            Debug.Assert(!string.IsNullOrWhiteSpace(name));
+            return name;
+        }
+
+        private string GetTypeNameForUnderlyingType(NamedDecl namedDecl, Type underlyingType)
+        {
+            string name;
+
+            if (underlyingType is ElaboratedType elaboratedType)
+            {
+                name = GetTypeNameForUnderlyingType(namedDecl, elaboratedType.NamedType);
+            }
+            else if (underlyingType is TagType tagType)
+            {
+                name = GetRemappedCursorName(tagType.Decl);
+            }
+            else if (underlyingType is TypedefType typedefType)
+            {
+                name = GetTypeNameForUnderlyingType(namedDecl, typedefType.UnderlyingType);
+            }
+            else
+            {
+                name = string.Empty;
+            }
+
+            return name;
         }
 
         private bool IsSupportedFixedSizedBufferType(string typeName)
@@ -1894,7 +1800,7 @@ namespace ClangSharp
         {
             if (typedefNameDecl is TypedefDecl typedefDecl)
             {
-                VisitTypedefDecl(typedefDecl, parent);
+                VisitTypedefDecl(typedefDecl, parent, typedefDecl.UnderlyingType);
             }
             else
             {
@@ -1902,188 +1808,142 @@ namespace ClangSharp
             }
         }
 
-        private void VisitTypedefDecl(TypedefDecl typedefDecl, Cursor parent)
-        {
-            VisitTypedefDecl(typedefDecl, parent, typedefDecl.UnderlyingType);
-        }
-
         private void VisitTypedefDecl(TypedefDecl typedefDecl, Cursor parent, Type underlyingType)
         {
-            switch (underlyingType.Kind)
+            if (_config.GenerateUnsafeCode)
             {
-                case CXTypeKind.CXType_Bool:
-                case CXTypeKind.CXType_Char_U:
-                case CXTypeKind.CXType_UChar:
-                case CXTypeKind.CXType_UShort:
-                case CXTypeKind.CXType_UInt:
-                case CXTypeKind.CXType_ULong:
-                case CXTypeKind.CXType_ULongLong:
-                case CXTypeKind.CXType_Char_S:
-                case CXTypeKind.CXType_SChar:
-                case CXTypeKind.CXType_WChar:
-                case CXTypeKind.CXType_Short:
-                case CXTypeKind.CXType_Int:
-                case CXTypeKind.CXType_Long:
-                case CXTypeKind.CXType_LongLong:
-                case CXTypeKind.CXType_Float:
-                case CXTypeKind.CXType_Double:
-                {
-                    if (!_config.GenerateUnsafeCode)
-                    {
-                        var name = GetRemappedCursorName(typedefDecl);
-
-                        StartUsingOutputBuilder(name);
-                        {
-
-                            var escapedName = EscapeName(name);
-
-                            _outputBuilder.WriteIndented("public partial struct");
-                            _outputBuilder.Write(' ');
-                            _outputBuilder.WriteLine(escapedName);
-                            _outputBuilder.WriteBlockStart();
-                            {
-                                var typeName = GetRemappedTypeName(typedefDecl, underlyingType);
-
-                                _outputBuilder.WriteIndented("public");
-                                _outputBuilder.Write(' ');
-                                _outputBuilder.Write(escapedName);
-                                _outputBuilder.Write('(');
-                                _outputBuilder.Write(typeName);
-                                _outputBuilder.Write(' ');
-                                _outputBuilder.Write("value");
-                                _outputBuilder.WriteLine(')');
-                                _outputBuilder.WriteBlockStart();
-                                {
-                                    _outputBuilder.WriteIndentedLine("Value = value;");
-                                }
-                                _outputBuilder.WriteBlockEnd();
-                                _outputBuilder.WriteLine();
-                                _outputBuilder.WriteIndented("public");
-                                _outputBuilder.Write(' ');
-                                _outputBuilder.Write(typeName);
-                                _outputBuilder.Write(' ');
-                                _outputBuilder.Write("Value");
-                                _outputBuilder.WriteLine(';');
-                            }
-                            _outputBuilder.WriteBlockEnd();
-                        }
-                        StopUsingOutputBuilder();
-                    }
-                    break;
-                }
-
-                case CXTypeKind.CXType_Pointer:
-                {
-                    var pointerType = (PointerType)underlyingType;
-                    VisitTypedefDeclForPointer(typedefDecl, parent, pointerType.PointeeType);
-                    break;
-                }
-
-                case CXTypeKind.CXType_Record:
-                case CXTypeKind.CXType_Enum:
-                {
-                    // We recurse the struct and record declarations directly
-                    break;
-                }
-
-                case CXTypeKind.CXType_Typedef:
-                case CXTypeKind.CXType_Elaborated:
-                {
-                    VisitTypedefDecl(typedefDecl, parent, underlyingType.CanonicalType);
-                    break;
-                }
-
-                default:
-                {
-                    AddDiagnostic(DiagnosticLevel.Error, $"Unsupported underlying type: '{underlyingType.KindSpelling}'. Generating bindings may be incomplete.", typedefDecl);
-                    break;
-                }
+                return;
             }
-        }
 
-        private void VisitTypedefDeclForPointer(TypedefDecl typedefDecl, Cursor parent, Type pointeeType)
-        {
-            switch (pointeeType.Kind)
+            if (underlyingType is BuiltinType)
             {
-                case CXTypeKind.CXType_Void:
-                case CXTypeKind.CXType_Record:
+                var name = GetRemappedCursorName(typedefDecl);
+
+                StartUsingOutputBuilder(name);
                 {
-                    if (!_config.GenerateUnsafeCode)
+
+                    var escapedName = EscapeName(name);
+
+                    _outputBuilder.WriteIndented("public partial struct");
+                    _outputBuilder.Write(' ');
+                    _outputBuilder.WriteLine(escapedName);
+                    _outputBuilder.WriteBlockStart();
                     {
-                        var name = GetRemappedCursorName(typedefDecl);
-                        StartUsingOutputBuilder(name);
-                        {
-                            var escapedName = EscapeName(name);
+                        var typeName = GetRemappedTypeName(typedefDecl, underlyingType);
 
-                            _outputBuilder.AddUsingDirective("System");
-
-                            _outputBuilder.WriteIndented("public partial struct");
-                            _outputBuilder.Write(' ');
-                            _outputBuilder.WriteLine(escapedName);
-                            _outputBuilder.WriteBlockStart();
-                            {
-                                _outputBuilder.WriteIndented("public");
-                                _outputBuilder.Write(' ');
-                                _outputBuilder.Write(escapedName);
-                                _outputBuilder.WriteLine("(IntPtr pointer)");
-                                _outputBuilder.WriteBlockStart();
-                                {
-                                    _outputBuilder.WriteIndentedLine("Pointer = pointer;");
-                                }
-                                _outputBuilder.WriteBlockEnd();
-                                _outputBuilder.WriteLine();
-                                _outputBuilder.WriteIndentedLine("public IntPtr Pointer;");
-                            }
-                            _outputBuilder.WriteBlockEnd();
-                        }
-                        StopUsingOutputBuilder();
-                    }
-                    break;
-                }
-
-                case CXTypeKind.CXType_FunctionProto:
-                {
-                    var name = GetRemappedCursorName(typedefDecl);
-                    var functionType = (FunctionType)pointeeType;
-
-                    StartUsingOutputBuilder(name);
-                    {
-                        var escapedName = EscapeName(name);
-
-                        _outputBuilder.AddUsingDirective("System.Runtime.InteropServices");
-
-                        _outputBuilder.WriteIndented("[UnmanagedFunctionPointer(CallingConvention.");
-                        _outputBuilder.Write(GetCallingConventionName(typedefDecl, functionType.CallConv));
-                        _outputBuilder.WriteLine(")]");
-                        _outputBuilder.WriteIndented("public delegate");
-                        _outputBuilder.Write(' ');
-                        _outputBuilder.Write(GetRemappedTypeName(typedefDecl, functionType.ReturnType));
+                        _outputBuilder.WriteIndented("public");
                         _outputBuilder.Write(' ');
                         _outputBuilder.Write(escapedName);
                         _outputBuilder.Write('(');
-
-                        foreach (var parmVarDecl in typedefDecl.Parameters)
+                        _outputBuilder.Write(typeName);
+                        _outputBuilder.Write(' ');
+                        _outputBuilder.Write("value");
+                        _outputBuilder.WriteLine(')');
+                        _outputBuilder.WriteBlockStart();
                         {
-                            Visit(parmVarDecl, typedefDecl);
+                            _outputBuilder.WriteIndentedLine("Value = value;");
                         }
-
-                        _outputBuilder.WriteLine(");");
+                        _outputBuilder.WriteBlockEnd();
+                        _outputBuilder.WriteLine();
+                        _outputBuilder.WriteIndented("public");
+                        _outputBuilder.Write(' ');
+                        _outputBuilder.Write(typeName);
+                        _outputBuilder.Write(' ');
+                        _outputBuilder.Write("Value");
+                        _outputBuilder.WriteLine(';');
                     }
-                    StopUsingOutputBuilder();
-                    break;
+                    _outputBuilder.WriteBlockEnd();
                 }
+                StopUsingOutputBuilder();
+            }
+            else if (underlyingType is ElaboratedType elaboratedType)
+            {
+                VisitTypedefDecl(typedefDecl, parent, elaboratedType.NamedType);
+            }
+            else if (underlyingType is PointerType pointerType)
+            {
+                VisitTypedefDeclForPointeeType(typedefDecl, parent, pointerType.PointeeType);
+            }
+            else if (underlyingType is TypedefType typedefType)
+            {
+                VisitTypedefDecl(typedefDecl, parent, typedefType.UnderlyingType);
+            }
+            else if (!(underlyingType is TagType))
+            {
+                AddDiagnostic(DiagnosticLevel.Error, $"Unsupported underlying type: '{underlyingType.KindSpelling}'. Generating bindings may be incomplete.", typedefDecl);
+            }
+        }
 
-                case CXTypeKind.CXType_Elaborated:
-                {
-                    VisitTypedefDeclForPointer(typedefDecl, parent, pointeeType.CanonicalType);
-                    break;
-                }
+        private void VisitTypedefDeclForPointeeType(TypedefDecl typedefDecl, Cursor parent, Type pointeeType)
+        {
+            Debug.Assert(!_config.GenerateUnsafeCode);
 
-                default:
+            if ((pointeeType is BuiltinType) || (pointeeType is TagType))
+            {
+                var name = GetRemappedCursorName(typedefDecl);
+                StartUsingOutputBuilder(name);
                 {
-                    AddDiagnostic(DiagnosticLevel.Error, $"Unsupported pointee type: '{pointeeType.KindSpelling}'. Generating bindings may be incomplete.", typedefDecl);
-                    break;
+                    var escapedName = EscapeName(name);
+
+                    _outputBuilder.AddUsingDirective("System");
+
+                    _outputBuilder.WriteIndented("public partial struct");
+                    _outputBuilder.Write(' ');
+                    _outputBuilder.WriteLine(escapedName);
+                    _outputBuilder.WriteBlockStart();
+                    {
+                        _outputBuilder.WriteIndented("public");
+                        _outputBuilder.Write(' ');
+                        _outputBuilder.Write(escapedName);
+                        _outputBuilder.WriteLine("(IntPtr pointer)");
+                        _outputBuilder.WriteBlockStart();
+                        {
+                            _outputBuilder.WriteIndentedLine("Pointer = pointer;");
+                        }
+                        _outputBuilder.WriteBlockEnd();
+                        _outputBuilder.WriteLine();
+                        _outputBuilder.WriteIndentedLine("public IntPtr Pointer;");
+                    }
+                    _outputBuilder.WriteBlockEnd();
                 }
+                StopUsingOutputBuilder();
+            }
+            else if (pointeeType is ElaboratedType elaboratedType)
+            {
+                VisitTypedefDeclForPointeeType(typedefDecl, parent, elaboratedType.NamedType);
+            }
+            else if (pointeeType is FunctionType functionType)
+            {
+                var name = GetRemappedCursorName(typedefDecl);
+
+                StartUsingOutputBuilder(name);
+                {
+                    var escapedName = EscapeName(name);
+
+                    _outputBuilder.AddUsingDirective("System.Runtime.InteropServices");
+
+                    _outputBuilder.WriteIndented("[UnmanagedFunctionPointer(CallingConvention.");
+                    _outputBuilder.Write(GetCallingConventionName(typedefDecl, functionType.CallConv));
+                    _outputBuilder.WriteLine(")]");
+                    _outputBuilder.WriteIndented("public delegate");
+                    _outputBuilder.Write(' ');
+                    _outputBuilder.Write(GetRemappedTypeName(typedefDecl, functionType.ReturnType));
+                    _outputBuilder.Write(' ');
+                    _outputBuilder.Write(escapedName);
+                    _outputBuilder.Write('(');
+
+                    foreach (var parmVarDecl in typedefDecl.Parameters)
+                    {
+                        Visit(parmVarDecl, typedefDecl);
+                    }
+
+                    _outputBuilder.WriteLine(");");
+                }
+                StopUsingOutputBuilder();
+            }
+            else
+            {
+                AddDiagnostic(DiagnosticLevel.Error, $"Unsupported pointee type: '{pointeeType.KindSpelling}'. Generating bindings may be incomplete.", typedefDecl);
             }
         }
 

--- a/sources/ClangSharp.PInvokeGenerator/Types/ArrayType.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Types/ArrayType.cs
@@ -1,0 +1,12 @@
+namespace ClangSharp
+{
+    internal class ArrayType : Type
+    {
+        protected ArrayType(CXType handle, TranslationUnit translationUnit) : base(handle, translationUnit)
+        {
+            ElementType = TranslationUnit.GetOrCreateType(Handle.ArrayElementType, () => Create(Handle.ArrayElementType, TranslationUnit));
+        }
+
+        public Type ElementType { get; }
+    }
+}

--- a/sources/ClangSharp.PInvokeGenerator/Types/AttributedType.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Types/AttributedType.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+
+namespace ClangSharp
+{
+    internal sealed class AttributedType : Type
+    {
+        public AttributedType(CXType handle, TranslationUnit translationUnit) : base(handle, translationUnit)
+        {
+            Debug.Assert(handle.kind == CXTypeKind.CXType_Attributed);
+            ModifiedType = TranslationUnit.GetOrCreateType(Handle.ModifiedType, () => Create(Handle.ModifiedType, TranslationUnit));
+        }
+
+        public Type ModifiedType { get; }
+    }
+}

--- a/sources/ClangSharp.PInvokeGenerator/Types/BuiltinType.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Types/BuiltinType.cs
@@ -1,0 +1,9 @@
+namespace ClangSharp
+{
+    internal sealed class BuiltinType : Type
+    {
+        public BuiltinType(CXType handle, TranslationUnit translationUnit) : base(handle, translationUnit)
+        {
+        }
+    }
+}

--- a/sources/ClangSharp.PInvokeGenerator/Types/ConstantArrayType.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Types/ConstantArrayType.cs
@@ -1,0 +1,14 @@
+using System.Diagnostics;
+
+namespace ClangSharp
+{
+    internal sealed class ConstantArrayType : ArrayType
+    {
+        public ConstantArrayType(CXType handle, TranslationUnit translationUnit) : base(handle, translationUnit)
+        {
+            Debug.Assert(handle.kind == CXTypeKind.CXType_ConstantArray);
+        }
+
+        public long Size => Handle.ArraySize;
+    }
+}

--- a/sources/ClangSharp.PInvokeGenerator/Types/DependentSizedArrayType.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Types/DependentSizedArrayType.cs
@@ -1,0 +1,12 @@
+using System.Diagnostics;
+
+namespace ClangSharp
+{
+    internal sealed class DependentSizedArrayType : ArrayType
+    {
+        public DependentSizedArrayType(CXType handle, TranslationUnit translationUnit) : base(handle, translationUnit)
+        {
+            Debug.Assert(handle.kind == CXTypeKind.CXType_DependentSizedArray);
+        }
+    }
+}

--- a/sources/ClangSharp.PInvokeGenerator/Types/ElaboratedType.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Types/ElaboratedType.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+
+namespace ClangSharp
+{
+    internal sealed class ElaboratedType : TypeWithKeyword
+    {
+        public ElaboratedType(CXType handle, TranslationUnit translationUnit) : base(handle, translationUnit)
+        {
+            Debug.Assert(handle.kind == CXTypeKind.CXType_Elaborated);
+            NamedType = TranslationUnit.GetOrCreateType(Handle.NamedType, () => Create(Handle.NamedType, TranslationUnit));
+        }
+
+        public Type NamedType { get; }
+    }
+}

--- a/sources/ClangSharp.PInvokeGenerator/Types/EnumType.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Types/EnumType.cs
@@ -1,0 +1,12 @@
+using System.Diagnostics;
+
+namespace ClangSharp
+{
+    internal sealed class EnumType : TagType
+    {
+        public EnumType(CXType handle, TranslationUnit translationUnit) : base(handle, translationUnit)
+        {
+            Debug.Assert(handle.kind == CXTypeKind.CXType_Enum);
+        }
+    }
+}

--- a/sources/ClangSharp.PInvokeGenerator/Types/FunctionProtoType.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Types/FunctionProtoType.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace ClangSharp
+{
+    internal sealed class FunctionProtoType : FunctionType
+    {
+        private readonly Type[] _parameters;
+
+        public FunctionProtoType(CXType handle, TranslationUnit translationUnit) : base(handle, translationUnit)
+        {
+            Debug.Assert(handle.kind == CXTypeKind.CXType_FunctionProto);
+
+            _parameters = new Type[Handle.NumArgTypes];
+
+            for (uint index = 0; index < Handle.NumArgTypes; index++)
+            {
+                var parameterTypeHandle = Handle.GetArgType(index);
+                var parameterType = TranslationUnit.GetOrCreateType(parameterTypeHandle, () => Create(parameterTypeHandle, TranslationUnit));
+                _parameters[index] = parameterType;
+            }
+        }
+
+        public CXCursor_ExceptionSpecificationKind ExceptionSpecType => Handle.ExceptionSpecificationType;
+
+        public bool IsVariadic => Handle.IsFunctionTypeVariadic;
+
+        public IReadOnlyList<Type> Parameters => _parameters;
+
+        public CXRefQualifierKind RefQualifier => Handle.CXXRefQualifier;
+    }
+}

--- a/sources/ClangSharp.PInvokeGenerator/Types/FunctionType.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Types/FunctionType.cs
@@ -1,0 +1,14 @@
+namespace ClangSharp
+{
+    internal class FunctionType : Type
+    {
+        protected FunctionType(CXType handle, TranslationUnit translationUnit) : base(handle, translationUnit)
+        {
+            ReturnType = TranslationUnit.GetOrCreateType(Handle.ResultType, () => Create(Handle.ResultType, TranslationUnit));
+        }
+
+        public CXCallingConv CallConv => Handle.FunctionTypeCallingConv;
+
+        public Type ReturnType { get; }
+    }
+}

--- a/sources/ClangSharp.PInvokeGenerator/Types/IncompleteArrayType.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Types/IncompleteArrayType.cs
@@ -1,0 +1,12 @@
+using System.Diagnostics;
+
+namespace ClangSharp
+{
+    internal sealed class IncompleteArrayType : ArrayType
+    {
+        public IncompleteArrayType(CXType handle, TranslationUnit translationUnit) : base(handle, translationUnit)
+        {
+            Debug.Assert(handle.kind == CXTypeKind.CXType_IncompleteArray);
+        }
+    }
+}

--- a/sources/ClangSharp.PInvokeGenerator/Types/LValueReferenceType.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Types/LValueReferenceType.cs
@@ -1,0 +1,12 @@
+using System.Diagnostics;
+
+namespace ClangSharp
+{
+    internal sealed class LValueReferenceType : ReferenceType
+    {
+        public LValueReferenceType(CXType handle, TranslationUnit translationUnit) : base(handle, translationUnit)
+        {
+            Debug.Assert(handle.kind == CXTypeKind.CXType_LValueReference);
+        }
+    }
+}

--- a/sources/ClangSharp.PInvokeGenerator/Types/PointerType.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Types/PointerType.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+
+namespace ClangSharp
+{
+    internal sealed class PointerType : Type
+    {
+        public PointerType(CXType handle, TranslationUnit translationUnit) : base(handle, translationUnit)
+        {
+            Debug.Assert(handle.kind == CXTypeKind.CXType_Pointer);
+            PointeeType = TranslationUnit.GetOrCreateType(Handle.PointeeType, () => Create(Handle.PointeeType, TranslationUnit));
+        }
+
+        public Type PointeeType { get; }
+    }
+}

--- a/sources/ClangSharp.PInvokeGenerator/Types/RecordType.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Types/RecordType.cs
@@ -1,0 +1,12 @@
+using System.Diagnostics;
+
+namespace ClangSharp
+{
+    internal sealed class RecordType : TagType
+    {
+        public RecordType(CXType handle, TranslationUnit translationUnit) : base(handle, translationUnit)
+        {
+            Debug.Assert(handle.kind == CXTypeKind.CXType_Record);
+        }
+    }
+}

--- a/sources/ClangSharp.PInvokeGenerator/Types/ReferenceType.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Types/ReferenceType.cs
@@ -1,0 +1,12 @@
+namespace ClangSharp
+{
+    internal class ReferenceType : Type
+    {
+        protected ReferenceType(CXType handle, TranslationUnit translationUnit) : base(handle, translationUnit)
+        {
+            PointeeType = TranslationUnit.GetOrCreateType(Handle.PointeeType, () => Create(Handle.PointeeType, TranslationUnit));
+        }
+
+        public Type PointeeType { get; }
+    }
+}

--- a/sources/ClangSharp.PInvokeGenerator/Types/TagType.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Types/TagType.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace ClangSharp
+{
+    internal class TagType : Type
+    {
+        private readonly Lazy<TagDecl> _decl;
+
+        protected TagType(CXType handle, TranslationUnit translationUnit) : base(handle, translationUnit)
+        {
+            _decl = new Lazy<TagDecl>(() => {
+                var cursor = translationUnit.GetOrCreateCursor(Handle.Declaration, () => Cursor.Create(Handle.Declaration, translationUnit));
+                cursor?.Visit(clientData: default);
+                return (TagDecl)cursor;
+            });
+        }
+
+        public TagDecl Decl => _decl.Value;
+    }
+}

--- a/sources/ClangSharp.PInvokeGenerator/Types/Type.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Types/Type.cs
@@ -1,25 +1,109 @@
-﻿using System;
 using System.Diagnostics;
 
 namespace ClangSharp
 {
-    internal sealed class Type
+    internal class Type
     {
         public static Type Create(CXType handle, TranslationUnit translationUnit)
         {
             Debug.Assert(handle.kind != CXTypeKind.CXType_Invalid);
-            return new Type(handle, translationUnit);
+
+            switch (handle.kind)
+            {
+                case CXTypeKind.CXType_Unexposed:
+                {
+                    return new UnexposedType(handle, translationUnit);
+                }
+
+                case CXTypeKind.CXType_Void:
+                case CXTypeKind.CXType_Bool:
+                case CXTypeKind.CXType_Char_U:
+                case CXTypeKind.CXType_UChar:
+                case CXTypeKind.CXType_UShort:
+                case CXTypeKind.CXType_UInt:
+                case CXTypeKind.CXType_ULong:
+                case CXTypeKind.CXType_ULongLong:
+                case CXTypeKind.CXType_Char_S:
+                case CXTypeKind.CXType_SChar:
+                case CXTypeKind.CXType_WChar:
+                case CXTypeKind.CXType_Short:
+                case CXTypeKind.CXType_Int:
+                case CXTypeKind.CXType_Long:
+                case CXTypeKind.CXType_LongLong:
+                case CXTypeKind.CXType_Float:
+                case CXTypeKind.CXType_Double:
+                case CXTypeKind.CXType_LongDouble:
+                case CXTypeKind.CXType_NullPtr:
+                case CXTypeKind.CXType_Dependent:
+                {
+                    return new BuiltinType(handle, translationUnit);
+                }
+
+                case CXTypeKind.CXType_Pointer:
+                {
+                    return new PointerType(handle, translationUnit);
+                }
+
+                case CXTypeKind.CXType_LValueReference:
+                {
+                    return new LValueReferenceType(handle, translationUnit);
+                }
+
+                case CXTypeKind.CXType_Record:
+                {
+                    return new RecordType(handle, translationUnit);
+                }
+
+                case CXTypeKind.CXType_Enum:
+                {
+                    return new EnumType(handle, translationUnit);
+                }
+
+                case CXTypeKind.CXType_Typedef:
+                {
+                    return new TypedefType(handle, translationUnit);
+                }
+
+                case CXTypeKind.CXType_FunctionProto:
+                {
+                    return new FunctionProtoType(handle, translationUnit);
+                }
+
+                case CXTypeKind.CXType_ConstantArray:
+                {
+                    return new ConstantArrayType(handle, translationUnit);
+                }
+
+                case CXTypeKind.CXType_IncompleteArray:
+                {
+                    return new IncompleteArrayType(handle, translationUnit);
+                }
+
+                case CXTypeKind.CXType_DependentSizedArray:
+                {
+                    return new DependentSizedArrayType(handle, translationUnit);
+                }
+
+                case CXTypeKind.CXType_Elaborated:
+                {
+                    return new ElaboratedType(handle, translationUnit);
+                }
+
+                case CXTypeKind.CXType_Attributed:
+                {
+                    return new AttributedType(handle, translationUnit);
+                }
+
+                default:
+                {
+                    Debug.WriteLine($"Unhandled type kind: {handle.KindSpelling}.");
+                    Debugger.Break();
+                    return new Type(handle, translationUnit);
+                }
+            }
         }
 
-        private readonly Lazy<Type> _canonicalType;
-        private readonly Lazy<Type> _elementType;
-        private readonly Lazy<Type> _modifierType;
-        private readonly Lazy<Type> _pointeeType;
-        private readonly Lazy<Type> _resultType;
-
-        private readonly Lazy<Decl> _declarationCursor;
-
-        private Type(CXType handle, TranslationUnit translationUnit)
+        protected Type(CXType handle, TranslationUnit translationUnit)
         {
             Debug.Assert(translationUnit != null);
 
@@ -27,41 +111,16 @@ namespace ClangSharp
             TranslationUnit = translationUnit;
 
             translationUnit.AddVisitedType(this);
-
-            _canonicalType = new Lazy<Type>(() => translationUnit.GetOrCreateType(Handle.CanonicalType, () => Create(Handle.CanonicalType, translationUnit)));
-            _elementType = new Lazy<Type>(() => translationUnit.GetOrCreateType(Handle.ElementType, () => Create(Handle.ElementType, translationUnit)));
-            _modifierType = new Lazy<Type>(() => translationUnit.GetOrCreateType(Handle.ModifierType, () => Create(Handle.ModifierType, translationUnit)));
-            _pointeeType = new Lazy<Type>(() => translationUnit.GetOrCreateType(Handle.PointeeType, () => Create(Handle.PointeeType, translationUnit)));
-            _resultType = new Lazy<Type>(() => translationUnit.GetOrCreateType(Handle.ResultType, () => Create(Handle.ResultType, translationUnit)));
-
-            _declarationCursor = new Lazy<Decl>(() => {
-                var cursor = translationUnit.GetOrCreateCursor(Handle.Declaration, () => Cursor.Create(Handle.Declaration, translationUnit));
-                cursor?.Visit(clientData: default);
-                return (Decl)cursor;
-            });
+            CanonicalType = TranslationUnit.GetOrCreateType(Handle.CanonicalType, () => Create(Handle.CanonicalType, TranslationUnit));
         }
 
-        public CXCallingConv CallingConv => Handle.FunctionTypeCallingConv;
-
-        public Type CanonicalType => _canonicalType.Value;
-
-        public Decl DeclarationCursor => _declarationCursor.Value;
-
-        public Type ElementType => _elementType.Value;
+        public Type CanonicalType { get; }
 
         public CXType Handle { get; }
 
         public CXTypeKind Kind => Handle.kind;
 
         public string KindSpelling => Handle.KindSpelling.ToString();
-
-        public Type ModifierType => _modifierType.Value;
-
-        public long NumElements => Handle.NumElements;
-
-        public Type PointeeType => _pointeeType.Value;
-
-        public Type ResultType => _resultType.Value;
 
         public TranslationUnit TranslationUnit { get; }
 

--- a/sources/ClangSharp.PInvokeGenerator/Types/TypeWithKeyword.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Types/TypeWithKeyword.cs
@@ -1,0 +1,9 @@
+namespace ClangSharp
+{
+    internal class TypeWithKeyword : Type
+    {
+        protected TypeWithKeyword(CXType handle, TranslationUnit translationUnit) : base(handle, translationUnit)
+        {
+        }
+    }
+}

--- a/sources/ClangSharp.PInvokeGenerator/Types/TypedefType.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Types/TypedefType.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Diagnostics;
+
+namespace ClangSharp
+{
+    internal sealed class TypedefType : Type
+    {
+        private readonly Lazy<TypedefNameDecl> _decl;
+
+        public TypedefType(CXType handle, TranslationUnit translationUnit) : base(handle, translationUnit)
+        {
+            Debug.Assert(handle.kind == CXTypeKind.CXType_Typedef);
+
+            _decl = new Lazy<TypedefNameDecl>(() => {
+                var cursor = translationUnit.GetOrCreateCursor(Handle.Declaration, () => Cursor.Create(Handle.Declaration, translationUnit));
+                cursor?.Visit(clientData: default);
+                return (TypedefNameDecl)cursor;
+            });
+        }
+
+        public TypedefNameDecl Decl => _decl.Value;
+
+        public string Name => Handle.GetTypedefName().ToString();
+
+        public bool IsTransparentTag => Handle.IsTransparentTagTypedef;
+
+        public Type UnderlyingType => Decl.UnderlyingType;
+    }
+}

--- a/sources/ClangSharp.PInvokeGenerator/Types/UnexposedType.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Types/UnexposedType.cs
@@ -1,0 +1,12 @@
+using System.Diagnostics;
+
+namespace ClangSharp
+{
+    internal sealed class UnexposedType : Type
+    {
+        public UnexposedType(CXType handle, TranslationUnit translationUnit) : base(handle, translationUnit)
+        {
+            Debug.Assert(handle.kind == CXTypeKind.CXType_Unexposed);
+        }
+    }
+}

--- a/sources/ClangSharp/Extensions/CXTranslationUnit.cs
+++ b/sources/ClangSharp/Extensions/CXTranslationUnit.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace ClangSharp
 {
@@ -48,7 +48,7 @@ namespace ClangSharp
 
         public CXFile GetFile(string fileName) => clang.getFile(this, fileName);
 
-        public string GetFileContents(CXFile file, out IntPtr size) => clang.getFileContents(this, file, out size);
+        public string GetFileContents(CXFile file, out UIntPtr size) => clang.getFileContents(this, file, out size);
 
         public void GetInclusions(CXInclusionVisitor visitor, CXClientData clientData) => clang.getInclusions(this, visitor, clientData);
 

--- a/sources/ClangSharp/Extensions/CXType.cs
+++ b/sources/ClangSharp/Extensions/CXType.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace ClangSharp
 {
@@ -40,7 +40,7 @@ namespace ClangSharp
 
         public CXString KindSpelling => clang.getTypeKindSpelling(kind);
 
-        public CXType ModifierType => clang.Type_getModifiedType(this);
+        public CXType ModifiedType => clang.Type_getModifiedType(this);
 
         public CXType NamedType => clang.Type_getNamedType(this);
 

--- a/sources/ClangSharp/Generated/clang.cs
+++ b/sources/ClangSharp/Generated/clang.cs
@@ -39,7 +39,7 @@ namespace ClangSharp
 
         [DllImport(libraryPath, EntryPoint = "clang_getFileContents", CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(StringMarshaler))]
-        public static extern string getFileContents(CXTranslationUnit tu, CXFile file, out IntPtr size);
+        public static extern string getFileContents(CXTranslationUnit tu, CXFile file, out UIntPtr size);
 
         [DllImport(libraryPath, EntryPoint = "clang_File_isEqual", CallingConvention = CallingConvention.Cdecl)]
         public static extern int File_isEqual(CXFile file1, CXFile file2);

--- a/sources/ClangSharpPInvokeGenerator/ClangSharpPInvokeGenerator.csproj
+++ b/sources/ClangSharpPInvokeGenerator/ClangSharpPInvokeGenerator.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="Properties/launchsettings.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="System.CommandLine.Experimental" />
   </ItemGroup>
 

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
@@ -117,7 +117,7 @@ namespace ClangSharp
 
             foreach (var configSwitch in configSwitches)
             {
-                if (configSwitch.EndsWith("multi-file"))
+                if (configSwitch.Equals("multi-file"))
                 {
                     configOptions |= PInvokeGeneratorConfigurationOptions.GenerateMultipleFiles;
                 }


### PR DESCRIPTION
This does some minor cleanup that namely extends the CXType wrapper to more closely match the Clang C++ bindings.

This also improves how cursor and type names are resolved to better match how the wrapper types/etc are generated.