### PR TITLE
Updating the GetTypeName handling to better handle anonymous records and pointee types

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -518,14 +518,13 @@ namespace ClangSharp
                             _outputBuilder.WriteLine();
                         }
 
-                        var nestedRecordDeclName = GetRemappedCursorName(nestedRecordDecl);
-                        var nestedRecordDeclTypeName = GetRemappedTypeName(nestedRecordDecl, nestedRecordDecl.TypeForDecl, out _);
+                        var nestedRecordDeclName = GetRemappedTypeName(nestedRecordDecl, nestedRecordDecl.TypeForDecl, out string nativeTypeName);
 
                         if (recordDecl.IsUnion)
                         {
                             _outputBuilder.WriteIndentedLine("[FieldOffset(0)]");
                         }
-                        AddNativeTypeNameAttribute(nestedRecordDeclTypeName);
+                        AddNativeTypeNameAttribute(nativeTypeName);
 
                         _outputBuilder.WriteIndented(GetAccessSpecifierName(nestedRecordDecl));
                         _outputBuilder.Write(' ');

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -770,6 +770,10 @@ namespace ClangSharp
             {
                 name = GetTypeName(cursor, elaboratedType.NamedType, out var nativeNamedTypeName);
             }
+            else if (type is FunctionType)
+            {
+                // The default name should be correct
+            }
             else if (type is PointerType pointerType)
             {
                 name = GetTypeNameForPointeeType(cursor, pointerType.PointeeType, out var nativePointeeTypeName);
@@ -777,6 +781,17 @@ namespace ClangSharp
             else if (type is ReferenceType referenceType)
             {
                 name = GetTypeNameForPointeeType(cursor, referenceType.PointeeType, out var nativePointeeTypeName);
+            }
+            else if (type is TagType tagType)
+            {
+                if (tagType.Decl.Handle.IsAnonymous)
+                {
+                    name = GetAnonymousName(tagType.Decl, tagType.KindSpelling);
+                }
+                else
+                {
+                    // The default name should be correct
+                }
             }
             else if (type is TypedefType typedefType)
             {
@@ -793,7 +808,7 @@ namespace ClangSharp
                     name = GetTypeName(cursor, typedefType.Decl.UnderlyingType, out var nativeUnderlyingTypeName);
                 }
             }
-            else if (!(type is FunctionType) && !(type is TagType))
+            else
             {
                 AddDiagnostic(DiagnosticLevel.Warning, $"Unsupported type: '{type.TypeClass}'. Falling back '{name}'.", cursor);
             }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -839,6 +839,11 @@ namespace ClangSharp
             else
             {
                 name = GetTypeName(cursor, pointeeType, out nativePointeeTypeName);
+
+                if (_config.RemappedNames.TryGetValue(name, out string remappedName))
+                {
+                    name = remappedName;
+                }
                 name += '*';
             }
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/PInvokeGeneratorTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/PInvokeGeneratorTest.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using ClangSharp.Interop;
 using Xunit;


### PR DESCRIPTION
This updates `GetTypeName` to better handle anonymous records and pointee types. This ensures that emitted `[NativeTypeName]` and the emitted managed types are more correct.