### PR TITLE
Always write headers and check against empty paths

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -268,20 +268,25 @@ namespace ClangSharp
             using var sw = new StreamWriter(stream, defaultStreamWriterEncoding, DefaultStreamWriterBufferSize, leaveStreamOpen);
             sw.NewLine = "\n";
 
-            if (_config.HeaderText != string.Empty && !isMethodClass)
-                sw.WriteLine(_config.HeaderText);
-
-            if (outputBuilder.UsingDirectives.Any() && _config.GenerateMultipleFiles)
+            if (_config.GenerateMultipleFiles)
             {
-                foreach (var usingDirective in outputBuilder.UsingDirectives)
+                if (_config.HeaderText != string.Empty)
                 {
-                    sw.Write("using");
-                    sw.Write(' ');
-                    sw.Write(usingDirective);
-                    sw.WriteLine(';');
+                    sw.WriteLine(_config.HeaderText);
                 }
 
-                sw.WriteLine();
+                if (outputBuilder.UsingDirectives.Any())
+                {
+                    foreach (var usingDirective in outputBuilder.UsingDirectives)
+                    {
+                        sw.Write("using");
+                        sw.Write(' ');
+                        sw.Write(usingDirective);
+                        sw.WriteLine(';');
+                    }
+
+                    sw.WriteLine();
+                }
             }
 
             var indentationString = outputBuilder.IndentationString;

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -268,7 +268,7 @@ namespace ClangSharp
             using var sw = new StreamWriter(stream, defaultStreamWriterEncoding, DefaultStreamWriterBufferSize, leaveStreamOpen);
             sw.NewLine = "\n";
 
-            if (_config.HeaderText != string.Empty)
+            if (_config.HeaderText != string.Empty && !isMethodClass)
                 sw.WriteLine(_config.HeaderText);
 
             if (outputBuilder.UsingDirectives.Any() && _config.GenerateMultipleFiles)

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -268,10 +268,11 @@ namespace ClangSharp
             using var sw = new StreamWriter(stream, defaultStreamWriterEncoding, DefaultStreamWriterBufferSize, leaveStreamOpen);
             sw.NewLine = "\n";
 
+            if (_config.HeaderText != string.Empty)
+                sw.WriteLine(_config.HeaderText);
+
             if (outputBuilder.UsingDirectives.Any() && _config.GenerateMultipleFiles)
             {
-                sw.Write(_config.HeaderText);
-
                 foreach (var usingDirective in outputBuilder.UsingDirectives)
                 {
                     sw.Write("using");
@@ -1399,12 +1400,12 @@ namespace ClangSharp
             var parameters = typedefDecl.CursorChildren.Where((cursor) => cursor is ParmVarDecl).Cast<ParmVarDecl>().ToList();
             var index = parameters.IndexOf(parmVarDecl);
             var lastIndex = parameters.Count - 1;
-            
+
             if (name.Equals("param"))
             {
                 _outputBuilder.Write(index);
             }
-            
+
             if (index != lastIndex)
             {
                 _outputBuilder.Write(',');

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -51,7 +51,7 @@ namespace ClangSharp
             _options = options;
 
             ExcludedNames = excludedNames;
-            HeaderText = headerFile is object ? File.ReadAllText(headerFile) : string.Empty;
+            HeaderText = string.IsNullOrWhiteSpace(headerFile) ? string.Empty : File.ReadAllText(headerFile);
             LibraryPath = libraryPath;
             MethodClassName = methodClassName;
             MethodPrefixToStrip = methodPrefixToStrip;


### PR DESCRIPTION
This fixes #78 and fixes #79. Header files are written whenever a valid header file is passed, and null/empty paths are now ignored.

Sorry about the whitespace changes, I didn't realise I had VS Code set to hide whitespace changes in git diffs.