### PR TITLE
Updating libclang to use the new 8.0.0 package.

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -27,7 +27,7 @@
 
   <!-- Package versions for package references across all projects -->
   <ItemGroup>
-    <PackageReference Update="libClang" Version="5.0.0" NoWarn="NU1701" />
+    <PackageReference Update="libclang" Version="8.0.0" />
     <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="3.2.0-beta1-final" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Update="System.CommandLine.Experimental" Version="0.2.0-alpha.19174.3" />

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -52,6 +52,8 @@ jobs:
 - job: ubuntu_1604_debug_x64
   pool:
     name: Hosted Ubuntu 1604
+  variables:
+    RuntimeIdentifier: ubuntu.16.04-x64
   steps:
   - task: Bash@3
     displayName: 'Run scripts/cibuild.sh'
@@ -63,6 +65,8 @@ jobs:
 - job: ubuntu_1604_release_x64
   pool:
     name: Hosted Ubuntu 1604
+  variables:
+    RuntimeIdentifier: ubuntu.16.04-x64
   steps:
   - task: Bash@3
     displayName: 'Run scripts/cibuild.sh'


### PR DESCRIPTION
This looks to require a fix to the ubuntu 16.04 images as they are missing a dependency.