### PR TITLE
Some more minor improvements

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -175,9 +175,22 @@ namespace ClangSharp
 
             foreach (var decl in translationUnitDecl.Decls)
             {
-                if (!decl.IsFromMainFile)
+                if (_config.TraversalNames.Length == 0)
                 {
-                    continue;
+                    if (!decl.Location.IsFromMainFile)
+                    {
+                        continue;
+                    }
+                }
+                else
+                {
+                    decl.Location.GetFileLocation(out CXFile file, out _, out _, out _);
+                    var fileName = file.Name.ToString();
+
+                    if (!_config.TraversalNames.Contains(fileName))
+                    {
+                        continue;
+                    }
                 }
                 Visit(decl);
             }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace ClangSharp
 {
@@ -49,7 +50,7 @@ namespace ClangSharp
             MethodClassName = methodClassName;
             MethodPrefixToStrip = methodPrefixToStrip;
             Namespace = namespaceName;
-            OutputLocation = outputLocation;
+            OutputLocation = Path.GetFullPath(outputLocation);
 
             if (!_options.HasFlag(PInvokeGeneratorConfigurationOptions.NoDefaultRemappings))
             {

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -51,13 +51,16 @@ namespace ClangSharp
             Namespace = namespaceName;
             OutputLocation = outputLocation;
 
-            _remappedNames = new Dictionary<string, string>()
+            if (!_options.HasFlag(PInvokeGeneratorConfigurationOptions.NoDefaultRemappings))
             {
-                ["intptr_t"] = "IntPtr",
-                ["ptrdiff_t"] = "IntPtr",
-                ["size_t"] = "UIntPtr",
-                ["uintptr_t"] = "UIntPtr",
-            };
+                _remappedNames = new Dictionary<string, string>()
+                {
+                    ["intptr_t"] = "IntPtr",
+                    ["ptrdiff_t"] = "IntPtr",
+                    ["size_t"] = "UIntPtr",
+                    ["uintptr_t"] = "UIntPtr",
+                };
+            }
 
             if (remappedNames != null)
             {

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -11,7 +11,7 @@ namespace ClangSharp
         private readonly Dictionary<string, string> _remappedNames;
         private readonly PInvokeGeneratorConfigurationOptions _options;
 
-        public PInvokeGeneratorConfiguration(string libraryPath, string namespaceName, string outputLocation, PInvokeGeneratorConfigurationOptions options = PInvokeGeneratorConfigurationOptions.None, string[] excludedNames = null, string methodClassName = null, string methodPrefixToStrip = null, IReadOnlyDictionary<string, string> remappedNames = null)
+        public PInvokeGeneratorConfiguration(string libraryPath, string namespaceName, string outputLocation, PInvokeGeneratorConfigurationOptions options = PInvokeGeneratorConfigurationOptions.None, string[] excludedNames = null, string methodClassName = null, string methodPrefixToStrip = null, IReadOnlyDictionary<string, string> remappedNames = null, string[] traversalNames = null)
         {
             if (excludedNames is null)
             {
@@ -43,6 +43,11 @@ namespace ClangSharp
                 throw new ArgumentNullException(nameof(outputLocation));
             }
 
+            if (traversalNames is null)
+            {
+                traversalNames = Array.Empty<string>();
+            }
+
             _options = options;
 
             ExcludedNames = excludedNames;
@@ -51,6 +56,7 @@ namespace ClangSharp
             MethodPrefixToStrip = methodPrefixToStrip;
             Namespace = namespaceName;
             OutputLocation = Path.GetFullPath(outputLocation);
+            TraversalNames = traversalNames;
 
             if (!_options.HasFlag(PInvokeGeneratorConfigurationOptions.NoDefaultRemappings))
             {
@@ -91,5 +97,7 @@ namespace ClangSharp
         public string OutputLocation { get; }
 
         public IReadOnlyDictionary<string, string> RemappedNames => _remappedNames;
+
+        public string[] TraversalNames { get; }
     }
 }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
@@ -10,5 +10,7 @@ namespace ClangSharp
         GenerateMultipleFiles = 0x00000001,
 
         GenerateUnixTypes = 0x00000002,
+
+        NoDefaultRemappings = 0x00000004,
     }
 }

--- a/sources/ClangSharp/Cursors/Cursor.cs
+++ b/sources/ClangSharp/Cursors/Cursor.cs
@@ -42,8 +42,6 @@ namespace ClangSharp
 
         public CXCursor Handle { get; }
 
-        public bool IsFromMainFile => Location.IsFromMainFile;
-
         public CXCursorKind Kind => Handle.Kind;
 
         public string KindSpelling => Handle.KindSpelling.ToString();

--- a/sources/ClangSharp/Cursors/Exprs/BinaryOperator.cs
+++ b/sources/ClangSharp/Cursors/Exprs/BinaryOperator.cs
@@ -28,75 +28,13 @@ namespace ClangSharp
 
         protected virtual string GetOpcode()
         {
-            var tokens = Handle.TranslationUnit.Tokenize(Extent);
+            var lhsTokens = Handle.TranslationUnit.Tokenize(LHS.Extent);
 
+            var tokens = Handle.TranslationUnit.Tokenize(Extent);
             Debug.Assert(tokens.Length >= 3);
 
-            int operatorIndex = -1;
-            int parenDepth = 0;
+            int operatorIndex = lhsTokens.Length;
 
-            for (int index = 0; (index < tokens.Length) && (operatorIndex == -1); index++)
-            {
-                var token = tokens[index];
-
-                if (token.Kind != CXTokenKind.CXToken_Punctuation)
-                {
-                    continue;
-                }
-
-                var punctuation = tokens[index].GetSpelling(Handle.TranslationUnit).ToString();
-
-                switch (punctuation)
-                {
-                    case "!=":
-                    case "%":
-                    case "&":
-                    case "&&":
-                    case "*":
-                    case "+":
-                    case "-":
-                    case "/":
-                    case "<":
-                    case "<<":
-                    case "<=":
-                    case "=":
-                    case "==":
-                    case ">":
-                    case ">>":
-                    case ">=":
-                    case "^":
-                    case "|":
-                    case "||":
-                    {
-                        if (parenDepth == 0)
-                        {
-                            operatorIndex = index;
-                        }
-                        break;
-                    }
-
-                    case "(":
-                    {
-                        parenDepth++;
-                        break;
-                    }
-
-                    case ")":
-                    {
-                        parenDepth--;
-                        break;
-                    }
-
-                    default:
-                    {
-                        Debug.WriteLine($"Unhandled punctuation kind: {punctuation}.");
-                        Debugger.Break();
-                        break;
-                    }
-                }
-            }
-
-            Debug.Assert(operatorIndex != -1);
             Debug.Assert(tokens[operatorIndex].Kind == CXTokenKind.CXToken_Punctuation);
             return tokens[operatorIndex].GetSpelling(Handle.TranslationUnit).ToString();
         }

--- a/sources/ClangSharp/Cursors/Exprs/UnaryOperator.cs
+++ b/sources/ClangSharp/Cursors/Exprs/UnaryOperator.cs
@@ -26,77 +26,15 @@ namespace ClangSharp
 
         private (string Opcode, bool IsPrefix) GetOpcode()
         {
-            var tokens = Handle.TranslationUnit.Tokenize(Extent);
+            var subExprTokens = Handle.TranslationUnit.Tokenize(SubExpr.Extent);
 
+            var tokens = Handle.TranslationUnit.Tokenize(Extent);
             Debug.Assert(tokens.Length >= 2);
 
-            int operatorIndex = -1;
-            int parenDepth = 0;
-            bool isPrefix = false;
+            bool isPrefix = tokens[0] != subExprTokens[0];
+            int operatorIndex = isPrefix ? 0 : subExprTokens.Length;
 
-            for (int index = 0; (index < tokens.Length) && (operatorIndex == -1); index++)
-            {
-                var token = tokens[index];
-
-                if (token.Kind != CXTokenKind.CXToken_Punctuation)
-                {
-                    continue;
-                }
-
-                var punctuation = tokens[index].GetSpelling(Handle.TranslationUnit).ToString();
-
-                switch (punctuation)
-                {
-                    case "!":
-                    case "&":
-                    case "*":
-                    case "+":
-                    case "-":
-                    case "~":
-                    {
-                        if (parenDepth == 0)
-                        {
-                            operatorIndex = index;
-                            isPrefix = true;
-                        }
-                        break;
-                    }
-
-                    case "(":
-                    {
-                        parenDepth++;
-                        break;
-                    }
-
-                    case ")":
-                    {
-                        parenDepth--;
-                        break;
-                    }
-
-                    case "++":
-                    case "--":
-                    {
-                        if (parenDepth == 0)
-                        {
-                            operatorIndex = index;
-                            isPrefix = ((index + 1) != tokens.Length);
-                        }
-                        break;
-                    }
-
-                    default:
-                    {
-                        Debug.WriteLine($"Unhandled punctuation kind: {punctuation}.");
-                        Debugger.Break();
-                        break;
-                    }
-                }
-            }
-
-            Debug.Assert(operatorIndex != -1);
             Debug.Assert(tokens[operatorIndex].Kind == CXTokenKind.CXToken_Punctuation);
-
             var opcode = tokens[operatorIndex].GetSpelling(Handle.TranslationUnit).ToString();
             return (opcode, isPrefix);
         }

--- a/sources/ClangSharp/Interop.Extensions/CXToken.cs
+++ b/sources/ClangSharp/Interop.Extensions/CXToken.cs
@@ -1,13 +1,41 @@
+using System;
+
 namespace ClangSharp.Interop
 {
-    public unsafe partial struct CXToken
+    public unsafe partial struct CXToken : IEquatable<CXToken>
     {
         public CXTokenKind Kind => clang.getTokenKind(this);
 
+        public static bool operator ==(CXToken left, CXToken right)
+        {
+            return (left.int_data[0] == right.int_data[0]) &&
+                   (left.int_data[1] == right.int_data[1]) &&
+                   (left.int_data[2] == right.int_data[2]) &&
+                   (left.int_data[3] == right.int_data[3]) &&
+                   (left.ptr_data == right.ptr_data);
+        }
+
+        public static bool operator !=(CXToken left, CXToken right)
+        {
+            return (left.int_data[0] != right.int_data[0]) ||
+                   (left.int_data[1] != right.int_data[1]) ||
+                   (left.int_data[2] != right.int_data[2]) ||
+                   (left.int_data[3] != right.int_data[3]) ||
+                   (left.ptr_data != right.ptr_data);
+        }
+
+        public override bool Equals(object obj) => (obj is CXSourceRange other) && Equals(other);
+
+        public bool Equals(CXToken other) => this == other;
+
         public CXSourceRange GetExtent(CXTranslationUnit translationUnit) => clang.getTokenExtent(translationUnit, this);
+
+        public override int GetHashCode() => HashCode.Combine(int_data[0], int_data[1], int_data[2], int_data[3], (IntPtr)ptr_data);
 
         public CXSourceLocation GetLocation(CXTranslationUnit translationUnit) => clang.getTokenLocation(translationUnit, this);
 
         public CXString GetSpelling(CXTranslationUnit translationUnit) => clang.getTokenSpelling(translationUnit, this);
+
+        public override string ToString() => "";
     }
 }

--- a/sources/ClangSharp/Interop.Extensions/CXUnsavedFile.cs
+++ b/sources/ClangSharp/Interop.Extensions/CXUnsavedFile.cs
@@ -2,6 +2,12 @@ using System;
 using System.Runtime.InteropServices;
 using System.Text;
 
+#if Windows_NT
+using nulong = System.UInt32;
+#else
+using nulong = System.UIntPtr;
+#endif
+
 namespace ClangSharp.Interop
 {
     public unsafe partial struct CXUnsavedFile : IDisposable
@@ -43,7 +49,7 @@ namespace ClangSharp.Interop
             {
                 Filename = (sbyte*)pFilename,
                 Contents = (sbyte*)pContents,
-                Length = (uint)contentsLength
+                Length = (nulong)contentsLength
             };
         }
 
@@ -59,7 +65,7 @@ namespace ClangSharp.Interop
             {
                 Marshal.FreeHGlobal((IntPtr)Contents);
                 Contents = null;
-                Length = 0;
+                Length = (nulong)0;
             }
         }
 

--- a/sources/ClangSharp/Interop/CXTUResourceUsageEntry.cs
+++ b/sources/ClangSharp/Interop/CXTUResourceUsageEntry.cs
@@ -1,3 +1,10 @@
+#if Windows_NT
+using nulong = System.UInt32;
+#else
+using System;
+using nulong = System.UIntPtr;
+#endif
+
 namespace ClangSharp.Interop
 {
     public partial struct CXTUResourceUsageEntry
@@ -6,6 +13,6 @@ namespace ClangSharp.Interop
         public CXTUResourceUsageKind kind;
 
         [NativeTypeName("unsigned long")]
-        public uint amount;
+        public nulong amount;
     }
 }

--- a/sources/ClangSharp/Interop/CXUnsavedFile.cs
+++ b/sources/ClangSharp/Interop/CXUnsavedFile.cs
@@ -1,3 +1,10 @@
+#if Windows_NT
+using nulong = System.UInt32;
+#else
+using System;
+using nulong = System.UIntPtr;
+#endif
+
 namespace ClangSharp.Interop
 {
     public unsafe partial struct CXUnsavedFile
@@ -9,6 +16,6 @@ namespace ClangSharp.Interop
         public sbyte* Contents;
 
         [NativeTypeName("unsigned long")]
-        public uint Length;
+        public nulong Length;
     }
 }

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -32,6 +32,7 @@ namespace ClangSharp
                 AddOutputOption(s_rootCommand);
                 AddPrefixStripOption(s_rootCommand);
                 AddRemapOption(s_rootCommand);
+                AddTraverseOption(s_rootCommand);
             }
             return await s_rootCommand.InvokeAsync(args);
         }
@@ -50,6 +51,7 @@ namespace ClangSharp
             var namespaceName = context.ParseResult.ValueForOption<string>("namespace");
             var outputLocation = context.ParseResult.ValueForOption<string>("output");
             var remappedNameValuePairs = context.ParseResult.ValueForOption<string[]>("remap");
+            var traversalNames = context.ParseResult.ValueForOption<string[]>("traverse");
 
             var errorList = new List<string>();
 
@@ -166,7 +168,7 @@ namespace ClangSharp
             translationFlags |= CXTranslationUnit_Flags.CXTranslationUnit_IncludeAttributedTypes;               // Include attributed types in CXType
             translationFlags |= CXTranslationUnit_Flags.CXTranslationUnit_VisitImplicitAttributes;              // Implicit attributes should be visited
 
-            var config = new PInvokeGeneratorConfiguration(libraryPath, namespaceName, outputLocation, configOptions, excludedNames, methodClassName, methodPrefixToStrip, remappedNames);
+            var config = new PInvokeGeneratorConfiguration(libraryPath, namespaceName, outputLocation, configOptions, excludedNames, methodClassName, methodPrefixToStrip, remappedNames, traversalNames);
 
             int exitCode = 0;
 
@@ -423,6 +425,22 @@ namespace ClangSharp
 
             var option = new Option("--remap", "A declaration name to be remapped to another name during binding generation.", argument);
             option.AddAlias("-r");
+
+            rootCommand.AddOption(option);
+        }
+
+        private static void AddTraverseOption(RootCommand rootCommand)
+        {
+            var argument = new Argument
+            {
+                ArgumentType = typeof(string),
+                Arity = ArgumentArity.OneOrMore,
+                Name = "name"
+            };
+            argument.SetDefaultValue(Array.Empty<string>());
+
+            var option = new Option("--traverse", "A file name included either directly or indirectly by -f that should be traversed during binding generation.", argument);
+            option.AddAlias("-t");
 
             rootCommand.AddOption(option);
         }

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -94,9 +94,21 @@ namespace ClangSharp
             {
                 switch (configSwitch)
                 {
+                    case "default-remappings":
+                    {
+                        configOptions &= ~PInvokeGeneratorConfigurationOptions.NoDefaultRemappings;
+                        break;
+                    }
+
                     case "multi-file":
                     {
                         configOptions |= PInvokeGeneratorConfigurationOptions.GenerateMultipleFiles;
+                        break;
+                    }
+
+                    case "no-default-remappings":
+                    {
+                        configOptions |= PInvokeGeneratorConfigurationOptions.NoDefaultRemappings;
                         break;
                     }
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
@@ -145,6 +145,48 @@ void MyFunction()
         }
 
         [Fact]
+        public async Task CompareMultipleEnumTest()
+        {
+            var inputContents = @"enum MyEnum : int
+{
+    MyEnum_Value0,
+    MyEnum_Value1,
+    MyEnum_Value2,
+};
+
+static inline int MyFunction(MyEnum x)
+{
+    return x == MyEnum_Value0 ||
+           x == MyEnum_Value1 ||
+           x == MyEnum_Value2;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public enum MyEnum
+    {
+        MyEnum_Value0,
+        MyEnum_Value1,
+        MyEnum_Value2,
+    }
+
+    public static partial class Methods
+    {
+        private const string libraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction(MyEnum x)
+        {
+            return x == MyEnum_Value0 || x == MyEnum_Value1 || x == MyEnum_Value2;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
         public async Task ReturnIntegerTest()
         {
             var inputContents = @"int MyFunction()


### PR DESCRIPTION
* Adds a config switch to ignore any default remappings added.
* Resolves the full path of `-o` so that `-o file.cs` works (it was creating a directory with that name currently)
* Adds a `--traverse` option so that you can `-f header.cs` and then generate bindings for a nested include
  * This is useful when you need to generate bindings for a header file which isn't "standalone"
* Fixes `CXUnsavedFile` and `CXTUResourceUsageEntry` to use `uint` on Windows and `UIntPtr` on Unix for their `unsigned long` usages
  * Going to log an issue tracking a general purpose solution for this, so it isn't manual