### PR TITLE
Add Minimal Support for NamespaceAliasDecl and UsingDirectiveDecl.

### DIFF
--- a/sources/ClangSharp/ClangSharp.csproj
+++ b/sources/ClangSharp/ClangSharp.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="libClang" />
-    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.0.0-preview6.19303.8" />
-    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" />
+    <PackageReference Include="System.Memory" />
   </ItemGroup>
 
 </Project>

--- a/sources/ClangSharp/ClangSharp.csproj
+++ b/sources/ClangSharp/ClangSharp.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="libClang" />
-    <PackageReference Include="Microsoft.Bcl.HashCode" />
-    <PackageReference Include="System.Memory" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.0.0-preview6.19303.8" />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 
 </Project>

--- a/sources/ClangSharp/Cursors/Decls/Decl.cs
+++ b/sources/ClangSharp/Cursors/Decls/Decl.cs
@@ -178,6 +178,18 @@ namespace ClangSharp
                     break;
                 }
 
+                case CXCursorKind.CXCursor_NamespaceAlias:
+                {
+                    result = new NamespaceAliasDecl(handle);
+                    break;
+                }
+
+                case CXCursorKind.CXCursor_UsingDirective:
+                {
+                    result = new UsingDirectiveDecl(handle);
+                    break;
+                }
+
                 case CXCursorKind.CXCursor_UsingDeclaration:
                 {
                     result = new UsingDecl(handle);

--- a/sources/ClangSharp/Cursors/Decls/NamespaceAliasDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/NamespaceAliasDecl.cs
@@ -1,8 +1,10 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
 using ClangSharp.Interop;
 
 namespace ClangSharp
 {
-    public sealed class NamespaceAliasDecl: NamedDecl, IRedeclarable<NamespaceDecl>
+    public sealed class NamespaceAliasDecl : NamedDecl, IRedeclarable<NamespaceDecl>
     {
         internal NamespaceAliasDecl(CXCursor handle) : base(handle, CXCursorKind.CXCursor_NamespaceAlias)
         {

--- a/sources/ClangSharp/Cursors/Decls/NamespaceAliasDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/NamespaceAliasDecl.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ClangSharp.Interop;
+
+namespace ClangSharp
+{
+    public sealed class NamespaceAliasDecl: NamedDecl, IRedeclarable<NamespaceDecl>
+    {
+        internal NamespaceAliasDecl(CXCursor handle) : base(handle, CXCursorKind.CXCursor_NamespaceAlias)
+        {
+        }
+    }
+}

--- a/sources/ClangSharp/Cursors/Decls/NamespaceAliasDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/NamespaceAliasDecl.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using ClangSharp.Interop;
 
 namespace ClangSharp

--- a/sources/ClangSharp/Cursors/Decls/UsingDirectiveDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/UsingDirectiveDecl.cs
@@ -1,10 +1,10 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
 using ClangSharp.Interop;
 
 namespace ClangSharp
 {
-    // e.g. `using namespace std;`
-    // See: https://clang.llvm.org/doxygen/classclang_1_1UsingDirectiveDecl.html
-    public class UsingDirectiveDecl: NamedDecl, IMergeable<UsingDecl>
+    public class UsingDirectiveDecl : NamedDecl
     {
         internal UsingDirectiveDecl(CXCursor handle) : base(handle, CXCursorKind.CXCursor_UsingDirective)
         {

--- a/sources/ClangSharp/Cursors/Decls/UsingDirectiveDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/UsingDirectiveDecl.cs
@@ -2,7 +2,7 @@ using ClangSharp.Interop;
 
 namespace ClangSharp
 {
-    // e.g. using namespace std;
+    // e.g. `using namespace std;`
     // See: https://clang.llvm.org/doxygen/classclang_1_1UsingDirectiveDecl.html
     public class UsingDirectiveDecl: NamedDecl, IMergeable<UsingDecl>
     {

--- a/sources/ClangSharp/Cursors/Decls/UsingDirectiveDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/UsingDirectiveDecl.cs
@@ -1,0 +1,13 @@
+using ClangSharp.Interop;
+
+namespace ClangSharp
+{
+    // e.g. using namespace std;
+    // See: https://clang.llvm.org/doxygen/classclang_1_1UsingDirectiveDecl.html
+    public class UsingDirectiveDecl: NamedDecl, IMergeable<UsingDecl>
+    {
+        internal UsingDirectiveDecl(CXCursor handle) : base(handle, CXCursorKind.CXCursor_UsingDirective)
+        {
+        }
+    }
+}


### PR DESCRIPTION
If a NamespaceAliasDecl or a UsingDirectiveDecl was encountered `Decl.Create` would hit a `Debugger.Break` statement in the default case. (Which probably should be removed before the next version is pushed to NuGet?)

This pull request adds two (very minimal) classes: `NamespaceAliasDecl` and `UsingDirectiveDecl` classes and the appropriate cases into the switch statement in `Decl.Create` to create them. 