### PR TITLE
Changing `runtime.rid.libclang` to be `libclang.runtime.rid`

### DIFF
--- a/ClangSharp.sln
+++ b/ClangSharp.sln
@@ -52,70 +52,59 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "libclang", "libclang", "{C8
 		packages\libclang\runtime.json = packages\libclang\runtime.json
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "runtime.freebsd.11-x64.libclang", "runtime.freebsd.11-x64.libclang", "{C90094F6-26DF-4B2C-BD61-540D4CE988A4}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "libclang.runtime.freebsd.11-x64", "libclang.runtime.freebsd.11-x64", "{C90094F6-26DF-4B2C-BD61-540D4CE988A4}"
 	ProjectSection(SolutionItems) = preProject
-		packages\runtime.freebsd.11-x64.libclang\LICENSE.TXT = packages\runtime.freebsd.11-x64.libclang\LICENSE.TXT
-		packages\runtime.freebsd.11-x64.libclang\runtime.freebsd.11-x64.libclang.nuspec = packages\runtime.freebsd.11-x64.libclang\runtime.freebsd.11-x64.libclang.nuspec
+		packages\libclang.runtime.freebsd.11-x64\libclang.runtime.freebsd.11-x64.nuspec = packages\libclang.runtime.freebsd.11-x64\libclang.runtime.freebsd.11-x64.nuspec
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "runtime.freebsd.11-x86.libclang", "runtime.freebsd.11-x86.libclang", "{C57B4A74-2791-44C3-92D3-9B8AD5993F27}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "libclang.runtime.freebsd.11-x86", "libclang.runtime.freebsd.11-x86", "{C57B4A74-2791-44C3-92D3-9B8AD5993F27}"
 	ProjectSection(SolutionItems) = preProject
-		packages\runtime.freebsd.11-x86.libclang\LICENSE.TXT = packages\runtime.freebsd.11-x86.libclang\LICENSE.TXT
-		packages\runtime.freebsd.11-x86.libclang\runtime.freebsd.11-x86.libclang.nuspec = packages\runtime.freebsd.11-x86.libclang\runtime.freebsd.11-x86.libclang.nuspec
+		packages\libclang.runtime.freebsd.11-x86\libclang.runtime.freebsd.11-x86.nuspec = packages\libclang.runtime.freebsd.11-x86\libclang.runtime.freebsd.11-x86.nuspec
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "runtime.linux-arm.libclang", "runtime.linux-arm.libclang", "{F9915660-2229-418C-B269-83FE74C1943E}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "libclang.runtime.linux-arm", "libclang.runtime.linux-arm", "{F9915660-2229-418C-B269-83FE74C1943E}"
 	ProjectSection(SolutionItems) = preProject
-		packages\runtime.linux-arm.libclang\LICENSE.TXT = packages\runtime.linux-arm.libclang\LICENSE.TXT
-		packages\runtime.linux-arm.libclang\runtime.linux-arm.libclang.nuspec = packages\runtime.linux-arm.libclang\runtime.linux-arm.libclang.nuspec
+		packages\libclang.runtime.linux-arm\libclang.runtime.linux-arm.nuspec = packages\libclang.runtime.linux-arm\libclang.runtime.linux-arm.nuspec
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "runtime.linux-arm64.libclang", "runtime.linux-arm64.libclang", "{7D89072F-8E3E-4009-BCCD-5D3C69F88042}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "libclang.runtime.linux-arm64", "libclang.runtime.linux-arm64", "{7D89072F-8E3E-4009-BCCD-5D3C69F88042}"
 	ProjectSection(SolutionItems) = preProject
-		packages\runtime.linux-arm64.libclang\LICENSE.TXT = packages\runtime.linux-arm64.libclang\LICENSE.TXT
-		packages\runtime.linux-arm64.libclang\runtime.linux-arm64.libclang.nuspec = packages\runtime.linux-arm64.libclang\runtime.linux-arm64.libclang.nuspec
+		packages\libclang.runtime.linux-arm64\libclang.runtime.linux-arm64.nuspec = packages\libclang.runtime.linux-arm64\libclang.runtime.linux-arm64.nuspec
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "runtime.osx-x64.libclang", "runtime.osx-x64.libclang", "{8006B5D7-5E0E-4A0A-884F-62C5216144EE}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "libclang.runtime.osx-x64", "libclang.runtime.osx-x64", "{8006B5D7-5E0E-4A0A-884F-62C5216144EE}"
 	ProjectSection(SolutionItems) = preProject
-		packages\runtime.osx-x64.libclang\LICENSE.TXT = packages\runtime.osx-x64.libclang\LICENSE.TXT
-		packages\runtime.osx-x64.libclang\runtime.osx-x64.libclang.nuspec = packages\runtime.osx-x64.libclang\runtime.osx-x64.libclang.nuspec
+		packages\libclang.runtime.osx-x64\libclang.runtime.osx-x64.nuspec = packages\libclang.runtime.osx-x64\libclang.runtime.osx-x64.nuspec
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "runtime.sles-x64.libclang", "runtime.sles-x64.libclang", "{C0D4BF1E-CFDA-4E9D-9A15-2A1FDA7D56C2}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "libclang.runtime.sles-x64", "libclang.runtime.sles-x64", "{C0D4BF1E-CFDA-4E9D-9A15-2A1FDA7D56C2}"
 	ProjectSection(SolutionItems) = preProject
-		packages\runtime.sles-x64.libclang\LICENSE.TXT = packages\runtime.sles-x64.libclang\LICENSE.TXT
-		packages\runtime.sles-x64.libclang\runtime.sles-x64.libclang.nuspec = packages\runtime.sles-x64.libclang\runtime.sles-x64.libclang.nuspec
+		packages\libclang.runtime.sles-x64\libclang.runtime.sles-x64.nuspec = packages\libclang.runtime.sles-x64\libclang.runtime.sles-x64.nuspec
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "runtime.ubuntu.14.04-x64.libclang", "runtime.ubuntu.14.04-x64.libclang", "{9F9CD2A9-475B-4D9A-AFB6-958B71AC0111}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "libclang.runtime.ubuntu.14.04-x64", "libclang.runtime.ubuntu.14.04-x64", "{9F9CD2A9-475B-4D9A-AFB6-958B71AC0111}"
 	ProjectSection(SolutionItems) = preProject
-		packages\runtime.ubuntu.14.04-x64.libclang\LICENSE.TXT = packages\runtime.ubuntu.14.04-x64.libclang\LICENSE.TXT
-		packages\runtime.ubuntu.14.04-x64.libclang\runtime.ubuntu.14.04-x64.libclang.nuspec = packages\runtime.ubuntu.14.04-x64.libclang\runtime.ubuntu.14.04-x64.libclang.nuspec
+		packages\libclang.runtime.ubuntu.14.04-x64\libclang.runtime.ubuntu.14.04-x64.nuspec = packages\libclang.runtime.ubuntu.14.04-x64\libclang.runtime.ubuntu.14.04-x64.nuspec
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "runtime.ubuntu.16.04-x64.libclang", "runtime.ubuntu.16.04-x64.libclang", "{6185B159-5F40-4D96-AD52-EB2D37241E25}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "libclang.runtime.ubuntu.16.04-x64", "libclang.runtime.ubuntu.16.04-x64", "{6185B159-5F40-4D96-AD52-EB2D37241E25}"
 	ProjectSection(SolutionItems) = preProject
-		packages\runtime.ubuntu.16.04-x64.libclang\LICENSE.TXT = packages\runtime.ubuntu.16.04-x64.libclang\LICENSE.TXT
-		packages\runtime.ubuntu.16.04-x64.libclang\runtime.ubuntu.16.04-x64.libclang.nuspec = packages\runtime.ubuntu.16.04-x64.libclang\runtime.ubuntu.16.04-x64.libclang.nuspec
+		packages\libclang.runtime.ubuntu.16.04-x64\libclang.runtime.ubuntu.16.04-x64.nuspec = packages\libclang.runtime.ubuntu.16.04-x64\libclang.runtime.ubuntu.16.04-x64.nuspec
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "runtime.ubuntu.18.04-x64.libclang", "runtime.ubuntu.18.04-x64.libclang", "{8756B75F-F244-43AD-9C79-1610059BDF36}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "libclang.runtime.ubuntu.18.04-x64", "libclang.runtime.ubuntu.18.04-x64", "{8756B75F-F244-43AD-9C79-1610059BDF36}"
 	ProjectSection(SolutionItems) = preProject
-		packages\runtime.ubuntu.18.04-x64.libclang\LICENSE.TXT = packages\runtime.ubuntu.18.04-x64.libclang\LICENSE.TXT
-		packages\runtime.ubuntu.18.04-x64.libclang\runtime.ubuntu.18.04-x64.libclang.nuspec = packages\runtime.ubuntu.18.04-x64.libclang\runtime.ubuntu.18.04-x64.libclang.nuspec
+		packages\libclang.runtime.ubuntu.18.04-x64\libclang.runtime.ubuntu.18.04-x64.nuspec = packages\libclang.runtime.ubuntu.18.04-x64\libclang.runtime.ubuntu.18.04-x64.nuspec
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "runtime.win-x64.libclang", "runtime.win-x64.libclang", "{4A298C7E-BF4D-418D-B70D-FE6D6F8097FD}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "libclang.runtime.win-x64", "libclang.runtime.win-x64", "{4A298C7E-BF4D-418D-B70D-FE6D6F8097FD}"
 	ProjectSection(SolutionItems) = preProject
-		packages\runtime.win-x64.libclang\LICENSE.TXT = packages\runtime.win-x64.libclang\LICENSE.TXT
-		packages\runtime.win-x64.libclang\runtime.win-x64.libclang.nuspec = packages\runtime.win-x64.libclang\runtime.win-x64.libclang.nuspec
+		packages\libclang.runtime.win-x64\libclang.runtime.win-x64.nuspec = packages\libclang.runtime.win-x64\libclang.runtime.win-x64.nuspec
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "runtime.win-x86.libclang", "runtime.win-x86.libclang", "{98BDA79D-8D81-4381-B794-65BAF82349D4}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "libclang.runtime.win-x86", "libclang.runtime.win-x86", "{98BDA79D-8D81-4381-B794-65BAF82349D4}"
 	ProjectSection(SolutionItems) = preProject
-		packages\runtime.win-x86.libclang\LICENSE.TXT = packages\runtime.win-x86.libclang\LICENSE.TXT
-		packages\runtime.win-x86.libclang\runtime.win-x86.libclang.nuspec = packages\runtime.win-x86.libclang\runtime.win-x86.libclang.nuspec
+		packages\libclang.runtime.win-x86\libclang.runtime.win-x86.nuspec = packages\libclang.runtime.win-x86\libclang.runtime.win-x86.nuspec
 	EndProjectSection
 EndProject
 Global

--- a/packages/libclang.runtime.freebsd.11-x64/libclang.runtime.freebsd.11-x64.nuspec
+++ b/packages/libclang.runtime.freebsd.11-x64/libclang.runtime.freebsd.11-x64.nuspec
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
-    <id>runtime.win-x86.libclang</id>
+    <id>libclang.runtime.freebsd.11-x64</id>
     <version>8.0.0</version>
     <authors>Microsoft and Contributors</authors>
     <owners>Microsoft and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/microsoft/clangsharp</projectUrl>
-    <description>win x86 native library for libclang.</description>
+    <description>freebsd 11 x64 native library for libclang.</description>
     <copyright>Copyright © University of Illinois at Urbana-Champaign</copyright>
     <repository type="git" url="https://github.com/llvm-mirror/clang" branch="release_80" />
   </metadata>
   <files>
     <file src="..\libclang\LICENSE.TXT" target="LICENSE.TXT" />
-    <file src="runtimes\win-x86\native\libclang.dll" target="runtimes\win-x86\native\libclang.dll" />
+    <file src="runtimes\freebsd.11-x64\native\libclang.so" target="runtimes\freebsd.11-x64\native\libclang.so" />
   </files>
 </package>

--- a/packages/libclang.runtime.freebsd.11-x86/libclang.runtime.freebsd.11-x86.nuspec
+++ b/packages/libclang.runtime.freebsd.11-x86/libclang.runtime.freebsd.11-x86.nuspec
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
-    <id>runtime.osx-x64.libclang</id>
+    <id>libclang.runtime.freebsd.11-x86</id>
     <version>8.0.0</version>
     <authors>Microsoft and Contributors</authors>
     <owners>Microsoft and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/microsoft/clangsharp</projectUrl>
-    <description>osx x64 native library for libclang.</description>
+    <description>freebsd 11 x86 native library for libclang.</description>
     <copyright>Copyright © University of Illinois at Urbana-Champaign</copyright>
     <repository type="git" url="https://github.com/llvm-mirror/clang" branch="release_80" />
   </metadata>
   <files>
     <file src="..\libclang\LICENSE.TXT" target="LICENSE.TXT" />
-    <file src="runtimes\osx-x64\native\libclang.dylib" target="runtimes\osx-x64\native\libclang.dylib" />
+    <file src="runtimes\freebsd.11-x86\native\libclang.so" target="runtimes\freebsd.11-x86\native\libclang.so" />
   </files>
 </package>

--- a/packages/libclang.runtime.linux-arm/libclang.runtime.linux-arm.nuspec
+++ b/packages/libclang.runtime.linux-arm/libclang.runtime.linux-arm.nuspec
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
-    <id>runtime.freebsd.11-x86.libclang</id>
+    <id>libclang.runtime.linux-arm</id>
     <version>8.0.0</version>
     <authors>Microsoft and Contributors</authors>
     <owners>Microsoft and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/microsoft/clangsharp</projectUrl>
-    <description>freebsd 11 x86 native library for libclang.</description>
+    <description>linux arm native library for libclang.</description>
     <copyright>Copyright © University of Illinois at Urbana-Champaign</copyright>
     <repository type="git" url="https://github.com/llvm-mirror/clang" branch="release_80" />
   </metadata>
   <files>
     <file src="..\libclang\LICENSE.TXT" target="LICENSE.TXT" />
-    <file src="runtimes\freebsd.11-x86\native\libclang.so" target="runtimes\freebsd.11-x86\native\libclang.so" />
+    <file src="runtimes\linux-arm\native\libclang.so" target="runtimes\linux-arm\native\libclang.so" />
   </files>
 </package>

--- a/packages/libclang.runtime.linux-arm64/libclang.runtime.linux-arm64.nuspec
+++ b/packages/libclang.runtime.linux-arm64/libclang.runtime.linux-arm64.nuspec
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
-    <id>runtime.sles-x64.libclang</id>
+    <id>libclang.runtime.linux-arm64</id>
     <version>8.0.0</version>
     <authors>Microsoft and Contributors</authors>
     <owners>Microsoft and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/microsoft/clangsharp</projectUrl>
-    <description>sles x64 native library for libclang.</description>
+    <description>linux arm64 native library for libclang.</description>
     <copyright>Copyright © University of Illinois at Urbana-Champaign</copyright>
     <repository type="git" url="https://github.com/llvm-mirror/clang" branch="release_80" />
   </metadata>
   <files>
     <file src="..\libclang\LICENSE.TXT" target="LICENSE.TXT" />
-    <file src="runtimes\sles-x64\native\libclang.so" target="runtimes\sles-x64\native\libclang.so" />
+    <file src="runtimes\linux-arm64\native\libclang.so" target="runtimes\linux-arm64\native\libclang.so" />
   </files>
 </package>

--- a/packages/libclang.runtime.osx-x64/libclang.runtime.osx-x64.nuspec
+++ b/packages/libclang.runtime.osx-x64/libclang.runtime.osx-x64.nuspec
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
-    <id>runtime.freebsd.11-x64.libclang</id>
+    <id>libclang.runtime.osx-x64</id>
     <version>8.0.0</version>
     <authors>Microsoft and Contributors</authors>
     <owners>Microsoft and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/microsoft/clangsharp</projectUrl>
-    <description>freebsd 11 x64 native library for libclang.</description>
+    <description>osx x64 native library for libclang.</description>
     <copyright>Copyright © University of Illinois at Urbana-Champaign</copyright>
     <repository type="git" url="https://github.com/llvm-mirror/clang" branch="release_80" />
   </metadata>
   <files>
     <file src="..\libclang\LICENSE.TXT" target="LICENSE.TXT" />
-    <file src="runtimes\freebsd.11-x64\native\libclang.so" target="runtimes\freebsd.11-x64\native\libclang.so" />
+    <file src="runtimes\osx-x64\native\libclang.dylib" target="runtimes\osx-x64\native\libclang.dylib" />
   </files>
 </package>

--- a/packages/libclang.runtime.sles-x64/libclang.runtime.sles-x64.nuspec
+++ b/packages/libclang.runtime.sles-x64/libclang.runtime.sles-x64.nuspec
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
-    <id>runtime.linux-arm64.libclang</id>
+    <id>libclang.runtime.sles-x64</id>
     <version>8.0.0</version>
     <authors>Microsoft and Contributors</authors>
     <owners>Microsoft and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/microsoft/clangsharp</projectUrl>
-    <description>linux arm64 native library for libclang.</description>
+    <description>sles x64 native library for libclang.</description>
     <copyright>Copyright © University of Illinois at Urbana-Champaign</copyright>
     <repository type="git" url="https://github.com/llvm-mirror/clang" branch="release_80" />
   </metadata>
   <files>
     <file src="..\libclang\LICENSE.TXT" target="LICENSE.TXT" />
-    <file src="runtimes\linux-arm64\native\libclang.so" target="runtimes\linux-arm64\native\libclang.so" />
+    <file src="runtimes\sles-x64\native\libclang.so" target="runtimes\sles-x64\native\libclang.so" />
   </files>
 </package>

--- a/packages/libclang.runtime.ubuntu.14.04-x64/libclang.runtime.ubuntu.14.04-x64.nuspec
+++ b/packages/libclang.runtime.ubuntu.14.04-x64/libclang.runtime.ubuntu.14.04-x64.nuspec
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
-    <id>runtime.ubuntu.16.04-x64.libclang</id>
+    <id>libclang.runtime.ubuntu.14.04-x64</id>
     <version>8.0.0</version>
     <authors>Microsoft and Contributors</authors>
     <owners>Microsoft and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/microsoft/clangsharp</projectUrl>
-    <description>ubuntu 16.04 x64 native library for libclang.</description>
+    <description>ubuntu 14.04 x64 native library for libclang.</description>
     <copyright>Copyright © University of Illinois at Urbana-Champaign</copyright>
     <repository type="git" url="https://github.com/llvm-mirror/clang" branch="release_80" />
   </metadata>
   <files>
     <file src="..\libclang\LICENSE.TXT" target="LICENSE.TXT" />
-    <file src="runtimes\ubuntu.16.04-x64\native\libclang.so" target="runtimes\ubuntu.16.04-x64\native\libclang.so" />
+    <file src="runtimes\ubuntu.14.04-x64\native\libclang.so" target="runtimes\ubuntu.14.04-x64\native\libclang.so" />
   </files>
 </package>

--- a/packages/libclang.runtime.ubuntu.16.04-x64/libclang.runtime.ubuntu.16.04-x64.nuspec
+++ b/packages/libclang.runtime.ubuntu.16.04-x64/libclang.runtime.ubuntu.16.04-x64.nuspec
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
-    <id>runtime.win-x64.libclang</id>
+    <id>libclang.runtime.ubuntu.16.04-x64</id>
     <version>8.0.0</version>
     <authors>Microsoft and Contributors</authors>
     <owners>Microsoft and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/microsoft/clangsharp</projectUrl>
-    <description>win x64 native library for libclang.</description>
+    <description>ubuntu 16.04 x64 native library for libclang.</description>
     <copyright>Copyright © University of Illinois at Urbana-Champaign</copyright>
     <repository type="git" url="https://github.com/llvm-mirror/clang" branch="release_80" />
   </metadata>
   <files>
     <file src="..\libclang\LICENSE.TXT" target="LICENSE.TXT" />
-    <file src="runtimes\win-x64\native\libclang.dll" target="runtimes\win-x64\native\libclang.dll" />
+    <file src="runtimes\ubuntu.16.04-x64\native\libclang.so" target="runtimes\ubuntu.16.04-x64\native\libclang.so" />
   </files>
 </package>

--- a/packages/libclang.runtime.ubuntu.18.04-x64/libclang.runtime.ubuntu.18.04-x64.nuspec
+++ b/packages/libclang.runtime.ubuntu.18.04-x64/libclang.runtime.ubuntu.18.04-x64.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
-    <id>runtime.ubuntu.18.04-x64.libclang</id>
+    <id>libclang.runtime.ubuntu.18.04-x64</id>
     <version>8.0.0</version>
     <authors>Microsoft and Contributors</authors>
     <owners>Microsoft and Contributors</owners>

--- a/packages/libclang.runtime.win-x64/libclang.runtime.win-x64.nuspec
+++ b/packages/libclang.runtime.win-x64/libclang.runtime.win-x64.nuspec
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
-    <id>runtime.linux-arm.libclang</id>
+    <id>libclang.runtime.win-x64</id>
     <version>8.0.0</version>
     <authors>Microsoft and Contributors</authors>
     <owners>Microsoft and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/microsoft/clangsharp</projectUrl>
-    <description>linux arm native library for libclang.</description>
+    <description>win x64 native library for libclang.</description>
     <copyright>Copyright © University of Illinois at Urbana-Champaign</copyright>
     <repository type="git" url="https://github.com/llvm-mirror/clang" branch="release_80" />
   </metadata>
   <files>
     <file src="..\libclang\LICENSE.TXT" target="LICENSE.TXT" />
-    <file src="runtimes\linux-arm\native\libclang.so" target="runtimes\linux-arm\native\libclang.so" />
+    <file src="runtimes\win-x64\native\libclang.dll" target="runtimes\win-x64\native\libclang.dll" />
   </files>
 </package>

--- a/packages/libclang.runtime.win-x86/libclang.runtime.win-x86.nuspec
+++ b/packages/libclang.runtime.win-x86/libclang.runtime.win-x86.nuspec
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
-    <id>runtime.ubuntu.14.04-x64.libclang</id>
+    <id>libclang.runtime.win-x86</id>
     <version>8.0.0</version>
     <authors>Microsoft and Contributors</authors>
     <owners>Microsoft and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/microsoft/clangsharp</projectUrl>
-    <description>ubuntu 14.04 x64 native library for libclang.</description>
+    <description>win x86 native library for libclang.</description>
     <copyright>Copyright © University of Illinois at Urbana-Champaign</copyright>
     <repository type="git" url="https://github.com/llvm-mirror/clang" branch="release_80" />
   </metadata>
   <files>
     <file src="..\libclang\LICENSE.TXT" target="LICENSE.TXT" />
-    <file src="runtimes\ubuntu.14.04-x64\native\libclang.so" target="runtimes\ubuntu.14.04-x64\native\libclang.so" />
+    <file src="runtimes\win-x86\native\libclang.dll" target="runtimes\win-x86\native\libclang.dll" />
   </files>
 </package>

--- a/packages/libclang/runtime.json
+++ b/packages/libclang/runtime.json
@@ -2,57 +2,57 @@
   "runtimes": {
     "freebsd.11-x64": {
       "libclang": {
-        "runtime.freebsd.11-x64.libclang": "8.0.0"
+        "libclang.runtime.freebsd.11-x64": "8.0.0"
       }
     },
     "freebsd.11-x86": {
       "libclang": {
-        "runtime.freebsd.11-x86.libclang": "8.0.0"
+        "libclang.runtime.freebsd.11-x86": "8.0.0"
       }
     },
     "linux-arm": {
       "libclang": {
-        "runtime.linux-arm.libclang": "8.0.0"
+        "libclang.runtime.linux-arm": "8.0.0"
       }
     },
     "linux-arm64": {
       "libclang": {
-        "runtime.linux-arm64.libclang": "8.0.0"
+        "libclang.runtime.linux-arm64": "8.0.0"
       }
     },
     "osx-x64": {
       "libclang": {
-        "runtime.osx-x64.libclang": "8.0.0"
+        "libclang.runtime.osx-x64": "8.0.0"
       }
     },
     "sles-x64": {
       "libclang": {
-        "runtime.sles-x64.libclang": "8.0.0"
+        "libclang.runtime.sles-x64": "8.0.0"
       }
     },
     "ubuntu.14.04-x64": {
       "libclang": {
-        "runtime.ubuntu.14.04-x64.libclang": "8.0.0"
+        "libclang.runtime.ubuntu.14.04-x64": "8.0.0"
       }
     },
     "ubuntu.16.04-x64": {
       "libclang": {
-        "runtime.ubuntu.16.04-x64.libclang": "8.0.0"
+        "libclang.runtime.ubuntu.16.04-x64": "8.0.0"
       }
     },
     "ubuntu.18.04-x64": {
       "libclang": {
-        "runtime.ubuntu.18.04-x64.libclang": "8.0.0"
+        "libclang.runtime.ubuntu.18.04-x64": "8.0.0"
       }
     },
     "win-x64": {
       "libclang": {
-        "runtime.win-x64.libclang": "8.0.0"
+        "libclang.runtime.win-x64": "8.0.0"
       }
     },
     "win-x86": {
       "libclang": {
-        "runtime.win-x86.libclang": "8.0.0"
+        "libclang.runtime.win-x86": "8.0.0"
       }
     }
   }


### PR DESCRIPTION
The runtime prefix is reserved by nuget.