### PR TITLE
Updating ClangSharpPInvokeGenerator to pack as a global tool

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,7 +40,7 @@
     <Company>Microsoft</Company>
     <PackageOutputPath>$(BaseArtifactsPath)pkg/$(Configuration)/</PackageOutputPath>
     <Product>ClangSharp</Product>
-    <VersionPrefix>8.0.0</VersionPrefix>
+    <VersionPrefix>9.0.0</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
   </PropertyGroup>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,9 +15,9 @@
     <DefineConstants>$(DefineConstants);$(OS)</DefineConstants>
   </PropertyGroup>
 
-  <!-- Settings that allow testing to work by default -->
+  <!-- Settings that allow testing and packing to work by default -->
   <PropertyGroup>
-    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' AND '$(PackAsTool)' != 'true'">$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifier>
   </PropertyGroup>
 
   <!-- Tool versions for tool references across all projects -->

--- a/sources/ClangSharpPInvokeGenerator/ClangSharpPInvokeGenerator.csproj
+++ b/sources/ClangSharpPInvokeGenerator/ClangSharpPInvokeGenerator.csproj
@@ -3,6 +3,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <PackAsTool>true</PackAsTool>
+    <RuntimeIdentifier></RuntimeIdentifier>
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 


### PR DESCRIPTION
This updates ClangSharpPInvokeGenerator to pack as a global tool. Noting that this requires `libClang` and `libClangSharp` to exist somewhere on the path already. This is a due to a limitation in dotnet global tools not easily allowing rid specific distributions and the `libClang` dependencies being quite large.