### PR TITLE
Adding support for generating bitfield bindings

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -261,6 +261,11 @@ namespace ClangSharp
 
         private void VisitFieldDecl(FieldDecl fieldDecl)
         {
+            if (fieldDecl.IsBitField)
+            {
+                return;
+            }
+
             var name = GetRemappedCursorName(fieldDecl);
             var escapedName = EscapeName(name);
 
@@ -298,11 +303,6 @@ namespace ClangSharp
             }
             else
             {
-                if (fieldDecl.IsBitField)
-                {
-                    AddDiagnostic(DiagnosticLevel.Warning, "Unsupported field declaration kind: 'BitField'. Generated bindings may be incomplete.", fieldDecl);
-                }
-
                 _outputBuilder.Write(typeName);
                 _outputBuilder.Write(' ');
                 _outputBuilder.Write(escapedName);
@@ -499,6 +499,11 @@ namespace ClangSharp
                 _outputBuilder.WriteBlockStart();
 
                 var fieldCount = 0;
+                var bitfieldCount = GetBitfieldCount(this, recordDecl);
+
+                var bitfieldIndex = (bitfieldCount == 1) ? -1 : 0;
+                var bitfieldPreviousSize = 0L;
+                var bitfieldRemainingBits = 0L;
 
                 foreach (var declaration in recordDecl.Decls)
                 {
@@ -508,9 +513,13 @@ namespace ClangSharp
                         {
                             _outputBuilder.WriteLine();
                         }
-
-                        Visit(fieldDecl);
                         fieldCount++;
+
+                        if (fieldDecl.IsBitField)
+                        {
+                            VisitBitfieldDecl(this, fieldDecl, ref bitfieldIndex, ref bitfieldPreviousSize, ref bitfieldRemainingBits);
+                        }
+                        Visit(fieldDecl);
                     }
                     else if ((declaration is RecordDecl nestedRecordDecl) && nestedRecordDecl.IsAnonymousStructOrUnion)
                     {
@@ -518,6 +527,7 @@ namespace ClangSharp
                         {
                             _outputBuilder.WriteLine();
                         }
+                        fieldCount++;
 
                         var nestedRecordDeclName = GetRemappedTypeName(nestedRecordDecl, nestedRecordDecl.TypeForDecl, out string nativeTypeName);
 
@@ -533,8 +543,6 @@ namespace ClangSharp
                         _outputBuilder.Write(' ');
                         _outputBuilder.Write(GetRemappedAnonymousName(nestedRecordDecl, "Field"));
                         _outputBuilder.WriteLine(';');
-
-                        fieldCount++;
                     }
                 }
 
@@ -548,6 +556,273 @@ namespace ClangSharp
                 _outputBuilder.WriteBlockEnd();
             }
             StopUsingOutputBuilder();
+
+            static int GetBitfieldCount(PInvokeGenerator pinvokeGenerator, RecordDecl recordDecl)
+            {
+                var count = 0;
+                var previousSize = 0L;
+                var remainingBits = 0L;
+
+                foreach (var fieldDecl in recordDecl.Fields)
+                {
+                    if (!fieldDecl.IsBitField)
+                    {
+                        continue;
+                    }
+
+                    var currentSize = fieldDecl.Type.Handle.SizeOf;
+
+                    if ((currentSize != previousSize) || (fieldDecl.BitWidthValue > remainingBits))
+                    {
+                        count++;
+                        remainingBits = currentSize * 8;
+                    }
+
+                    remainingBits -= fieldDecl.BitWidthValue;
+                    previousSize = currentSize;
+                }
+
+                return count;
+            }
+
+            static void VisitBitfieldDecl(PInvokeGenerator pinvokeGenerator, FieldDecl fieldDecl, ref int index, ref long previousSize, ref long remainingBits)
+            {
+                Debug.Assert(fieldDecl.IsBitField);
+
+                var outputBuilder = pinvokeGenerator._outputBuilder;
+                var typeName = pinvokeGenerator.GetRemappedTypeName(fieldDecl, fieldDecl.Type, out var nativeTypeName);
+
+                if (string.IsNullOrWhiteSpace(nativeTypeName))
+                {
+                    nativeTypeName = typeName;
+                }
+                nativeTypeName += $" : {fieldDecl.BitWidthValue}";
+
+                if (fieldDecl.Parent.IsUnion)
+                {
+                    outputBuilder.WriteIndentedLine("[FieldOffset(0)]");
+                }
+                var currentSize = fieldDecl.Type.Handle.SizeOf;
+
+                var bitfieldName = "_bitfield";
+
+                if ((currentSize != previousSize) || (fieldDecl.BitWidthValue > remainingBits))
+                {
+                    index++;
+
+                    if (index > 0)
+                    {
+                        bitfieldName += index.ToString();
+                    }
+                    remainingBits = currentSize * 8;
+
+                    outputBuilder.WriteIndented("internal");
+                    outputBuilder.Write(' ');
+                    outputBuilder.Write(typeName);
+                    outputBuilder.Write(' ');
+                    outputBuilder.Write(bitfieldName);
+                    outputBuilder.WriteLine(';');
+                    outputBuilder.WriteLine();
+                }
+                else if (index > 0)
+                {
+                    bitfieldName += index.ToString();
+                }
+                pinvokeGenerator.AddNativeTypeNameAttribute(nativeTypeName);
+
+                var bitfieldOffset = (currentSize * 8) - remainingBits;
+                var bitwidthHexString = ((1 << fieldDecl.BitWidthValue) - 1).ToString("X");
+                var canonicalType = fieldDecl.Type.CanonicalType;
+
+                switch (canonicalType.Kind)
+                {
+                    case CXTypeKind.CXType_Char_U:
+                    case CXTypeKind.CXType_UChar:
+                    case CXTypeKind.CXType_UShort:
+                    case CXTypeKind.CXType_UInt:
+                    {
+                        bitwidthHexString += "u";
+                        break;
+                    }
+
+                    case CXTypeKind.CXType_ULong:
+                    {
+                        if (pinvokeGenerator._config.GenerateUnixTypes)
+                        {
+                            goto default;
+                        }
+                        goto case CXTypeKind.CXType_UInt;
+                    }
+
+                    case CXTypeKind.CXType_ULongLong:
+                    {
+                        bitwidthHexString += "UL";
+                        break;
+                    }
+
+                    case CXTypeKind.CXType_Char_S:
+                    case CXTypeKind.CXType_SChar:
+                    case CXTypeKind.CXType_Short:
+                    case CXTypeKind.CXType_Int:
+                    {
+                        break;
+                    }
+
+                    case CXTypeKind.CXType_Long:
+                    {
+                        if (pinvokeGenerator._config.GenerateUnixTypes)
+                        {
+                            goto default;
+                        }
+                        goto case CXTypeKind.CXType_Int;
+                    }
+
+                    case CXTypeKind.CXType_LongLong:
+                    {
+                        bitwidthHexString += "L";
+                        break;
+                    }
+
+                    default:
+                    {
+                        pinvokeGenerator.AddDiagnostic(DiagnosticLevel.Warning, $"Unsupported bitfield type: '{canonicalType.TypeClass}'. Generated bindings may be incomplete.", fieldDecl);
+                        break;
+                    }
+                }
+
+                var name = pinvokeGenerator.GetRemappedCursorName(fieldDecl);
+                var escapedName = pinvokeGenerator.EscapeName(name);
+
+                outputBuilder.WriteIndented(pinvokeGenerator.GetAccessSpecifierName(fieldDecl));
+                outputBuilder.Write(' ');
+                outputBuilder.Write(typeName);
+                outputBuilder.Write(' ');
+                outputBuilder.WriteLine(escapedName);
+                outputBuilder.WriteBlockStart();
+                outputBuilder.WriteIndentedLine("get");
+                outputBuilder.WriteBlockStart();
+                outputBuilder.WriteIndented("return");
+                outputBuilder.Write(' ');
+
+                if (currentSize < 4)
+                {
+                    outputBuilder.Write('(');
+                    outputBuilder.Write(typeName);
+                    outputBuilder.Write(')');
+                    outputBuilder.Write('(');
+                }
+
+                if (bitfieldOffset != 0)
+                {
+                    outputBuilder.Write('(');
+                }
+
+                outputBuilder.Write(bitfieldName);
+
+                if (bitfieldOffset != 0)
+                {
+                    outputBuilder.Write(' ');
+                    outputBuilder.Write(">>");
+                    outputBuilder.Write(' ');
+                    outputBuilder.Write(bitfieldOffset);
+                    outputBuilder.Write(')');
+                }
+
+                outputBuilder.Write(' ');
+                outputBuilder.Write('&');
+                outputBuilder.Write(' ');
+                outputBuilder.Write("0x");
+                outputBuilder.Write(bitwidthHexString);
+
+                if (currentSize < 4)
+                {
+                    outputBuilder.Write(')');
+                }
+
+                outputBuilder.WriteLine(';');
+                outputBuilder.WriteBlockEnd();
+                outputBuilder.WriteLine();
+
+                outputBuilder.WriteIndentedLine("set");
+                outputBuilder.WriteBlockStart();
+                outputBuilder.WriteIndented(bitfieldName);
+                outputBuilder.Write(' ');
+                outputBuilder.Write('=');
+                outputBuilder.Write(' ');
+
+                if (currentSize < 4)
+                {
+                    outputBuilder.Write('(');
+                    outputBuilder.Write(typeName);
+                    outputBuilder.Write(')');
+                    outputBuilder.Write('(');
+                }
+
+                outputBuilder.Write('(');
+                outputBuilder.Write(bitfieldName);
+                outputBuilder.Write(' ');
+                outputBuilder.Write('&');
+                outputBuilder.Write(' ');
+                outputBuilder.Write('~');
+
+                if (bitfieldOffset != 0)
+                {
+                    outputBuilder.Write('(');
+                }
+
+                outputBuilder.Write("0x");
+                outputBuilder.Write(bitwidthHexString);
+
+                if (bitfieldOffset != 0)
+                {
+                    outputBuilder.Write(' ');
+                    outputBuilder.Write("<<");
+                    outputBuilder.Write(' ');
+                    outputBuilder.Write(bitfieldOffset);
+                    outputBuilder.Write(')');
+                }
+
+                outputBuilder.Write(')');
+                outputBuilder.Write(' ');
+                outputBuilder.Write('|');
+                outputBuilder.Write(' ');
+                outputBuilder.Write('(');
+
+                if (bitfieldOffset != 0)
+                {
+                    outputBuilder.Write('(');
+                }
+
+                outputBuilder.Write("value");
+                outputBuilder.Write(' ');
+                outputBuilder.Write('&');
+                outputBuilder.Write(' ');
+                outputBuilder.Write("0x");
+                outputBuilder.Write(bitwidthHexString);
+
+                if (bitfieldOffset != 0)
+                {
+                    outputBuilder.Write(')');
+                    outputBuilder.Write(' ');
+                    outputBuilder.Write("<<");
+                    outputBuilder.Write(' ');
+                    outputBuilder.Write(bitfieldOffset);
+                }
+
+                outputBuilder.Write(')');
+
+                if (currentSize < 4)
+                {
+                    outputBuilder.Write(')');
+                }
+
+                outputBuilder.WriteLine(';');
+                outputBuilder.WriteBlockEnd();
+                outputBuilder.WriteBlockEnd();
+
+                remainingBits -= fieldDecl.BitWidthValue;
+                previousSize = currentSize;
+            }
 
             static void VisitConstantArrayFieldDecl(PInvokeGenerator pinvokeGenerator, FieldDecl constantArray)
             {

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using ClangSharp.Interop;
 
@@ -541,127 +542,135 @@ namespace ClangSharp
 
                 foreach (var constantArray in recordDecl.Fields.Where((field) => field.Type is ConstantArrayType))
                 {
-                    var type = (ConstantArrayType)constantArray.Type;
-                    var typeName = GetRemappedTypeName(constantArray, constantArray.Type, out _);
-
-                    if (IsSupportedFixedSizedBufferType(typeName))
-                    {
-                        continue;
-                    }
-                    bool isUnsafe = typeName.Contains('*');
-
-                    _outputBuilder.WriteLine();
-                    _outputBuilder.WriteIndented(GetAccessSpecifierName(constantArray));
-                    _outputBuilder.Write(' ');
-
-                    if (isUnsafe)
-                    {
-                        _outputBuilder.Write("unsafe");
-                        _outputBuilder.Write(' ');
-                    }
-
-                    _outputBuilder.Write("partial struct");
-                    _outputBuilder.Write(' ');
-                    _outputBuilder.WriteLine(GetArtificalFixedSizedBufferName(constantArray));
-                    _outputBuilder.WriteBlockStart();
-
-                    for (int i = 0; i < type.Size; i++)
-                    {
-                        _outputBuilder.WriteIndented("internal");
-                        _outputBuilder.Write(' ');
-                        _outputBuilder.Write(typeName);
-                        _outputBuilder.Write(' ');
-                        _outputBuilder.Write('e');
-                        _outputBuilder.Write(i);
-                        _outputBuilder.WriteLine(';');
-                    }
-
-                    _outputBuilder.WriteLine();
-                    _outputBuilder.WriteIndented("public");
-                    _outputBuilder.Write(' ');
-
-                    if (_config.GenerateCompatibleCode)
-                    {
-                        if (!isUnsafe)
-                        {
-                            _outputBuilder.Write("unsafe");
-                            _outputBuilder.Write(' ');
-                        }
-                    }
-                    else
-                    {
-                        _outputBuilder.AddUsingDirective("System");
-                        _outputBuilder.AddUsingDirective("System.Runtime.InteropServices");
-                    }
-
-                    _outputBuilder.Write("ref");
-                    _outputBuilder.Write(' ');
-                    _outputBuilder.Write(typeName);
-                    _outputBuilder.Write(' ');
-
-                    if (_config.GenerateCompatibleCode)
-                    {
-                        _outputBuilder.WriteLine("this[int index]");
-                        _outputBuilder.WriteBlockStart();
-                        _outputBuilder.WriteIndentedLine("get");
-                        _outputBuilder.WriteBlockStart();
-                        _outputBuilder.WriteIndented("fixed (");
-                        _outputBuilder.Write(typeName);
-                        _outputBuilder.WriteLine("* pThis = &e0)");
-                        _outputBuilder.WriteBlockStart();
-                        _outputBuilder.WriteIndentedLine("return ref pThis[index];");
-                        _outputBuilder.WriteBlockEnd();
-                        _outputBuilder.WriteBlockEnd();
-                        _outputBuilder.WriteBlockEnd();
-                    }
-                    else
-                    {
-                        _outputBuilder.Write("this[int index] => ref AsSpan(");
-
-                        if (type.Size == 1)
-                        {
-                            _outputBuilder.Write("int.MaxValue");
-                        }
-
-                        _outputBuilder.WriteLine(")[index];");
-                        _outputBuilder.WriteLine();
-                        _outputBuilder.WriteIndented("public");
-                        _outputBuilder.Write(' ');
-                        _outputBuilder.Write("Span<");
-                        _outputBuilder.Write(typeName);
-                        _outputBuilder.Write('>');
-                        _outputBuilder.Write(' ');
-                        _outputBuilder.Write("AsSpan(");
-
-                        if (type.Size == 1)
-                        {
-                            _outputBuilder.Write("int length");
-                        }
-
-                        _outputBuilder.Write(')');
-                        _outputBuilder.Write(' ');
-                        _outputBuilder.Write("=> MemoryMarshal.CreateSpan(ref e0,");
-                        _outputBuilder.Write(' ');
-
-                        if (type.Size == 1)
-                        {
-                            _outputBuilder.Write("length");
-                        }
-                        else
-                        {
-                            _outputBuilder.Write(type.Size);
-                        }
-
-                        _outputBuilder.Write(')');
-                        _outputBuilder.WriteLine(';');
-                    }
-
-                    _outputBuilder.WriteBlockEnd();
+                    VisitConstantArrayFieldDecl(this, constantArray);
                 }
 
                 _outputBuilder.WriteBlockEnd();
             }
             StopUsingOutputBuilder();
+
+            static void VisitConstantArrayFieldDecl(PInvokeGenerator pinvokeGenerator, FieldDecl constantArray)
+            {
+                Debug.Assert(constantArray.Type is ConstantArrayType);
+
+                var outputBuilder = pinvokeGenerator._outputBuilder;
+                var type = (ConstantArrayType)constantArray.Type;
+                var typeName = pinvokeGenerator.GetRemappedTypeName(constantArray, constantArray.Type, out _);
+
+                if (pinvokeGenerator.IsSupportedFixedSizedBufferType(typeName))
+                {
+                    return;
+                }
+                bool isUnsafe = typeName.Contains('*');
+
+                outputBuilder.WriteLine();
+                outputBuilder.WriteIndented(pinvokeGenerator.GetAccessSpecifierName(constantArray));
+                outputBuilder.Write(' ');
+
+                if (isUnsafe)
+                {
+                    outputBuilder.Write("unsafe");
+                    outputBuilder.Write(' ');
+                }
+
+                outputBuilder.Write("partial struct");
+                outputBuilder.Write(' ');
+                outputBuilder.WriteLine(pinvokeGenerator.GetArtificalFixedSizedBufferName(constantArray));
+                outputBuilder.WriteBlockStart();
+
+                for (int i = 0; i < type.Size; i++)
+                {
+                    outputBuilder.WriteIndented("internal");
+                    outputBuilder.Write(' ');
+                    outputBuilder.Write(typeName);
+                    outputBuilder.Write(' ');
+                    outputBuilder.Write('e');
+                    outputBuilder.Write(i);
+                    outputBuilder.WriteLine(';');
+                }
+
+                outputBuilder.WriteLine();
+                outputBuilder.WriteIndented("public");
+                outputBuilder.Write(' ');
+
+                if (pinvokeGenerator._config.GenerateCompatibleCode)
+                {
+                    if (!isUnsafe)
+                    {
+                        outputBuilder.Write("unsafe");
+                        outputBuilder.Write(' ');
+                    }
+                }
+                else
+                {
+                    outputBuilder.AddUsingDirective("System");
+                    outputBuilder.AddUsingDirective("System.Runtime.InteropServices");
+                }
+
+                outputBuilder.Write("ref");
+                outputBuilder.Write(' ');
+                outputBuilder.Write(typeName);
+                outputBuilder.Write(' ');
+
+                if (pinvokeGenerator._config.GenerateCompatibleCode)
+                {
+                    outputBuilder.WriteLine("this[int index]");
+                    outputBuilder.WriteBlockStart();
+                    outputBuilder.WriteIndentedLine("get");
+                    outputBuilder.WriteBlockStart();
+                    outputBuilder.WriteIndented("fixed (");
+                    outputBuilder.Write(typeName);
+                    outputBuilder.WriteLine("* pThis = &e0)");
+                    outputBuilder.WriteBlockStart();
+                    outputBuilder.WriteIndentedLine("return ref pThis[index];");
+                    outputBuilder.WriteBlockEnd();
+                    outputBuilder.WriteBlockEnd();
+                    outputBuilder.WriteBlockEnd();
+                }
+                else
+                {
+                    outputBuilder.Write("this[int index] => ref AsSpan(");
+
+                    if (type.Size == 1)
+                    {
+                        outputBuilder.Write("int.MaxValue");
+                    }
+
+                    outputBuilder.WriteLine(")[index];");
+                    outputBuilder.WriteLine();
+                    outputBuilder.WriteIndented("public");
+                    outputBuilder.Write(' ');
+                    outputBuilder.Write("Span<");
+                    outputBuilder.Write(typeName);
+                    outputBuilder.Write('>');
+                    outputBuilder.Write(' ');
+                    outputBuilder.Write("AsSpan(");
+
+                    if (type.Size == 1)
+                    {
+                        outputBuilder.Write("int length");
+                    }
+
+                    outputBuilder.Write(')');
+                    outputBuilder.Write(' ');
+                    outputBuilder.Write("=> MemoryMarshal.CreateSpan(ref e0,");
+                    outputBuilder.Write(' ');
+
+                    if (type.Size == 1)
+                    {
+                        outputBuilder.Write("length");
+                    }
+                    else
+                    {
+                        outputBuilder.Write(type.Size);
+                    }
+
+                    outputBuilder.Write(')');
+                    outputBuilder.WriteLine(';');
+                }
+
+                outputBuilder.WriteBlockEnd();
+            }
         }
 
         private void VisitTypedefDecl(TypedefDecl typedefDecl)

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
@@ -39,6 +39,161 @@ namespace ClangSharp.UnitTests
             await ValidateGeneratedBindings(inputContents, expectedOutputContents);
         }
 
+        [Fact]
+        public async Task BitfieldTest()
+        {
+            var inputContents = @"struct MyStruct1
+{
+    unsigned int o0_b0_24 : 24;
+    unsigned int o4_b0_16 : 16;
+    unsigned int o4_b16_3 : 3;
+    unsigned char o8_b0_1 : 1;
+    int o12_b0_1 : 1;
+    int o12_b1_1 : 1;
+};
+
+struct MyStruct2
+{
+    unsigned int o0_b0_1 : 1;
+    unsigned int o0_b1_1 : 1;
+};
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct MyStruct1
+    {
+        internal uint _bitfield1;
+
+        [NativeTypeName(""unsigned int : 24"")]
+        public uint o0_b0_24
+        {
+            get
+            {
+                return _bitfield1 & 0xFFFFFFu;
+            }
+
+            set
+            {
+                _bitfield1 = (_bitfield1 & ~0xFFFFFFu) | (value & 0xFFFFFFu);
+            }
+        }
+
+        internal uint _bitfield2;
+
+        [NativeTypeName(""unsigned int : 16"")]
+        public uint o4_b0_16
+        {
+            get
+            {
+                return _bitfield2 & 0xFFFFu;
+            }
+
+            set
+            {
+                _bitfield2 = (_bitfield2 & ~0xFFFFu) | (value & 0xFFFFu);
+            }
+        }
+
+        [NativeTypeName(""unsigned int : 3"")]
+        public uint o4_b16_3
+        {
+            get
+            {
+                return (_bitfield2 >> 16) & 0x7u;
+            }
+
+            set
+            {
+                _bitfield2 = (_bitfield2 & ~(0x7u << 16)) | ((value & 0x7u) << 16);
+            }
+        }
+
+        internal byte _bitfield3;
+
+        [NativeTypeName(""unsigned char : 1"")]
+        public byte o8_b0_1
+        {
+            get
+            {
+                return (byte)(_bitfield3 & 0x1u);
+            }
+
+            set
+            {
+                _bitfield3 = (byte)((_bitfield3 & ~0x1u) | (value & 0x1u));
+            }
+        }
+
+        internal int _bitfield4;
+
+        [NativeTypeName(""int : 1"")]
+        public int o12_b0_1
+        {
+            get
+            {
+                return _bitfield4 & 0x1;
+            }
+
+            set
+            {
+                _bitfield4 = (_bitfield4 & ~0x1) | (value & 0x1);
+            }
+        }
+
+        [NativeTypeName(""int : 1"")]
+        public int o12_b1_1
+        {
+            get
+            {
+                return (_bitfield4 >> 1) & 0x1;
+            }
+
+            set
+            {
+                _bitfield4 = (_bitfield4 & ~(0x1 << 1)) | ((value & 0x1) << 1);
+            }
+        }
+    }
+
+    public partial struct MyStruct2
+    {
+        internal uint _bitfield;
+
+        [NativeTypeName(""unsigned int : 1"")]
+        public uint o0_b0_1
+        {
+            get
+            {
+                return _bitfield & 0x1u;
+            }
+
+            set
+            {
+                _bitfield = (_bitfield & ~0x1u) | (value & 0x1u);
+            }
+        }
+
+        [NativeTypeName(""unsigned int : 1"")]
+        public uint o0_b1_1
+        {
+            get
+            {
+                return (_bitfield >> 1) & 0x1u;
+            }
+
+            set
+            {
+                _bitfield = (_bitfield & ~(0x1u << 1)) | ((value & 0x1u) << 1);
+            }
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
         [Theory]
         [InlineData("unsigned char", "byte")]
         [InlineData("long long", "long")]


### PR DESCRIPTION
This updates `VisitRecordDecl` to support generating bitfield bindings.