### PR TITLE
Updating CI to use the vmImage pool names

### DIFF
--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -8,35 +8,35 @@ jobs:
 - template: azure-windows.yml
   parameters:
     name: windows_debug_x86
-    pool: Hosted
+    pool: windows-latest
     configuration: Debug
     architecture: x86
 
 - template: azure-windows.yml
   parameters:
     name: windows_release_x86
-    pool: Hosted
+    pool: windows-latest
     configuration: Release
     architecture: x86
 
 - template: azure-windows.yml
   parameters:
     name: windows_debug_x64
-    pool: Hosted
+    pool: windows-latest
     configuration: Debug
     architecture: x64
 
 - template: azure-windows.yml
   parameters:
     name: windows_release_x64
-    pool: Hosted
+    pool: windows-latest
     configuration: Release
     architecture: x64
 
 - template: azure-unix.yml
   parameters:
     name: ubuntu_debug_x64
-    pool: Hosted Ubuntu 1604
+    pool: ubuntu-latest
     configuration: Debug
     architecture: x64
     rid: ubuntu.16.04-x64
@@ -44,7 +44,7 @@ jobs:
 - template: azure-unix.yml
   parameters:
     name: ubuntu_release_x64
-    pool: Hosted Ubuntu 1604
+    pool: ubuntu-latest
     configuration: Release
     architecture: x64
     rid: ubuntu.16.04-x64
@@ -52,13 +52,13 @@ jobs:
 - template: azure-unix.yml
   parameters:
     name: macos_debug_x64
-    pool: Hosted macOS
+    pool: macOS-latest
     configuration: Debug
     architecture: x64
 
 - template: azure-unix.yml
   parameters:
     name: macos_release_x64
-    pool: Hosted macOS
+    pool: macOS-latest
     configuration: Release
     architecture: x64

--- a/scripts/azure-unix.yml
+++ b/scripts/azure-unix.yml
@@ -1,7 +1,7 @@
 jobs:
 - job: ${{parameters.name}}
   pool:
-    name: ${{parameters.pool}}
+    vmImage: ${{parameters.pool}}
   steps:
   - task: Bash@3
     displayName: 'Run scripts/cibuild.sh'

--- a/scripts/azure-windows.yml
+++ b/scripts/azure-windows.yml
@@ -1,8 +1,7 @@
 jobs:
 - job: ${{parameters.name}}
   pool:
-    name: ${{parameters.pool}}
-    demands: Cmd
+    vmImage: ${{parameters.pool}}
   steps:
   - task: BatchScript@1
     displayName: 'Run scripts/cibuild.cmd'

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -120,7 +120,7 @@ try {
     $DotNetInstallDirectory = Join-Path -Path $ArtifactsDir -ChildPath "dotnet"
     Create-Directory -Path $DotNetInstallDirectory
 
-    & $DotNetInstallScript -Channel release/3.0.1xx -Version 3.0.100-preview7-012821 -InstallDir $DotNetInstallDirectory -Architecture $architecture
+    & $DotNetInstallScript -Channel 3.0 -Version latest -InstallDir $DotNetInstallDirectory -Architecture $architecture
     & $DotNetInstallScript -Channel 2.1 -Version latest -InstallDir $DotNetInstallDirectory -Architecture $architecture -Runtime dotnet
     & $DotNetInstallScript -Channel 2.0 -Version latest -InstallDir $DotNetInstallDirectory -Architecture $architecture -Runtime dotnet
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -204,7 +204,7 @@ if [[ ! -z "$architecture" ]]; then
   DotNetInstallDirectory="$ArtifactsDir/dotnet"
   CreateDirectory "$DotNetInstallDirectory"
 
-  . "$DotNetInstallScript" --channel release/3.0.1xx --version 3.0.100-preview7-012821 --install-dir "$DotNetInstallDirectory" --architecture "$architecture"
+  . "$DotNetInstallScript" --channel 3.0 --version latest --install-dir "$DotNetInstallDirectory" --architecture "$architecture"
   . "$DotNetInstallScript" --channel 2.1 --version latest --install-dir "$DotNetInstallDirectory" --architecture "$architecture" --runtime dotnet
   . "$DotNetInstallScript" --channel 2.0 --version latest --install-dir "$DotNetInstallDirectory" --architecture "$architecture" --runtime dotnet
 


### PR DESCRIPTION
This updates CI to use the `vmImage` pool names which have replaced the older named pools.