### PR TITLE
Minor improvements for type handling.

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -654,7 +654,7 @@ namespace ClangSharp
 
                     case CXTypeKind.CXType_ULong:
                     {
-                        name = "uint";
+                        name = _config.GenerateUnixTypes ? "UIntPtr" : "uint";
                         break;
                     }
 
@@ -673,7 +673,7 @@ namespace ClangSharp
 
                     case CXTypeKind.CXType_WChar:
                     {
-                        name = "char";
+                        name = _config.GenerateUnixTypes ? "int" : "char";
                         break;
                     }
 
@@ -691,7 +691,7 @@ namespace ClangSharp
 
                     case CXTypeKind.CXType_Long:
                     {
-                        name = "int";
+                        name = _config.GenerateUnixTypes ? "IntPtr" : "int";
                         break;
                     }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -734,32 +734,17 @@ namespace ClangSharp
             }
             else if (type is TypedefType typedefType)
             {
-                // We intercept some well known types that have variable sizes
-                // to ensure that we can treat them correctly. Otherwise, they
-                // will resolve to a particular platform size, based on whatever
-                // parameters were passed into clang.
+                // We check remapped names here so that types that have variable sizes
+                // can be treated correctly. Otherwise, they will resolve to a particular
+                // platform size, based on whatever parameters were passed into clang.
 
-                switch (name)
+                if (_config.RemappedNames.TryGetValue(name, out string remappedName))
                 {
-                    case "intptr_t":
-                    case "ptrdiff_t":
-                    {
-                        name = "IntPtr";
-                        break;
-                    }
-
-                    case "size_t":
-                    case "uintptr_t":
-                    {
-                        name = "UIntPtr";
-                        break;
-                    }
-
-                    default:
-                    {
-                        name = GetTypeName(namedDecl, typedefType.Decl.UnderlyingType, out var nativeUnderlyingTypeName);
-                        break;
-                    }
+                    name = remappedName;
+                }
+                else
+                {
+                    name = GetTypeName(namedDecl, typedefType.Decl.UnderlyingType, out var nativeUnderlyingTypeName);
                 }
             }
             else if (!(type is FunctionType) && !(type is TagType))

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -7,6 +7,7 @@ namespace ClangSharp
     {
         private const string DefaultMethodClassName = "Methods";
 
+        private readonly Dictionary<string, string> _remappedNames;
         private readonly PInvokeGeneratorConfigurationOptions _options;
 
         public PInvokeGeneratorConfiguration(string libraryPath, string namespaceName, string outputLocation, PInvokeGeneratorConfigurationOptions options = PInvokeGeneratorConfigurationOptions.None, string[] excludedNames = null, string methodClassName = null, string methodPrefixToStrip = null, IReadOnlyDictionary<string, string> remappedNames = null)
@@ -41,11 +42,6 @@ namespace ClangSharp
                 throw new ArgumentNullException(nameof(outputLocation));
             }
 
-            if (remappedNames is null)
-            {
-                remappedNames = new Dictionary<string, string>();
-            }
-
             _options = options;
 
             ExcludedNames = excludedNames;
@@ -54,7 +50,24 @@ namespace ClangSharp
             MethodPrefixToStrip = methodPrefixToStrip;
             Namespace = namespaceName;
             OutputLocation = outputLocation;
-            RemappedNames = remappedNames;
+
+            _remappedNames = new Dictionary<string, string>()
+            {
+                ["intptr_t"] = "IntPtr",
+                ["ptrdiff_t"] = "IntPtr",
+                ["size_t"] = "UIntPtr",
+                ["uintptr_t"] = "UIntPtr",
+            };
+
+            if (remappedNames != null)
+            {
+                foreach (var remappedName in remappedNames)
+                {
+                    // Use the indexer, rather than Add, so that any
+                    // default mappings can be overwritten if desired.
+                    _remappedNames[remappedName.Key] = remappedName.Value;
+                }
+            }
         }
 
         public string[] ExcludedNames { get; }
@@ -71,6 +84,6 @@ namespace ClangSharp
 
         public string OutputLocation { get; }
 
-        public IReadOnlyDictionary<string, string> RemappedNames { get; }
+        public IReadOnlyDictionary<string, string> RemappedNames => _remappedNames;
     }
 }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -74,6 +74,8 @@ namespace ClangSharp
 
         public bool GenerateMultipleFiles => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateMultipleFiles);
 
+        public bool GenerateUnixTypes => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateUnixTypes);
+
         public string LibraryPath { get;}
 
         public string MethodClassName { get; }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
@@ -8,5 +8,7 @@ namespace ClangSharp
         None = 0x00000000,
 
         GenerateMultipleFiles = 0x00000001,
+
+        GenerateUnixTypes = 0x00000002,
     }
 }

--- a/sources/ClangSharp/TranslationUnit.cs
+++ b/sources/ClangSharp/TranslationUnit.cs
@@ -53,15 +53,7 @@ namespace ClangSharp
                         translationUnit = new TranslationUnit(handle);
                         _createdTranslationUnits.Add(handle, translationUnit);
                     }
-                    else
-                    {
-                        System.Diagnostics.Debugger.Break();
-                    }
                 }
-            }
-            else
-            {
-                System.Diagnostics.Debugger.Break();
             }
 
             return translationUnit;

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using ClangSharp.Interop;
 
@@ -87,7 +88,7 @@ namespace ClangSharp
                 remappedNames[parts[0].TrimEnd()] = parts[1].TrimStart();
             }
 
-            var configOptions = PInvokeGeneratorConfigurationOptions.None;
+            var configOptions = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? PInvokeGeneratorConfigurationOptions.None : PInvokeGeneratorConfigurationOptions.GenerateUnixTypes;
 
             foreach (var configSwitch in configSwitches)
             {

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -87,6 +87,44 @@ namespace ClangSharp
                 remappedNames[parts[0].TrimEnd()] = parts[1].TrimStart();
             }
 
+            var configOptions = PInvokeGeneratorConfigurationOptions.None;
+
+            foreach (var configSwitch in configSwitches)
+            {
+                switch (configSwitch)
+                {
+                    case "multi-file":
+                    {
+                        configOptions |= PInvokeGeneratorConfigurationOptions.GenerateMultipleFiles;
+                        break;
+                    }
+
+                    case "single-file":
+                    {
+                        configOptions &= ~PInvokeGeneratorConfigurationOptions.GenerateMultipleFiles;
+                        break;
+                    }
+
+                    case "unix-types":
+                    {
+                        configOptions |= PInvokeGeneratorConfigurationOptions.GenerateUnixTypes;
+                        break;
+                    }
+
+                    case "windows-types":
+                    {
+                        configOptions &= ~PInvokeGeneratorConfigurationOptions.GenerateUnixTypes;
+                        break;
+                    }
+
+                    default:
+                    {
+                        errorList.Add($"Error: Unrecognized config switch: {configSwitch}.");
+                        break;
+                    }
+                }
+            }
+
             if (errorList.Any())
             {
                 foreach (var error in errorList)
@@ -114,16 +152,6 @@ namespace ClangSharp
 
             translationFlags |= CXTranslationUnit_Flags.CXTranslationUnit_IncludeAttributedTypes;               // Include attributed types in CXType
             translationFlags |= CXTranslationUnit_Flags.CXTranslationUnit_VisitImplicitAttributes;              // Implicit attributes should be visited
-
-            var configOptions = PInvokeGeneratorConfigurationOptions.None;
-
-            foreach (var configSwitch in configSwitches)
-            {
-                if (configSwitch.Equals("multi-file"))
-                {
-                    configOptions |= PInvokeGeneratorConfigurationOptions.GenerateMultipleFiles;
-                }
-            }
 
             var config = new PInvokeGeneratorConfiguration(libraryPath, namespaceName, outputLocation, configOptions, excludedNames, methodClassName, methodPrefixToStrip, remappedNames);
 


### PR DESCRIPTION
This updates the PInvokeGenerator to:
* Handle attributed types, which frequently comes up for function pointers in some Windows headers
* Check for remapped names when processing typedefs. This allows users to handle things like `SIZE_T`, in the same manner as we were handling `size_t`.
* Adds a config switch for generating "unix-sized types". So, for example, `long` will emit `IntPtr` rather than `int`
* Adds "reverse" config switches so users can explicitly specify the behavior they want (last specified switch wins, for a given pair)
* Defaults to generating "unix-sized types" on Unix and "windows-sized types" on Windows