### PR TITLE
Provide a mechanism for providing additional attributes and using directives for declarations

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -280,6 +280,9 @@ namespace ClangSharp
         
             StartUsingOutputBuilder(name);
             {
+                WithAttributes(name);
+                WithNamespaces(name);
+
                 var integerTypeName = GetRemappedTypeName(enumDecl, enumDecl.IntegerType, out var nativeTypeName);
                 AddNativeTypeNameAttribute(nativeTypeName);
         
@@ -368,6 +371,9 @@ namespace ClangSharp
             {
                 StartUsingOutputBuilder(_config.MethodClassName);
             }
+
+            WithAttributes(name);
+            WithNamespaces(name);
 
             var type = functionDecl.Type;
 
@@ -619,6 +625,9 @@ namespace ClangSharp
 
             StartUsingOutputBuilder(name);
             {
+                WithAttributes(name);
+                WithNamespaces(name);
+
                 var cxxRecordDecl = recordDecl as CXXRecordDecl;
                 var hasVtbl = false;
 
@@ -1473,6 +1482,9 @@ namespace ClangSharp
         
                 StartUsingOutputBuilder(name);
                 {
+                    WithAttributes(name);
+                    WithNamespaces(name);
+
                     _outputBuilder.AddUsingDirective("System.Runtime.InteropServices");
         
                     _outputBuilder.WriteIndented("[UnmanagedFunctionPointer(CallingConvention.");
@@ -1525,6 +1537,9 @@ namespace ClangSharp
 
             StartUsingOutputBuilder(_config.MethodClassName);
             {
+                WithAttributes(name);
+                WithNamespaces(name);
+
                 var type = varDecl.Type;
                 var typeName = GetRemappedTypeName(varDecl, type, out var nativeTypeName);
                 AddNativeTypeNameAttribute(nativeTypeName, prefix: "// ");

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -230,6 +230,30 @@ namespace ClangSharp
             }
         }
 
+        private void WithAttributes(string remappedName)
+        {
+            if (_config.WithAttributes.TryGetValue(remappedName, out IReadOnlyList<string> attributes))
+            {
+                foreach (var attribute in attributes)
+                {
+                    _outputBuilder.WriteIndented('[');
+                    _outputBuilder.Write(attribute);
+                    _outputBuilder.WriteLine(']');
+                }
+            }
+        }
+
+        private void WithNamespaces(string remappedName)
+        {
+            if (_config.WithNamespaces.TryGetValue(remappedName, out IReadOnlyList<string> namespaceNames))
+            {
+                foreach (var namespaceName in namespaceNames)
+                {
+                    _outputBuilder.AddUsingDirective(namespaceName);
+                }
+            }
+        }
+
         private void CloseOutputBuilder(Stream stream, OutputBuilder outputBuilder, bool isMethodClass, bool leaveStreamOpen, bool emitNamespaceDeclaration)
         {
             if (stream is null)

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/EnumDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/EnumDeclarationTest.cs
@@ -59,6 +59,40 @@ namespace ClangSharp.UnitTests
         }
 
         [Fact]
+        public async Task FlagsTest()
+        {
+            var inputContents = @"enum MyEnum : int
+{
+    MyEnum_Value1 = 1,
+    MyEnum_Value2,
+    MyEnum_Value3,
+};
+";
+
+            var expectedOutputContents = @"using System;
+
+namespace ClangSharp.Test
+{
+    [Flags]
+    public enum MyEnum
+    {
+        MyEnum_Value1 = 1,
+        MyEnum_Value2,
+        MyEnum_Value3,
+    }
+}
+";
+
+            var withAttributes = new Dictionary<string, IReadOnlyList<string>> {
+                ["MyEnum"] = new List<string>() { "Flags" }
+            };
+            var withNamespaces = new Dictionary<string, IReadOnlyList<string>> {
+                ["MyEnum"] = new List<string>() { "System" }
+            };
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents, withAttributes: withAttributes, withNamespaces: withNamespaces);
+        }
+
+        [Fact]
         public async Task ExcludeTest()
         {
             var inputContents = @"enum MyEnum : int

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/PInvokeGeneratorTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/PInvokeGeneratorTest.cs
@@ -24,17 +24,17 @@ namespace ClangSharp.UnitTests
             "-Wno-pragma-once-outside-header"       // We are processing files which may be header files
         };
 
-        protected Task ValidateGeneratedBindings(string inputContents, string expectedOutputContents, string[] excludedNames = null, IReadOnlyDictionary<string, string> remappedNames = null, IEnumerable<Diagnostic> expectedDiagnostics = null)
+        protected Task ValidateGeneratedBindings(string inputContents, string expectedOutputContents, string[] excludedNames = null, IReadOnlyDictionary<string, string> remappedNames = null, IReadOnlyDictionary<string, IReadOnlyList<string>> withAttributes = null, IReadOnlyDictionary<string, IReadOnlyList<string>> withNamespaces = null, IEnumerable<Diagnostic> expectedDiagnostics = null)
         {
-            return ValidateGeneratedBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.None, excludedNames, remappedNames, expectedDiagnostics);
+            return ValidateGeneratedBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.None, excludedNames, remappedNames, withAttributes, withNamespaces, expectedDiagnostics);
         }
 
-        protected Task ValidateGeneratedCompatibleBindings(string inputContents, string expectedOutputContents, string[] excludedNames = null, IReadOnlyDictionary<string, string> remappedNames = null, IEnumerable<Diagnostic> expectedDiagnostics = null)
+        protected Task ValidateGeneratedCompatibleBindings(string inputContents, string expectedOutputContents, string[] excludedNames = null, IReadOnlyDictionary<string, string> remappedNames = null, IReadOnlyDictionary<string, IReadOnlyList<string>> withAttributes = null, IReadOnlyDictionary<string, IReadOnlyList<string>> withNamespaces = null, IEnumerable<Diagnostic> expectedDiagnostics = null)
         {
-            return ValidateGeneratedBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateCompatibleCode, excludedNames, remappedNames, expectedDiagnostics);
+            return ValidateGeneratedBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateCompatibleCode, excludedNames, remappedNames, withAttributes, withNamespaces, expectedDiagnostics);
         }
 
-        private async Task ValidateGeneratedBindingsAsync(string inputContents, string expectedOutputContents, PInvokeGeneratorConfigurationOptions configOptions, string[] excludedNames, IReadOnlyDictionary<string, string> remappedNames, IEnumerable<Diagnostic> expectedDiagnostics)
+        private async Task ValidateGeneratedBindingsAsync(string inputContents, string expectedOutputContents, PInvokeGeneratorConfigurationOptions configOptions, string[] excludedNames, IReadOnlyDictionary<string, string> remappedNames, IReadOnlyDictionary<string, IReadOnlyList<string>> withAttributes, IReadOnlyDictionary<string, IReadOnlyList<string>> withNamespaces, IEnumerable<Diagnostic> expectedDiagnostics)
         {
             Assert.True(File.Exists(DefaultInputFileName));
 
@@ -42,7 +42,7 @@ namespace ClangSharp.UnitTests
             using var unsavedFile = CXUnsavedFile.Create(DefaultInputFileName, inputContents);
 
             var unsavedFiles = new CXUnsavedFile[] { unsavedFile };
-            var config = new PInvokeGeneratorConfiguration(DefaultLibraryPath, DefaultNamespaceName, Path.GetRandomFileName(), configOptions, excludedNames, headerFile: null, methodClassName: null, methodPrefixToStrip: null, remappedNames);
+            var config = new PInvokeGeneratorConfiguration(DefaultLibraryPath, DefaultNamespaceName, Path.GetRandomFileName(), configOptions, excludedNames, headerFile: null, methodClassName: null, methodPrefixToStrip: null, remappedNames, withAttributes: withAttributes, withNamespaces: withNamespaces);
 
             using (var pinvokeGenerator = new PInvokeGenerator(config, (path) => outputStream))
             {


### PR DESCRIPTION
This provides a mechanism for providing additional attributes and using directives for remapped declaration names.

This, for example, allows you to add the `System.Flags` attribute to an enum or a `System.Runtime.InteropServices.GuidAttribute` to a struct.

This resolves https://github.com/microsoft/ClangSharp/issues/83