### PR TITLE
Fixing binding generation to support multidimensional arrays and conflicting names

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -334,6 +334,12 @@ namespace ClangSharp
             _outputBuilder.WriteIndented(GetAccessSpecifierName(fieldDecl));
             _outputBuilder.Write(' ');
 
+            if (NeedsNewKeyword(name))
+            {
+                _outputBuilder.Write("new");
+                _outputBuilder.Write(' ');
+            }
+
             if (type is ConstantArrayType constantArrayType)
             {
                 if (IsSupportedFixedSizedBufferType(typeName))
@@ -472,9 +478,26 @@ namespace ClangSharp
 
             _outputBuilder.Write(' ');
 
-            if (IsUnsafe(functionDecl))
+            if (!isVirtual)
             {
-                _isMethodClassUnsafe = true;
+                if (NeedsNewKeyword(name, functionDecl.Parameters))
+                {
+                    _outputBuilder.Write("new");
+                    _outputBuilder.Write(' ');
+                }
+
+                if (IsUnsafe(functionDecl))
+                {
+                    if (cxxRecordDecl is null)
+                    {
+                        _isMethodClassUnsafe = true;
+                    }
+                    else
+                    {
+                        _outputBuilder.Write("unsafe");
+                        _outputBuilder.Write(' ');
+                    }
+                }
             }
 
             _outputBuilder.Write(returnTypeName);

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -979,6 +979,29 @@ namespace ClangSharp
             return needsReturnFixup;
         }
 
+        private bool NeedsNewKeyword(string name)
+        {
+            return name.Equals("Equals")
+                || name.Equals("GetHashCode")
+                || name.Equals("GetType")
+                || name.Equals("MemberwiseClone")
+                || name.Equals("ReferenceEquals")
+                || name.Equals("ToString");
+        }
+
+        private bool NeedsNewKeyword(string name, IReadOnlyList<ParmVarDecl> parmVarDecls)
+        {
+            if (name.Equals("GetHashCode")
+                || name.Equals("GetType")
+                || name.Equals("MemberwiseClone")
+                || name.Equals("ToString"))
+            {
+                return parmVarDecls.Count == 0;
+            }
+
+            return false;
+        }
+
         private string PrefixAndStripName(string name)
         {
             if (name.StartsWith(_config.MethodPrefixToStrip))

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
@@ -20,6 +20,11 @@ namespace ClangSharp.UnitTests
     {
         return 0;
     }
+
+    void* MyVoidStarMethod()
+    {
+        return nullptr;
+    }
 };
 ";
             var callConv = "Cdecl";
@@ -51,6 +56,172 @@ namespace ClangSharp.Test
         {{
             return 0;
         }}
+
+        [return: NativeTypeName(""void *"")]
+        public unsafe void* MyVoidStarMethod()
+        {{
+            return null;
+        }}
+    }}
+}}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task NewKeywordTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    int Equals() { return 0; }
+    int Equals(int obj) { return 0; }
+    int Finalize() { return 0; }
+    int Finalize(int obj) { return 0; }
+    int GetHashCode() { return 0; }
+    int GetHashCode(int obj) { return 0; }
+    int GetType() { return 0; }
+    int GetType(int obj) { return 0; }
+    int MemberwiseClone() { return 0; }
+    int MemberwiseClone(int obj) { return 0; }
+    int ReferenceEquals() { return 0; }
+    int ReferenceEquals(int obj) { return 0; }
+    int ToString() { return 0; }
+    int ToString(int obj) { return 0; }
+};";
+
+            var expectedOutputContents = $@"namespace ClangSharp.Test
+{{
+    public partial struct MyStruct
+    {{
+        public int Equals()
+        {{
+            return 0;
+        }}
+
+        public int Equals(int obj)
+        {{
+            return 0;
+        }}
+
+        public int Finalize()
+        {{
+            return 0;
+        }}
+
+        public int Finalize(int obj)
+        {{
+            return 0;
+        }}
+
+        public new int GetHashCode()
+        {{
+            return 0;
+        }}
+
+        public int GetHashCode(int obj)
+        {{
+            return 0;
+        }}
+
+        public new int GetType()
+        {{
+            return 0;
+        }}
+
+        public int GetType(int obj)
+        {{
+            return 0;
+        }}
+
+        public new int MemberwiseClone()
+        {{
+            return 0;
+        }}
+
+        public int MemberwiseClone(int obj)
+        {{
+            return 0;
+        }}
+
+        public int ReferenceEquals()
+        {{
+            return 0;
+        }}
+
+        public int ReferenceEquals(int obj)
+        {{
+            return 0;
+        }}
+
+        public new int ToString()
+        {{
+            return 0;
+        }}
+
+        public int ToString(int obj)
+        {{
+            return 0;
+        }}
+    }}
+}}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task NewKeywordVirtualTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    virtual int GetType() = 0;
+    virtual int GetType(int obj) = 0;
+};";
+
+            var callConv = "Cdecl";
+            var callConvAttr = "";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
+            {
+                callConv = "ThisCall";
+                callConvAttr = " __attribute__((thiscall))";
+            }
+
+            var expectedOutputContents = $@"using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    public unsafe partial struct MyStruct
+    {{
+        public readonly Vtbl* lpVtbl;
+
+        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        public delegate int _GetType(MyStruct* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        public delegate int _GetType(MyStruct* pThis, int obj);
+
+        public int GetType()
+        {{
+            return Marshal.GetDelegateForFunctionPointer<_GetType>(lpVtbl->GetType)((MyStruct*)Unsafe.AsPointer(ref this));
+        }}
+
+        public int GetType(int obj)
+        {{
+            return Marshal.GetDelegateForFunctionPointer<_GetType>(lpVtbl->GetType)((MyStruct*)Unsafe.AsPointer(ref this), obj);
+        }}
+
+        public partial struct Vtbl
+        {{
+            [NativeTypeName(""int (){callConvAttr}"")]
+            public IntPtr GetType;
+
+            [NativeTypeName(""int (int){callConvAttr}"")]
+            public IntPtr GetType;
+        }}
     }}
 }}
 ";
@@ -68,6 +239,11 @@ namespace ClangSharp.Test
     static int MyInt32Method()
     {
         return 0;
+    }
+
+    static void* MyVoidStarMethod()
+    {
+        return nullptr;
     }
 };
 ";
@@ -92,8 +268,53 @@ namespace ClangSharp.Test
         {{
             return 0;
         }}
+
+        [return: NativeTypeName(""void *"")]
+        public static unsafe void* MyVoidStarMethod()
+        {{
+            return null;
+        }}
     }}
 }}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task UnsafeDoesNotImpactDllImportTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    void* MyVoidStarMethod()
+    {
+        return nullptr;
+    }
+};
+
+void MyFunction();";
+
+            var expectedOutputContents = @"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        [return: NativeTypeName(""void *"")]
+        public unsafe void* MyVoidStarMethod()
+        {
+            return null;
+        }
+    }
+
+    public static partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        [DllImport(LibraryPath, CallingConvention = CallingConvention.Cdecl, EntryPoint = ""MyFunction"", ExactSpelling = true)]
+        public static extern void MyFunction();
+    }
+}
 ";
 
             await ValidateGeneratedBindings(inputContents, expectedOutputContents);
@@ -199,6 +420,8 @@ namespace ClangSharp.Test
     }
 
     virtual int MyInt32Method();
+
+    virtual void* MyVoidStarMethod() = 0;
 };
 ";
 
@@ -231,6 +454,10 @@ namespace ClangSharp.Test
         [UnmanagedFunctionPointer(CallingConvention.{callConv})]
         public delegate int _MyInt32Method(MyStruct* pThis);
 
+        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [return: NativeTypeName(""void *"")]
+        public delegate void* _MyVoidStarMethod(MyStruct* pThis);
+
         public void MyVoidMethod()
         {{
             Marshal.GetDelegateForFunctionPointer<_MyVoidMethod>(lpVtbl->MyVoidMethod)((MyStruct*)Unsafe.AsPointer(ref this));
@@ -247,6 +474,12 @@ namespace ClangSharp.Test
             return Marshal.GetDelegateForFunctionPointer<_MyInt32Method>(lpVtbl->MyInt32Method)((MyStruct*)Unsafe.AsPointer(ref this));
         }}
 
+        [return: NativeTypeName(""void *"")]
+        public void* MyVoidStarMethod()
+        {{
+            return Marshal.GetDelegateForFunctionPointer<_MyVoidStarMethod>(lpVtbl->MyVoidStarMethod)((MyStruct*)Unsafe.AsPointer(ref this));
+        }}
+
         public partial struct Vtbl
         {{
             [NativeTypeName(""void (){callConvAttr}"")]
@@ -257,6 +490,9 @@ namespace ClangSharp.Test
 
             [NativeTypeName(""int (){callConvAttr}"")]
             public IntPtr MyInt32Method;
+
+            [NativeTypeName(""void *(){callConvAttr}"")]
+            public IntPtr MyVoidStarMethod;
         }}
     }}
 }}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
@@ -177,6 +177,7 @@ namespace ClangSharp.Test
 {
     virtual int GetType() = 0;
     virtual int GetType(int obj) = 0;
+    virtual int GetType(int objA, int objB) = 0;
 };";
 
             var callConv = "Cdecl";
@@ -202,25 +203,36 @@ namespace ClangSharp.Test
         public delegate int _GetType(MyStruct* pThis);
 
         [UnmanagedFunctionPointer(CallingConvention.{callConv})]
-        public delegate int _GetType(MyStruct* pThis, int obj);
+        public delegate int _GetType1(MyStruct* pThis, int obj);
 
-        public int GetType()
+        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        public delegate int _GetType2(MyStruct* pThis, int objA, int objB);
+
+        public new int GetType()
         {{
             return Marshal.GetDelegateForFunctionPointer<_GetType>(lpVtbl->GetType)((MyStruct*)Unsafe.AsPointer(ref this));
         }}
 
         public int GetType(int obj)
         {{
-            return Marshal.GetDelegateForFunctionPointer<_GetType>(lpVtbl->GetType)((MyStruct*)Unsafe.AsPointer(ref this), obj);
+            return Marshal.GetDelegateForFunctionPointer<_GetType1>(lpVtbl->GetType1)((MyStruct*)Unsafe.AsPointer(ref this), obj);
+        }}
+
+        public int GetType(int objA, int objB)
+        {{
+            return Marshal.GetDelegateForFunctionPointer<_GetType2>(lpVtbl->GetType2)((MyStruct*)Unsafe.AsPointer(ref this), objA, objB);
         }}
 
         public partial struct Vtbl
         {{
             [NativeTypeName(""int (){callConvAttr}"")]
-            public IntPtr GetType;
+            public new IntPtr GetType;
 
             [NativeTypeName(""int (int){callConvAttr}"")]
-            public IntPtr GetType;
+            public IntPtr GetType1;
+
+            [NativeTypeName(""int (int, int){callConvAttr}"")]
+            public IntPtr GetType2;
         }}
     }}
 }}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
@@ -647,6 +647,44 @@ namespace ClangSharp.Test
             await ValidateGeneratedBindings(inputContents, expectedOutputContents, expectedDiagnostics: expectedDiagnostics);
         }
 
+        [Fact]
+        public async Task NewKeywordTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    int Equals;
+    int Finalize;
+    int GetHashCode;
+    int GetType;
+    int MemberwiseClone;
+    int ReferenceEquals;
+    int ToString;
+};";
+
+            var expectedOutputContents = $@"namespace ClangSharp.Test
+{{
+    public partial struct MyStruct
+    {{
+        public new int Equals;
+
+        public int Finalize;
+
+        public new int GetHashCode;
+
+        public new int GetType;
+
+        public new int MemberwiseClone;
+
+        public new int ReferenceEquals;
+
+        public new int ToString;
+    }}
+}}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
         [Theory]
         [InlineData("double", "double")]
         [InlineData("short", "short")]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
@@ -345,6 +345,88 @@ namespace ClangSharp.Test
         }
 
         [Theory]
+        [InlineData("double", "double")]
+        [InlineData("short", "short")]
+        [InlineData("int", "int")]
+        [InlineData("float", "float")]
+        public async Task FixedSizedBufferNonPrimitiveMultidimensionalTest(string nativeType, string expectedManagedType)
+        {
+            var inputContents = $@"struct MyStruct
+{{
+    {nativeType} value;
+}};
+
+struct MyOtherStruct
+{{
+    MyStruct c[2][1][3][4];
+}};
+";
+
+            var expectedOutputContents = $@"using System;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    public partial struct MyStruct
+    {{
+        public {expectedManagedType} value;
+    }}
+
+    public partial struct MyOtherStruct
+    {{
+        [NativeTypeName(""MyStruct [2][1][3][4]"")]
+        public _c_e__FixedBuffer c;
+
+        public partial struct _c_e__FixedBuffer
+        {{
+            internal MyStruct e0_0_0_0;
+            internal MyStruct e1_0_0_0;
+
+            internal MyStruct e0_0_1_0;
+            internal MyStruct e1_0_1_0;
+
+            internal MyStruct e0_0_2_0;
+            internal MyStruct e1_0_2_0;
+
+            internal MyStruct e0_0_0_1;
+            internal MyStruct e1_0_0_1;
+
+            internal MyStruct e0_0_1_1;
+            internal MyStruct e1_0_1_1;
+
+            internal MyStruct e0_0_2_1;
+            internal MyStruct e1_0_2_1;
+
+            internal MyStruct e0_0_0_2;
+            internal MyStruct e1_0_0_2;
+
+            internal MyStruct e0_0_1_2;
+            internal MyStruct e1_0_1_2;
+
+            internal MyStruct e0_0_2_2;
+            internal MyStruct e1_0_2_2;
+
+            internal MyStruct e0_0_0_3;
+            internal MyStruct e1_0_0_3;
+
+            internal MyStruct e0_0_1_3;
+            internal MyStruct e1_0_1_3;
+
+            internal MyStruct e0_0_2_3;
+            internal MyStruct e1_0_2_3;
+
+            public ref MyStruct this[int index] => ref AsSpan()[index];
+
+            public Span<MyStruct> AsSpan() => MemoryMarshal.CreateSpan(ref e0, 24);
+        }}
+    }}
+}}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Theory]
         [InlineData("unsigned char", "byte")]
         [InlineData("long long", "long")]
         [InlineData("signed char", "sbyte")]
@@ -479,6 +561,38 @@ namespace ClangSharp.Test
     {{
         [NativeTypeName(""{nativeType} [3]"")]
         public fixed {expectedManagedType} c[3];
+    }}
+}}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Theory]
+        [InlineData("unsigned char", "byte")]
+        [InlineData("double", "double")]
+        [InlineData("short", "short")]
+        [InlineData("int", "int")]
+        [InlineData("long long", "long")]
+        [InlineData("signed char", "sbyte")]
+        [InlineData("float", "float")]
+        [InlineData("unsigned short", "ushort")]
+        [InlineData("unsigned int", "uint")]
+        [InlineData("unsigned long long", "ulong")]
+        public async Task FixedSizedBufferPrimitiveMultidimensionalTest(string nativeType, string expectedManagedType)
+        {
+            var inputContents = $@"struct MyStruct
+{{
+    {nativeType} c[2][1][3][4];
+}};
+";
+
+            var expectedOutputContents = $@"namespace ClangSharp.Test
+{{
+    public unsafe partial struct MyStruct
+    {{
+        [NativeTypeName(""{nativeType} [2][1][3][4]"")]
+        public fixed {expectedManagedType} c[2 * 1 * 3 * 4];
     }}
 }}
 ";


### PR DESCRIPTION
This fixes up binding generation to support multidimensional arrays and to avoid conflicts when encountering certain member names or when generating the virtual dispatch table.