### PR TITLE
Add binding generation support for virtual instance methods

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -776,7 +776,7 @@ namespace ClangSharp
             }
             else if (type is FunctionType)
             {
-                // The default name should be correct
+                name = "IntPtr";
             }
             else if (type is PointerType pointerType)
             {
@@ -791,6 +791,10 @@ namespace ClangSharp
                 if (tagType.Decl.Handle.IsAnonymous)
                 {
                     name = GetAnonymousName(tagType.Decl, tagType.KindSpelling);
+                }
+                else if (tagType.Handle.IsConstQualified)
+                {
+                    name = GetTypeName(cursor, tagType.Decl.TypeForDecl, out var nativeDeclTypeName);
                 }
                 else
                 {
@@ -957,6 +961,52 @@ namespace ClangSharp
         {
             var typeName = GetRemappedTypeName(namedDecl, type, out _);
             return typeName.Contains('*');
+        }
+
+        private bool NeedsReturnFixup(CXXMethodDecl cxxMethodDecl)
+        {
+            Debug.Assert(cxxMethodDecl != null);
+
+            var needsReturnFixup = false;
+
+            if (cxxMethodDecl.IsVirtual)
+            {
+                var canonicalReturnType = cxxMethodDecl.ReturnType.CanonicalType;
+
+                switch (canonicalReturnType.TypeClass)
+                {
+                    case CX_TypeClass.CX_TypeClass_Builtin:
+                    case CX_TypeClass.CX_TypeClass_Enum:
+                    case CX_TypeClass.CX_TypeClass_Pointer:
+                    {
+                        break;
+                    }
+
+                    case CX_TypeClass.CX_TypeClass_Record:
+                    {
+                        needsReturnFixup = true;
+                        break;
+                    }
+
+                    default:
+                    {
+                        AddDiagnostic(DiagnosticLevel.Error, $"Unsupported return type for abstract method: '{canonicalReturnType.TypeClass}'. Generated bindings may be incomplete.", cxxMethodDecl);
+                        break;
+                    }
+                }
+            }
+
+            return needsReturnFixup;
+        }
+
+        private string PrefixAndStripName(string name)
+        {
+            if (name.StartsWith(_config.MethodPrefixToStrip))
+            {
+                name = name.Substring(_config.MethodPrefixToStrip.Length);
+            }
+
+            return '_' + name;
         }
 
         private void StartUsingOutputBuilder(string name)

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -589,7 +589,11 @@ namespace ClangSharp
                     if ((typeDecl is TagDecl tagDecl) && tagDecl.Handle.IsAnonymous)
                     {
                         name = GetAnonymousName(tagDecl, tagDecl.TypeForDecl.KindSpelling);
-                        AddDiagnostic(DiagnosticLevel.Info, $"Anonymous declaration found in '{nameof(GetCursorName)}'. Falling back to '{name}'.", namedDecl);
+
+                        if (!_config.RemappedNames.ContainsKey(name))
+                        {
+                            AddDiagnostic(DiagnosticLevel.Info, $"Anonymous declaration found in '{nameof(GetCursorName)}'. Falling back to '{name}'.", namedDecl);
+                        }
                     }
                     else
                     {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
@@ -1,0 +1,268 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ClangSharp.UnitTests
+{
+    public sealed class CXXMethodDeclarationTest : PInvokeGeneratorTest
+    {
+        [Fact]
+        public async Task InstanceTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    void MyVoidMethod();
+
+    int MyInt32Method()
+    {
+        return 0;
+    }
+};
+";
+            var callConv = "Cdecl";
+            var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "__ZN8MyStruct12MyVoidMethodEv" : "_ZN8MyStruct12MyVoidMethodEv";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                if (!Environment.Is64BitProcess)
+                {
+                    callConv = "ThisCall";
+                    entryPoint = "?MyVoidMethod@MyStruct@@QAEXXZ";
+                }
+                else
+                {
+                    entryPoint = "?MyVoidMethod@MyStruct@@QEAAXXZ";
+                }
+            }
+
+            var expectedOutputContents = $@"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    public partial struct MyStruct
+    {{
+        [DllImport(Methods.LibraryPath, CallingConvention = CallingConvention.{callConv}, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
+        public static extern void MyVoidMethod();
+
+        public int MyInt32Method()
+        {{
+            return 0;
+        }}
+    }}
+}}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task StaticTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    static void MyVoidMethod();
+
+    static int MyInt32Method()
+    {
+        return 0;
+    }
+};
+";
+
+            var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "?MyVoidMethod@MyStruct@@SAXXZ" : "_ZN8MyStruct12MyVoidMethodEv";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                entryPoint = $"_{entryPoint}";
+            }
+
+            var expectedOutputContents = $@"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    public partial struct MyStruct
+    {{
+        [DllImport(Methods.LibraryPath, CallingConvention = CallingConvention.Cdecl, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
+        public static extern void MyVoidMethod();
+
+        public static int MyInt32Method()
+        {{
+            return 0;
+        }}
+    }}
+}}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task VirtualCompatibleTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    virtual void MyVoidMethod() = 0;
+
+    virtual char MyInt8Method()
+    {
+        return 0;
+    }
+
+    virtual int MyInt32Method();
+};
+";
+
+            var callConv = "Cdecl";
+            var callConvAttr = "";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
+            {
+                callConv = "ThisCall";
+                callConvAttr = " __attribute__((thiscall))";
+            }
+
+            var expectedOutputContents = $@"using System;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    public unsafe partial struct MyStruct
+    {{
+        public readonly Vtbl* lpVtbl;
+
+        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        public delegate void _MyVoidMethod(MyStruct* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [return: NativeTypeName(""char"")]
+        public delegate sbyte _MyInt8Method(MyStruct* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        public delegate int _MyInt32Method(MyStruct* pThis);
+
+        public void MyVoidMethod()
+        {{
+            fixed (MyStruct* pThis = &this)
+            {{
+                Marshal.GetDelegateForFunctionPointer<_MyVoidMethod>(lpVtbl->MyVoidMethod)(pThis);
+            }}
+        }}
+
+        [return: NativeTypeName(""char"")]
+        public sbyte MyInt8Method()
+        {{
+            fixed (MyStruct* pThis = &this)
+            {{
+                return Marshal.GetDelegateForFunctionPointer<_MyInt8Method>(lpVtbl->MyInt8Method)(pThis);
+            }}
+        }}
+
+        public int MyInt32Method()
+        {{
+            fixed (MyStruct* pThis = &this)
+            {{
+                return Marshal.GetDelegateForFunctionPointer<_MyInt32Method>(lpVtbl->MyInt32Method)(pThis);
+            }}
+        }}
+
+        public partial struct Vtbl
+        {{
+            [NativeTypeName(""void (){callConvAttr}"")]
+            public IntPtr MyVoidMethod;
+
+            [NativeTypeName(""char (){callConvAttr}"")]
+            public IntPtr MyInt8Method;
+
+            [NativeTypeName(""int (){callConvAttr}"")]
+            public IntPtr MyInt32Method;
+        }}
+    }}
+}}
+";
+
+            await ValidateGeneratedCompatibleBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task VirtualTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    virtual void MyVoidMethod() = 0;
+
+    virtual char MyInt8Method()
+    {
+        return 0;
+    }
+
+    virtual int MyInt32Method();
+};
+";
+
+            var callConv = "Cdecl";
+            var callConvAttr = "";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
+            {
+                callConv = "ThisCall";
+                callConvAttr = " __attribute__((thiscall))";
+            }
+
+            var expectedOutputContents = $@"using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    public unsafe partial struct MyStruct
+    {{
+        public readonly Vtbl* lpVtbl;
+
+        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        public delegate void _MyVoidMethod(MyStruct* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [return: NativeTypeName(""char"")]
+        public delegate sbyte _MyInt8Method(MyStruct* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        public delegate int _MyInt32Method(MyStruct* pThis);
+
+        public void MyVoidMethod()
+        {{
+            Marshal.GetDelegateForFunctionPointer<_MyVoidMethod>(lpVtbl->MyVoidMethod)((MyStruct*)Unsafe.AsPointer(ref this));
+        }}
+
+        [return: NativeTypeName(""char"")]
+        public sbyte MyInt8Method()
+        {{
+            return Marshal.GetDelegateForFunctionPointer<_MyInt8Method>(lpVtbl->MyInt8Method)((MyStruct*)Unsafe.AsPointer(ref this));
+        }}
+
+        public int MyInt32Method()
+        {{
+            return Marshal.GetDelegateForFunctionPointer<_MyInt32Method>(lpVtbl->MyInt32Method)((MyStruct*)Unsafe.AsPointer(ref this));
+        }}
+
+        public partial struct Vtbl
+        {{
+            [NativeTypeName(""void (){callConvAttr}"")]
+            public IntPtr MyVoidMethod;
+
+            [NativeTypeName(""char (){callConvAttr}"")]
+            public IntPtr MyInt8Method;
+
+            [NativeTypeName(""int (){callConvAttr}"")]
+            public IntPtr MyInt32Method;
+        }}
+    }}
+}}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
@@ -714,10 +714,7 @@ namespace ClangSharp.Test
                 ["__AnonymousField_ClangUnsavedFile_L7_C5"] = "Anonymous",
                 ["__AnonymousRecord_ClangUnsavedFile_L7_C5"] = "_Anonymous_e__Struct"
             };
-            var expectedDiagnostics = new Diagnostic[] {
-                new Diagnostic(DiagnosticLevel.Info, "Anonymous declaration found in 'GetCursorName'. Falling back to '__AnonymousRecord_ClangUnsavedFile_L7_C5'.", "Line 7, Column 5 in ClangUnsavedFile.h")
-            };
-            await ValidateGeneratedBindings(inputContents, expectedOutputContents, excludedNames: null, remappedNames, expectedDiagnostics);
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents, excludedNames: null, remappedNames);
         }
 
         [Theory]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/UnionDeclarationTest.cs
@@ -641,10 +641,7 @@ namespace ClangSharp.Test
                 ["__AnonymousField_ClangUnsavedFile_L7_C5"] = "Anonymous",
                 ["__AnonymousRecord_ClangUnsavedFile_L7_C5"] = "_Anonymous_e__Union"
             };
-            var expectedDiagnostics = new Diagnostic[] {
-                new Diagnostic(DiagnosticLevel.Info, "Anonymous declaration found in 'GetCursorName'. Falling back to '__AnonymousRecord_ClangUnsavedFile_L7_C5'.", "Line 7, Column 5 in ClangUnsavedFile.h")
-            };
-            await ValidateGeneratedBindings(inputContents, expectedOutputContents, excludedNames: null, remappedNames, expectedDiagnostics);
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents, excludedNames: null, remappedNames);
         }
 
         [Theory]


### PR DESCRIPTION
This is namely meant to support COM on Windows, but it should also correctly handle static members, instance members, and virtual members for any platform.