### PR TITLE
Adding support for binding the most common statement and expression kinds

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/OutputBuilder.cs
+++ b/sources/ClangSharp.PInvokeGenerator/OutputBuilder.cs
@@ -35,6 +35,8 @@ namespace ClangSharp
 
         public string Name => _name;
 
+        public bool NeedsNewline { get; set; }
+
         public IEnumerable<string> StaticUsingDirectives => _staticUsingDirectives;
 
         public IEnumerable<string> UsingDirectives => _usingDirectives;
@@ -74,6 +76,9 @@ namespace ClangSharp
 
         public void WriteBlockEnd()
         {
+            // We don't need a newline if immediately closing the scope
+            NeedsNewline = false;
+
             DecreaseIndentation();
             WriteIndentedLine('}');
         }
@@ -85,6 +90,12 @@ namespace ClangSharp
 
         public void WriteIndentation()
         {
+            if (NeedsNewline)
+            {
+                WriteLine();
+            }
+            NeedsNewline = false;
+
             for (var i = 0; i < _indentationLevel; i++)
             {
                 _currentLine.Append(_indentationString);
@@ -109,7 +120,7 @@ namespace ClangSharp
             WriteLine();
         }
 
-        public void WriteLine()
+        private void WriteLine()
         {
             _contents.Add(_currentLine.ToString());
             _currentLine.Clear();

--- a/sources/ClangSharp.PInvokeGenerator/OutputBuilder.cs
+++ b/sources/ClangSharp.PInvokeGenerator/OutputBuilder.cs
@@ -37,6 +37,8 @@ namespace ClangSharp
 
         public bool NeedsNewline { get; set; }
 
+        public bool NeedsSemicolon { get; set; }
+
         public IEnumerable<string> StaticUsingDirectives => _staticUsingDirectives;
 
         public IEnumerable<string> UsingDirectives => _usingDirectives;
@@ -79,6 +81,9 @@ namespace ClangSharp
             // We don't need a newline if immediately closing the scope
             NeedsNewline = false;
 
+            // We don't need a semicolon if immediately closing the scope
+            NeedsSemicolon = false;
+
             DecreaseIndentation();
             WriteIndentedLine('}');
         }
@@ -118,6 +123,15 @@ namespace ClangSharp
         {
             Write(value);
             WriteLine();
+        }
+
+        public void WriteSemicolonIfNeeded()
+        {
+            if (NeedsSemicolon)
+            {
+                WriteLine(';');
+            }
+            NeedsSemicolon = true;
         }
 
         private void WriteLine()

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -1055,7 +1055,9 @@ namespace ClangSharp
                 var cxxMethodDeclName = pinvokeGenerator.GetRemappedCursorName(cxxMethodDecl);
                 RestoreNameForMultipleHits(pinvokeGenerator, cxxMethodDecl, hitsPerName, remappedName);
 
-                if (pinvokeGenerator.NeedsNewKeyword(cxxMethodDeclName))
+                var escapedName = pinvokeGenerator.EscapeAndStripName(cxxMethodDeclName);
+
+                if (pinvokeGenerator.NeedsNewKeyword(escapedName))
                 {
                     outputBuilder.Write("new");
                     outputBuilder.Write(' ');
@@ -1064,7 +1066,7 @@ namespace ClangSharp
                 outputBuilder.Write("IntPtr");
                 outputBuilder.Write(' ');
 
-                outputBuilder.Write(pinvokeGenerator.EscapeAndStripName(cxxMethodDeclName));
+                outputBuilder.Write(escapedName);
 
                 outputBuilder.WriteLine(';');
             }
@@ -1087,7 +1089,9 @@ namespace ClangSharp
                 var cxxMethodDeclName = pinvokeGenerator.GetRemappedCursorName(cxxMethodDecl);
                 RestoreNameForMultipleHits(pinvokeGenerator, cxxMethodDecl, hitsPerName, remappedName);
 
-                if (pinvokeGenerator.NeedsNewKeyword(cxxMethodDeclName))
+                var escapedName = pinvokeGenerator.EscapeAndStripName(remappedName);
+
+                if (pinvokeGenerator.NeedsNewKeyword(escapedName, cxxMethodDecl.Parameters))
                 {
                     outputBuilder.Write("new");
                     outputBuilder.Write(' ');
@@ -1096,7 +1100,7 @@ namespace ClangSharp
                 outputBuilder.Write(returnTypeName);
                 outputBuilder.Write(' ');
 
-                outputBuilder.Write(pinvokeGenerator.EscapeAndStripName(remappedName));
+                outputBuilder.Write(escapedName);
 
                 outputBuilder.Write('(');
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -560,7 +560,7 @@ namespace ClangSharp
 
             foreach (var parmVarDecl in functionDecl.Parameters)
             {
-                _visitedCursors.Add(parmVarDecl);
+                _visitedDecls.Add(parmVarDecl);
                 VisitParmVarDecl(parmVarDecl);
             }
 
@@ -991,7 +991,7 @@ namespace ClangSharp
                     }
 
                     pinvokeGenerator._outputBuilder.WriteLine();
-                    pinvokeGenerator._visitedCursors.Add(cxxMethodDecl);
+                    pinvokeGenerator._visitedDecls.Add(cxxMethodDecl);
 
                     var remappedName = FixupNameForMultipleHits(pinvokeGenerator, cxxMethodDecl, hitsPerName);
                     pinvokeGenerator.VisitFunctionDecl(cxxMethodDecl, rootCxxRecordDecl);

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -117,7 +117,15 @@ namespace ClangSharp
                 }
 
                 // case CX_DeclKind.CX_DeclKind_UnresolvedUsingTypename:
-                // case CX_DeclKind.CX_DeclKind_Using:
+
+                case CX_DeclKind.CX_DeclKind_Using:
+                {
+                    // Using declarations only introduce existing members into
+                    // the current scope. There isn't an easy way to translate
+                    // this to C#, so we will ignore them for now.
+                    break;
+                }
+
                 // case CX_DeclKind.CX_DeclKind_UsingDirective:
                 // case CX_DeclKind.CX_DeclKind_UsingPack:
                 // case CX_DeclKind.CX_DeclKind_UsingShadow:

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -1675,6 +1675,10 @@ namespace ClangSharp
             {
                 VisitTypedefDeclForPointeeType(typedefDecl, parentType: null, pointerType.PointeeType);
             }
+            else if (underlyingType is ReferenceType referenceType)
+            {
+                VisitTypedefDeclForPointeeType(typedefDecl, parentType: null, referenceType.PointeeType);
+            }
             else if (underlyingType is TypedefType typedefType)
             {
                 VisitTypedefDeclForUnderlyingType(typedefDecl, typedefType.Decl.UnderlyingType);

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -635,7 +635,21 @@ namespace ClangSharp
                             continue;
                         }
 
+                        var memberRefName = pinvokeGenerator.GetRemappedCursorName(memberRef.Referenced);
+                        var memberInitName = memberInit.Spelling;
+
+                        if ((memberInit is ImplicitCastExpr implicitCastExpr) && (implicitCastExpr.SubExpr is DeclRefExpr declRefExpr))
+                        {
+                            memberInitName = pinvokeGenerator.GetRemappedCursorName(declRefExpr.Decl);
+                        }
                         outputBuilder.WriteIndentation();
+
+                        if (memberRefName.Equals(memberInitName))
+                        {
+                            outputBuilder.Write("this");
+                            outputBuilder.Write('.');
+                        }
+
                         pinvokeGenerator.Visit(memberRef);
                         outputBuilder.Write(' ');
                         outputBuilder.Write('=');

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -581,7 +581,12 @@ namespace ClangSharp
                 else
                 {
                     _outputBuilder.WriteBlockStart();
+                    _outputBuilder.WriteIndentation();
+
+                    _outputBuilder.NeedsSemicolon = true;
                     Visit(body);
+
+                    _outputBuilder.WriteSemicolonIfNeeded();
                     _outputBuilder.WriteBlockEnd();
                 }
             }
@@ -1692,8 +1697,9 @@ namespace ClangSharp
                     _outputBuilder.Write('(');
 
                     VisitDecls(typedefDecl.CursorChildren.OfType<ParmVarDecl>());
-        
-                    _outputBuilder.WriteLine(");");
+
+                    _outputBuilder.Write(')');
+                    _outputBuilder.WriteLine(";");
                 }
                 StopUsingOutputBuilder();
             }
@@ -1764,7 +1770,7 @@ namespace ClangSharp
                 var type = varDecl.Type;
                 var typeName = GetRemappedTypeName(varDecl, type, out var nativeTypeName);
 
-                _outputBuilder.WriteIndented(typeName);
+                _outputBuilder.Write(typeName);
                 _outputBuilder.Write(' ');
             }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitRef.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitRef.cs
@@ -6,7 +6,8 @@ namespace ClangSharp
     {
         private void VisitRef(Ref @ref)
         {
-            AddDiagnostic(DiagnosticLevel.Error, $"Unsupported reference: '{@ref.CursorKindSpelling}'. Generated bindings may be incomplete.", @ref);
+            var name = GetRemappedCursorName(@ref.Referenced);
+            _outputBuilder.Write(name);
         }
     }
 }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -92,6 +92,11 @@ namespace ClangSharp
             _outputBuilder.Write("null");
         }
 
+        private void VisitCXXThisExpr(CXXThisExpr cxxThisExpr)
+        {
+            _outputBuilder.Write("this");
+        }
+
         private void VisitDeclRefExpr(DeclRefExpr declRefExpr)
         {
             var name = GetRemappedCursorName(declRefExpr.Decl);
@@ -146,7 +151,7 @@ namespace ClangSharp
             {
                 Visit(memberExpr.Base);
 
-                if (memberExpr.Base.Type is PointerType)
+                if ((memberExpr.Base.Type is PointerType) && !(memberExpr.Base is CXXThisExpr))
                 {
                     _outputBuilder.Write('-');
                     _outputBuilder.Write('>');
@@ -333,7 +338,13 @@ namespace ClangSharp
                 // case CX_StmtClass.CX_StmtClass_CXXPseudoDestructorExpr:
                 // case CX_StmtClass.CX_StmtClass_CXXScalarValueInitExpr:
                 // case CX_StmtClass.CX_StmtClass_CXXStdInitializerListExpr:
-                // case CX_StmtClass.CX_StmtClass_CXXThisExpr:
+
+                case CX_StmtClass.CX_StmtClass_CXXThisExpr:
+                {
+                    VisitCXXThisExpr((CXXThisExpr)stmt);
+                    break;
+                }
+
                 // case CX_StmtClass.CX_StmtClass_CXXThrowExpr:
                 // case CX_StmtClass.CX_StmtClass_CXXTypeidExpr:
                 // case CX_StmtClass.CX_StmtClass_CXXUnresolvedConstructExpr:

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -69,6 +69,19 @@ namespace ClangSharp
             _outputBuilder.WriteBlockEnd();
         }
 
+        private void VisitConditionalOperator(ConditionalOperator conditionalOperator)
+        {
+            Visit(conditionalOperator.Cond);
+            _outputBuilder.Write(' ');
+            _outputBuilder.Write('?');
+            _outputBuilder.Write(' ');
+            Visit(conditionalOperator.TrueExpr);
+            _outputBuilder.Write(' ');
+            _outputBuilder.Write(':');
+            _outputBuilder.Write(' ');
+            Visit(conditionalOperator.FalseExpr);
+        }
+
         private void VisitCXXBoolLiteralExpr(CXXBoolLiteralExpr cxxBoolLiteralExpr)
         {
             _outputBuilder.Write(cxxBoolLiteralExpr.Value);
@@ -244,7 +257,13 @@ namespace ClangSharp
                 // case CX_StmtClass.CX_StmtClass_SwitchStmt:
                 // case CX_StmtClass.CX_StmtClass_AttributedStmt:
                 // case CX_StmtClass.CX_StmtClass_BinaryConditionalOperator:
-                // case CX_StmtClass.CX_StmtClass_ConditionalOperator:
+
+                case CX_StmtClass.CX_StmtClass_ConditionalOperator:
+                {
+                    VisitConditionalOperator((ConditionalOperator)stmt);
+                    break;
+                }
+
                 // case CX_StmtClass.CX_StmtClass_AddrLabelExpr:
                 // case CX_StmtClass.CX_StmtClass_ArrayInitIndexExpr:
                 // case CX_StmtClass.CX_StmtClass_ArrayInitLoopExpr:

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using ClangSharp.Interop;
@@ -103,22 +104,7 @@ namespace ClangSharp
             _outputBuilder.WriteBlockStart();
             _outputBuilder.NeedsSemicolon = true;
 
-            Stmt previousStmt = null;
-
-            foreach (var stmt in compoundStmt.Body)
-            {
-                if ((previousStmt is DeclStmt declStmt) && (stmt is DeclStmt))
-                {
-                    _outputBuilder.NeedsNewline = false;
-                }
-
-                _outputBuilder.WriteIndentation();
-                Visit(stmt);
-                _outputBuilder.WriteSemicolonIfNeeded();
-
-                previousStmt = stmt;
-            }
-
+            VisitStmts(compoundStmt.Body);
             _outputBuilder.WriteBlockEnd();
         }
 
@@ -802,6 +788,25 @@ namespace ClangSharp
                     AddDiagnostic(DiagnosticLevel.Error, $"Unsupported statement: '{stmt.StmtClass}'. Generated bindings may be incomplete.", stmt);
                     break;
                 }
+            }
+        }
+
+        private void VisitStmts(IEnumerable<Stmt> stmts)
+        {
+            Stmt previousStmt = null;
+
+            foreach (var stmt in stmts)
+            {
+                if ((previousStmt is DeclStmt declStmt) && (stmt is DeclStmt))
+                {
+                    _outputBuilder.NeedsNewline = false;
+                }
+
+                _outputBuilder.WriteIndentation();
+                Visit(stmt);
+                _outputBuilder.WriteSemicolonIfNeeded();
+
+                previousStmt = stmt;
             }
         }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -140,6 +140,37 @@ namespace ClangSharp
             _outputBuilder.NeedsNewline = true;
         }
 
+        private void VisitDoStmt(DoStmt doStmt)
+        {
+            _outputBuilder.WriteLine("do");
+
+            if (doStmt.Body is CompoundStmt)
+            {
+                Visit(doStmt.Body);
+            }
+            else
+            {
+                _outputBuilder.IncreaseIndentation();
+                _outputBuilder.WriteIndentation();
+
+                _outputBuilder.NeedsSemicolon = true;
+                Visit(doStmt.Body);
+
+                _outputBuilder.WriteSemicolonIfNeeded();
+                _outputBuilder.DecreaseIndentation();
+            }
+
+            _outputBuilder.WriteIndented("while");
+            _outputBuilder.Write(' ');
+            _outputBuilder.Write('(');
+
+            Visit(doStmt.Cond);
+            _outputBuilder.Write(')');
+
+            _outputBuilder.NeedsSemicolon = true;
+            _outputBuilder.NeedsNewline = true;
+        }
+
         private void VisitExplicitCastExpr(ExplicitCastExpr explicitCastExpr)
         {
             if (!(explicitCastExpr is CXXConstCastExpr))
@@ -305,7 +336,12 @@ namespace ClangSharp
                     break;
                 }
 
-                // case CX_StmtClass.CX_StmtClass_DoStmt:
+                case CX_StmtClass.CX_StmtClass_DoStmt:
+                {
+                    VisitDoStmt((DoStmt)stmt);
+                    break;
+                }
+
                 // case CX_StmtClass.CX_StmtClass_ForStmt:
                 // case CX_StmtClass.CX_StmtClass_GotoStmt:
 
@@ -597,7 +633,12 @@ namespace ClangSharp
 
                 // case CX_StmtClass.CX_StmtClass_VAArgExpr:
                 // case CX_StmtClass.CX_StmtClass_LabelStmt:
-                // case CX_StmtClass.CX_StmtClass_WhileStmt:
+
+                case CX_StmtClass.CX_StmtClass_WhileStmt:
+                {
+                    VisitWhileStmt((WhileStmt)stmt);
+                    break;
+                }
 
                 default:
                 {
@@ -639,6 +680,34 @@ namespace ClangSharp
                     break;
                 }
             }
+        }
+
+        private void VisitWhileStmt(WhileStmt whileStmt)
+        {
+            _outputBuilder.Write("while");
+            _outputBuilder.Write(' ');
+            _outputBuilder.Write('(');
+
+            Visit(whileStmt.Cond);
+
+            _outputBuilder.WriteLine(')');
+
+            if (whileStmt.Body is CompoundStmt)
+            {
+                Visit(whileStmt.Body);
+            }
+            else
+            {
+                _outputBuilder.IncreaseIndentation();
+                _outputBuilder.WriteIndentation();
+
+                _outputBuilder.NeedsSemicolon = true;
+                Visit(whileStmt.Body);
+
+                _outputBuilder.DecreaseIndentation();
+            }
+
+            _outputBuilder.NeedsNewline = true;
         }
     }
 }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -49,6 +49,11 @@ namespace ClangSharp
             }
         }
 
+        private void VisitCharacterLiteral(CharacterLiteral characterLiteral)
+        {
+            _outputBuilder.Write(characterLiteral.Value);
+        }
+
         private void VisitCompoundStmt(CompoundStmt compoundStmt)
         {
             _outputBuilder.WriteBlockStart();
@@ -298,7 +303,12 @@ namespace ClangSharp
                     break;
                 }
 
-                // case CX_StmtClass.CX_StmtClass_CharacterLiteral:
+                case CX_StmtClass.CX_StmtClass_CharacterLiteral:
+                {
+                    VisitCharacterLiteral((CharacterLiteral)stmt);
+                    break;
+                }
+
                 // case CX_StmtClass.CX_StmtClass_ChooseExpr:
                 // case CX_StmtClass.CX_StmtClass_CompoundLiteralExpr:
                 // case CX_StmtClass.CX_StmtClass_ConvertVectorExpr:

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -8,6 +8,14 @@ namespace ClangSharp
 {
     public partial class PInvokeGenerator
     {
+        private void VisitArraySubscriptExpr(ArraySubscriptExpr arraySubscriptExpr)
+        {
+            Visit(arraySubscriptExpr.Base);
+            _outputBuilder.Write('[');
+            Visit(arraySubscriptExpr.Idx);
+            _outputBuilder.Write(']');
+        }
+
         private void VisitBinaryOperator(BinaryOperator binaryOperator)
         {
             Visit(binaryOperator.LHS);
@@ -240,7 +248,13 @@ namespace ClangSharp
                 // case CX_StmtClass.CX_StmtClass_AddrLabelExpr:
                 // case CX_StmtClass.CX_StmtClass_ArrayInitIndexExpr:
                 // case CX_StmtClass.CX_StmtClass_ArrayInitLoopExpr:
-                // case CX_StmtClass.CX_StmtClass_ArraySubscriptExpr:
+
+                case CX_StmtClass.CX_StmtClass_ArraySubscriptExpr:
+                {
+                    VisitArraySubscriptExpr((ArraySubscriptExpr)stmt);
+                    break;
+                }
+
                 // case CX_StmtClass.CX_StmtClass_ArrayTypeTraitExpr:
                 // case CX_StmtClass.CX_StmtClass_AsTypeExpr:
                 // case CX_StmtClass.CX_StmtClass_AtomicExpr:

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -140,6 +140,25 @@ namespace ClangSharp
             _outputBuilder.Write(integerLiteral.Value);
         }
 
+        private void VisitMemberExpr(MemberExpr memberExpr)
+        {
+            if (memberExpr.Base != null)
+            {
+                Visit(memberExpr.Base);
+
+                if (memberExpr.Base.Type is PointerType)
+                {
+                    _outputBuilder.Write('-');
+                    _outputBuilder.Write('>');
+                }
+                else
+                {
+                    _outputBuilder.Write('.');
+                }
+            }
+            _outputBuilder.Write(GetRemappedCursorName(memberExpr.MemberDecl));
+        }
+
         private void VisitParenExpr(ParenExpr parenExpr)
         {
             _outputBuilder.Write('(');
@@ -402,7 +421,13 @@ namespace ClangSharp
                 // case CX_StmtClass.CX_StmtClass_MSPropertyRefExpr:
                 // case CX_StmtClass.CX_StmtClass_MSPropertySubscriptExpr:
                 // case CX_StmtClass.CX_StmtClass_MaterializeTemporaryExpr:
-                // case CX_StmtClass.CX_StmtClass_MemberExpr:
+
+                case CX_StmtClass.CX_StmtClass_MemberExpr:
+                {
+                    VisitMemberExpr((MemberExpr)stmt);
+                    break;
+                }
+
                 // case CX_StmtClass.CX_StmtClass_NoInitExpr:
                 // case CX_StmtClass.CX_StmtClass_OMPArraySectionExpr:
                 // case CX_StmtClass.CX_StmtClass_ObjCArrayLiteral:

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -96,7 +96,17 @@ namespace ClangSharp
 
         private void VisitImplicitCastExpr(ImplicitCastExpr implicitCastExpr)
         {
-            Visit(implicitCastExpr.SubExpr);
+            if ((implicitCastExpr.Type is PointerType) && (implicitCastExpr.SubExpr is IntegerLiteral integerLiteral) && (integerLiteral.Value.Equals("0")))
+            {
+                // C# doesn't have implicit conversion from zero to a pointer
+                // so we will manually check and handle the most common case
+
+                _outputBuilder.Write("null");
+            }
+            else
+            {
+                Visit(implicitCastExpr.SubExpr);
+            }
         }
 
         private void VisitIntegerLiteral(IntegerLiteral integerLiteral)

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -193,6 +193,55 @@ namespace ClangSharp
             _outputBuilder.Write(floatingLiteral.Value);
         }
 
+        private void VisitForStmt(ForStmt forStmt)
+        {
+            _outputBuilder.Write("for");
+            _outputBuilder.Write(' ');
+            _outputBuilder.Write('(');
+
+            if (forStmt.ConditionVariableDeclStmt != null)
+            {
+                Visit(forStmt.ConditionVariableDeclStmt);
+            }
+            else if (forStmt.Init != null)
+            {
+                Visit(forStmt.Init);
+            }
+            _outputBuilder.Write(';');
+
+            if (forStmt.Cond != null)
+            {
+                _outputBuilder.Write(' ');
+                Visit(forStmt.Cond);
+            }
+            _outputBuilder.Write(';');
+
+            if (forStmt.Inc != null)
+            {
+                _outputBuilder.Write(' ');
+                Visit(forStmt.Inc);
+            }
+            _outputBuilder.Write(')');
+            _outputBuilder.NeedsNewline = true;
+
+            if (forStmt.Body is CompoundStmt)
+            {
+                Visit(forStmt.Body);
+            }
+            else
+            {
+                _outputBuilder.IncreaseIndentation();
+                _outputBuilder.WriteIndentation();
+
+                _outputBuilder.NeedsSemicolon = true;
+                Visit(forStmt.Body);
+
+                _outputBuilder.DecreaseIndentation();
+            }
+
+            _outputBuilder.NeedsNewline = true;
+        }
+
         private void VisitIfStmt(IfStmt ifStmt)
         {
             _outputBuilder.Write("if");
@@ -342,7 +391,12 @@ namespace ClangSharp
                     break;
                 }
 
-                // case CX_StmtClass.CX_StmtClass_ForStmt:
+                case CX_StmtClass.CX_StmtClass_ForStmt:
+                {
+                    VisitForStmt((ForStmt)stmt);
+                    break;
+                }
+
                 // case CX_StmtClass.CX_StmtClass_GotoStmt:
 
                 case CX_StmtClass.CX_StmtClass_IfStmt:

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -414,8 +414,6 @@ namespace ClangSharp
                     break;
                 }
             }
-
-            VisitStmts(stmt.Children);
         }
 
         private void VisitStmts(IEnumerable<Stmt> stmts)

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -106,6 +106,23 @@ namespace ClangSharp
 
         private void VisitDeclStmt(DeclStmt declStmt)
         {
+            var siblings = declStmt.CursorParent.CursorChildren.OfType<Stmt>();
+ 
+            Stmt previousSibling = null;
+ 
+            foreach (var sibling in siblings)
+            {
+                if (declStmt == sibling)
+                {
+                    if ((previousSibling != null) && (previousSibling is DeclStmt))
+                    {
+                        _outputBuilder.NeedsNewline = false;
+                    }
+                    break;
+                }
+                previousSibling = sibling;
+            }
+
             if (declStmt.IsSingleDecl)
             {
                 Visit(declStmt.SingleDecl);
@@ -124,6 +141,8 @@ namespace ClangSharp
                     _outputBuilder.WriteLine(';');
                 }
             }
+
+            _outputBuilder.NeedsNewline = true;
         }
 
         private void VisitExplicitCastExpr(ExplicitCastExpr explicitCastExpr)

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -650,13 +650,14 @@ namespace ClangSharp
                 // case CX_StmtClass.CX_StmtClass_CXXUuidofExpr:
 
                 case CX_StmtClass.CX_StmtClass_CallExpr:
+                case CX_StmtClass.CX_StmtClass_CXXMemberCallExpr:
                 {
                     VisitCallExpr((CallExpr)stmt);
                     break;
                 }
 
                 // case CX_StmtClass.CX_StmtClass_CUDAKernelCallExpr:
-                // case CX_StmtClass.CX_StmtClass_CXXMemberCallExpr:
+
                 // case CX_StmtClass.CX_StmtClass_CXXOperatorCallExpr:
                 // case CX_StmtClass.CX_StmtClass_UserDefinedLiteral:
                 // case CX_StmtClass.CX_StmtClass_BuiltinBitCastExpr:

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -79,13 +79,18 @@ namespace ClangSharp
 
         private void VisitExplicitCastExpr(ExplicitCastExpr explicitCastExpr)
         {
-            var type = explicitCastExpr.Type;
-            var typeName = GetRemappedTypeName(explicitCastExpr, type, out var nativeTypeName);
+            if (!(explicitCastExpr is CXXConstCastExpr))
+            {
+                // C# doesn't have a concept of const pointers so
+                // ignore rather than adding a cast from T* to T*
 
-            _outputBuilder.Write('(');
-            _outputBuilder.Write(typeName);
-            _outputBuilder.Write(')');
+                var type = explicitCastExpr.Type;
+                var typeName = GetRemappedTypeName(explicitCastExpr, type, out var nativeTypeName);
 
+                _outputBuilder.Write('(');
+                _outputBuilder.Write(typeName);
+                _outputBuilder.Write(')');
+            }
             Visit(explicitCastExpr.SubExpr);
         }
 
@@ -296,15 +301,15 @@ namespace ClangSharp
 
                 case CX_StmtClass.CX_StmtClass_CStyleCastExpr:
                 case CX_StmtClass.CX_StmtClass_CXXFunctionalCastExpr:
+                case CX_StmtClass.CX_StmtClass_CXXConstCastExpr:
+                case CX_StmtClass.CX_StmtClass_CXXDynamicCastExpr:
+                case CX_StmtClass.CX_StmtClass_CXXReinterpretCastExpr:
+                case CX_StmtClass.CX_StmtClass_CXXStaticCastExpr:
                 {
                     VisitExplicitCastExpr((ExplicitCastExpr)stmt);
                     break;
                 }
 
-                // case CX_StmtClass.CX_StmtClass_CXXConstCastExpr:
-                // case CX_StmtClass.CX_StmtClass_CXXDynamicCastExpr:
-                // case CX_StmtClass.CX_StmtClass_CXXReinterpretCastExpr:
-                // case CX_StmtClass.CX_StmtClass_CXXStaticCastExpr:
                 // case CX_StmtClass.CX_StmtClass_ObjCBridgedCastExpr:
 
                 case CX_StmtClass.CX_StmtClass_ImplicitCastExpr:

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -259,9 +259,11 @@ namespace ClangSharp
                     sw.WriteLine(_config.HeaderText);
                 }
 
-                if (outputBuilder.UsingDirectives.Any())
+                var usingDirectives = outputBuilder.UsingDirectives.Concat(outputBuilder.StaticUsingDirectives);
+
+                if (usingDirectives.Any())
                 {
-                    foreach (var usingDirective in outputBuilder.UsingDirectives.Concat(outputBuilder.StaticUsingDirectives))
+                    foreach(var usingDirective in usingDirectives)
                     {
                         sw.Write("using");
                         sw.Write(' ');

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -229,7 +229,7 @@ namespace ClangSharp
 
             if (postfix is null)
             {
-                _outputBuilder.WriteLine();
+                _outputBuilder.NeedsNewline = true;
             }
             else
             {
@@ -1021,7 +1021,7 @@ namespace ClangSharp
                 Debug.Assert(_outputBuilderUsers >= 1);
                 _outputBuilderUsers++;
 
-                _outputBuilder.WriteLine();
+                _outputBuilder.NeedsNewline = true;
                 return;
             }
 
@@ -1039,7 +1039,7 @@ namespace ClangSharp
             }
             else
             {
-                _outputBuilder.WriteLine();
+                _outputBuilder.NeedsNewline = true;
             }
             _outputBuilderUsers++;
         }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -594,6 +594,10 @@ namespace ClangSharp
                     AddDiagnostic(DiagnosticLevel.Error, $"Unsupported anonymous named declaration: '{namedDecl.Kind}'.", namedDecl);
                 }
             }
+            else if (namedDecl is CXXDestructorDecl)
+            {
+                name = "Finalize";
+            }
 
             Debug.Assert(!string.IsNullOrWhiteSpace(name));
             return name;

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -504,9 +504,9 @@ namespace ClangSharp
             return name;
         }
 
-        private string GetAnonymousName(NamedDecl namedDecl, string kind)
+        private string GetAnonymousName(Cursor cursor, string kind)
         {
-            namedDecl.Location.GetFileLocation(out var file, out var line, out var column, out _);
+            cursor.Location.GetFileLocation(out var file, out var line, out var column, out _);
             var fileName = Path.GetFileNameWithoutExtension(file.Name.ToString());
             return $"__Anonymous{kind}_{fileName}_L{line}_C{column}";
         }
@@ -597,9 +597,9 @@ namespace ClangSharp
             return name;
         }
 
-        private string GetRemappedAnonymousName(NamedDecl namedDecl, string kind)
+        private string GetRemappedAnonymousName(Cursor cursor, string kind)
         {
-            var name = GetAnonymousName(namedDecl, kind);
+            var name = GetAnonymousName(cursor, kind);
             return GetRemappedName(name);
         }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -18,7 +18,7 @@ namespace ClangSharp
         private readonly CXIndex _index;
         private readonly OutputBuilderFactory _outputBuilderFactory;
         private readonly Func<string, Stream> _outputStreamFactory;
-        private readonly HashSet<Cursor> _visitedCursors;
+        private readonly HashSet<Decl> _visitedDecls;
         private readonly List<Diagnostic> _diagnostics;
         private readonly PInvokeGeneratorConfiguration _config;
 
@@ -41,7 +41,7 @@ namespace ClangSharp
                 Directory.CreateDirectory(directoryPath);
                 return new FileStream(path, FileMode.Create);
             });
-            _visitedCursors = new HashSet<Cursor>();
+            _visitedDecls = new HashSet<Decl>();
             _diagnostics = new List<Diagnostic>();
             _config = config;
         }
@@ -143,7 +143,7 @@ namespace ClangSharp
 
             _diagnostics.Clear();
             _outputBuilderFactory.Clear();
-            _visitedCursors.Clear();
+            _visitedDecls.Clear();
         }
 
         public void Dispose()
@@ -181,7 +181,7 @@ namespace ClangSharp
             }
 
             var translationUnitDecl = translationUnit.TranslationUnitDecl;
-            _visitedCursors.Add(translationUnitDecl);
+            _visitedDecls.Add(translationUnitDecl);
 
             VisitDecls(translationUnitDecl.Decls);
         }
@@ -1053,19 +1053,18 @@ namespace ClangSharp
 
         private void Visit(Cursor cursor)
         {
-            if (_visitedCursors.Contains(cursor))
-            {
-                return;
-            }
-
-            _visitedCursors.Add(cursor);
-
             if (cursor is Attr attr)
             {
                 VisitAttr(attr);
             }
             else if (cursor is Decl decl)
             {
+                if (_visitedDecls.Contains(decl))
+                {
+                    return;
+                }
+                _visitedDecls.Add(decl);
+
                 VisitDecl(decl);
             }
             else if (cursor is Ref @ref)

--- a/sources/ClangSharp/Cursors/Decls/FunctionDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/FunctionDecl.cs
@@ -25,7 +25,7 @@ namespace ClangSharp
                 throw new ArgumentException(nameof(handle));
             }
 
-            _body = new Lazy<Stmt>(() => CursorChildren.OfType<Stmt>().SingleOrDefault());
+            _body = new Lazy<Stmt>(() => CursorChildren.OfType<Stmt>().LastOrDefault());
             _decls = new Lazy<IReadOnlyList<Decl>>(() => CursorChildren.OfType<Decl>().ToList());
             _parameters = new Lazy<IReadOnlyList<ParmVarDecl>>(() => Decls.OfType<ParmVarDecl>().ToList());
             _returnType = new Lazy<Type>(() => TranslationUnit.GetOrCreate<Type>(Handle.ResultType));

--- a/sources/ClangSharp/Cursors/Exprs/ArraySubscriptExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/ArraySubscriptExpr.cs
@@ -1,13 +1,28 @@
 // Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
 
+using System;
+using System.Linq;
 using ClangSharp.Interop;
 
 namespace ClangSharp
 {
     public sealed class ArraySubscriptExpr : Expr
     {
+        private readonly Lazy<Expr> _lhs;
+        private readonly Lazy<Expr> _rhs;
+
         internal ArraySubscriptExpr(CXCursor handle) : base(handle, CXCursorKind.CXCursor_ArraySubscriptExpr, CX_StmtClass.CX_StmtClass_ArraySubscriptExpr)
         {
+            _lhs = new Lazy<Expr>(() => Children.OfType<Expr>().ElementAt(0));
+            _rhs = new Lazy<Expr>(() => Children.OfType<Expr>().ElementAt(1));
         }
+
+        public Expr Base => RHS.Type.IsIntegerType ? LHS : RHS;
+
+        public Expr Idx => RHS.Type.IsIntegerType ? RHS : LHS;
+
+        public Expr LHS => _lhs.Value;
+
+        public Expr RHS => _rhs.Value;
     }
 }

--- a/sources/ClangSharp/Cursors/Exprs/BinaryOperator.cs
+++ b/sources/ClangSharp/Cursors/Exprs/BinaryOperator.cs
@@ -22,10 +22,9 @@ namespace ClangSharp
             {
                 throw new ArgumentException(nameof(handle));
             }
-            Debug.Assert(Children.OfType<Expr>().Count() == 2);
 
-            _lhs = new Lazy<Expr>(() => Children.OfType<Expr>().First());
-            _rhs = new Lazy<Expr>(() => Children.OfType<Expr>().Last());
+            _lhs = new Lazy<Expr>(() => Children.OfType<Expr>().ElementAt(0));
+            _rhs = new Lazy<Expr>(() => Children.OfType<Expr>().ElementAt(1));
         }
 
         public Expr LHS => _lhs.Value;

--- a/sources/ClangSharp/Cursors/Exprs/CXXConstructExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CXXConstructExpr.cs
@@ -1,12 +1,15 @@
 // Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using ClangSharp.Interop;
 
 namespace ClangSharp
 {
     public class CXXConstructExpr : Expr
     {
+        private readonly Lazy<IReadOnlyList<Expr>> _args;
+
         internal CXXConstructExpr(CXCursor handle) : this(handle, CXCursorKind.CXCursor_CallExpr, CX_StmtClass.CX_StmtClass_CXXConstructExpr)
         {
         }
@@ -17,6 +20,23 @@ namespace ClangSharp
             {
                 throw new ArgumentException(nameof(handle));
             }
+
+            _args = new Lazy<IReadOnlyList<Expr>>(() => {
+                var numArgs = NumArgs;
+                var args = new List<Expr>((int)numArgs);
+
+                for (var index = 0u; index < numArgs; index++)
+                {
+                    var arg = Handle.GetArgument(index);
+                    args.Add(TranslationUnit.GetOrCreate<Expr>(arg));
+                }
+
+                return args;
+            });
         }
+
+        public IReadOnlyList<Expr> Args => _args.Value;
+
+        public uint NumArgs => (uint)Handle.NumArguments;
     }
 }

--- a/sources/ClangSharp/Cursors/Exprs/CallExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CallExpr.cs
@@ -37,7 +37,7 @@ namespace ClangSharp
                 return args;
             });
 
-            _callee = new Lazy<Expr>(() => Children.OfType<Expr>().First());
+            _callee = new Lazy<Expr>(() => Children.OfType<Expr>().ElementAt(0));
             _calleeDecl = new Lazy<Decl>(() => TranslationUnit.GetOrCreate<Decl>(Handle.Referenced));
         }
 

--- a/sources/ClangSharp/Cursors/Exprs/CharacterLiteral.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CharacterLiteral.cs
@@ -1,13 +1,27 @@
 // Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
 
+using System;
+using System.Diagnostics;
 using ClangSharp.Interop;
 
 namespace ClangSharp
 {
     public sealed class CharacterLiteral : Expr
     {
+        private readonly Lazy<string> _value;
+
         internal CharacterLiteral(CXCursor handle) : base(handle, CXCursorKind.CXCursor_CharacterLiteral, CX_StmtClass.CX_StmtClass_CharacterLiteral)
         {
+            _value = new Lazy<string>(() => {
+                var tokens = Handle.TranslationUnit.Tokenize(Extent);
+
+                Debug.Assert(tokens.Length == 1);
+                Debug.Assert(tokens[0].Kind == CXTokenKind.CXToken_Literal);
+
+                return tokens[0].GetSpelling(Handle.TranslationUnit).ToString();
+            });
         }
+
+        public string Value => _value.Value;
     }
 }

--- a/sources/ClangSharp/Cursors/Exprs/ConditionalOperator.cs
+++ b/sources/ClangSharp/Cursors/Exprs/ConditionalOperator.cs
@@ -1,13 +1,32 @@
 // Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
 
+using System;
+using System.Linq;
 using ClangSharp.Interop;
 
 namespace ClangSharp
 {
     public sealed class ConditionalOperator : AbstractConditionalOperator
     {
+        private readonly Lazy<Expr> _cond;
+        private readonly Lazy<Expr> _lhs;
+        private readonly Lazy<Expr> _rhs;
+
         internal ConditionalOperator(CXCursor handle) : base(handle, CXCursorKind.CXCursor_ConditionalOperator, CX_StmtClass.CX_StmtClass_ConditionalOperator)
         {
+            _cond = new Lazy<Expr>(() => Children.OfType<Expr>().ElementAt(0));
+            _lhs = new Lazy<Expr>(() => Children.OfType<Expr>().ElementAt(1));
+            _rhs = new Lazy<Expr>(() => Children.OfType<Expr>().ElementAt(2));
         }
+
+        public Expr Cond => _cond.Value;
+
+        public Expr FalseExpr => RHS;
+
+        public Expr LHS => _lhs.Value;
+
+        public Expr RHS => _rhs.Value;
+
+        public Expr TrueExpr => LHS;
     }
 }

--- a/sources/ClangSharp/Cursors/Exprs/MemberExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/MemberExpr.cs
@@ -1,13 +1,24 @@
 // Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
 
+using System;
+using System.Linq;
 using ClangSharp.Interop;
 
 namespace ClangSharp
 {
     public sealed class MemberExpr : Expr
     {
+        private readonly Lazy<Expr> _base;
+        private readonly Lazy<ValueDecl> _memberDecl;
+
         internal MemberExpr(CXCursor handle) : base(handle, CXCursorKind.CXCursor_MemberRefExpr, CX_StmtClass.CX_StmtClass_MemberExpr)
         {
+            _base = new Lazy<Expr>(() => Children.OfType<Expr>().SingleOrDefault());
+            _memberDecl = new Lazy<ValueDecl>(() => TranslationUnit.GetOrCreate<ValueDecl>(Handle.Referenced));
         }
+
+        public Expr Base => _base.Value;
+
+        public ValueDecl MemberDecl => _memberDecl.Value;
     }
 }

--- a/sources/ClangSharp/Cursors/Refs/Ref.cs
+++ b/sources/ClangSharp/Cursors/Refs/Ref.cs
@@ -8,12 +8,16 @@ namespace ClangSharp
 {
     public class Ref : Cursor
     {
+        private readonly Lazy<NamedDecl> _referenced;
         private readonly Lazy<Type> _type;
 
         private protected Ref(CXCursor handle, CXCursorKind expectedCursorKind) : base(handle, expectedCursorKind)
         {
+            _referenced = new Lazy<NamedDecl>(() => TranslationUnit.GetOrCreate<NamedDecl>(Handle.Referenced));
             _type = new Lazy<Type>(() => TranslationUnit.GetOrCreate<Type>(Handle.Type));
         }
+
+        public NamedDecl Referenced => _referenced.Value;
 
         public Type Type => _type.Value;
 

--- a/sources/ClangSharp/Cursors/Stmts/CaseStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/CaseStmt.cs
@@ -1,13 +1,24 @@
 // Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
 
+using System;
+using System.Linq;
 using ClangSharp.Interop;
 
 namespace ClangSharp
 {
     public sealed class CaseStmt : SwitchCase
     {
+        private readonly Lazy<Expr> _lhs;
+        private readonly Lazy<Stmt> _subStmt;
+
         internal CaseStmt(CXCursor handle) : base(handle, CXCursorKind.CXCursor_CaseStmt, CX_StmtClass.CX_StmtClass_CaseStmt)
         {
+            _lhs = new Lazy<Expr>(() => Children.OfType<Expr>().ElementAt(0));
+            _subStmt = new Lazy<Stmt>(() => Children.OfType<Stmt>().ElementAt(1));
         }
+
+        public Expr LHS => _lhs.Value;
+
+        public Stmt SubStmt => _subStmt.Value;
     }
 }

--- a/sources/ClangSharp/Cursors/Stmts/DefaultStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/DefaultStmt.cs
@@ -1,13 +1,20 @@
 // Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
 
+using System;
+using System.Linq;
 using ClangSharp.Interop;
 
 namespace ClangSharp
 {
     public sealed class DefaultStmt : SwitchCase
     {
+        private readonly Lazy<Stmt> _subStmt;
+
         internal DefaultStmt(CXCursor handle) : base(handle, CXCursorKind.CXCursor_DefaultStmt, CX_StmtClass.CX_StmtClass_DefaultStmt)
         {
+            _subStmt = new Lazy<Stmt>(() => Children.OfType<Stmt>().Single());
         }
+
+        public Stmt SubStmt => _subStmt.Value;
     }
 }

--- a/sources/ClangSharp/Cursors/Stmts/DoStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/DoStmt.cs
@@ -1,13 +1,24 @@
 // Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
 
+using System;
+using System.Linq;
 using ClangSharp.Interop;
 
 namespace ClangSharp
 {
     public sealed class DoStmt : Stmt
     {
+        private readonly Lazy<Stmt> _body;
+        private readonly Lazy<Expr> _cond;
+
         internal DoStmt(CXCursor handle) : base(handle, CXCursorKind.CXCursor_DoStmt, CX_StmtClass.CX_StmtClass_DoStmt)
         {
+            _body = new Lazy<Stmt>(() => Children.OfType<Stmt>().ElementAt(0));
+            _cond = new Lazy<Expr>(() => Children.OfType<Expr>().ElementAt(Body is Expr ? 1 : 0));
         }
+
+        public Stmt Body => _body.Value;
+
+        public Expr Cond => _cond.Value;
     }
 }

--- a/sources/ClangSharp/Cursors/Stmts/ForStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/ForStmt.cs
@@ -1,13 +1,84 @@
 // Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
 
+using System;
+using System.Linq;
 using ClangSharp.Interop;
 
 namespace ClangSharp
 {
     public sealed class ForStmt : Stmt
     {
+        private readonly Lazy<DeclStmt> _conditionVariableDeclStmt;
+        private readonly Lazy<Stmt> _init;
+        private readonly Lazy<Expr> _cond;
+        private readonly Lazy<Expr> _inc;
+        private readonly Lazy<Stmt> _body;
+
         internal ForStmt(CXCursor handle) : base(handle, CXCursorKind.CXCursor_ForStmt, CX_StmtClass.CX_StmtClass_ForStmt)
         {
+            _conditionVariableDeclStmt = new Lazy<DeclStmt>(() => (Children.Count != 1) ? Children.OfType<DeclStmt>().SingleOrDefault() : null);
+            _init = new Lazy<Stmt>(() => {
+                if ((ConditionVariableDeclStmt is null) && (Children.Count != 1))
+                {
+                    if (Children.Count == 4)
+                    {
+                        return Children.ElementAt(0);
+                    }
+
+                    var stmt = Children.OfType<Stmt>().First();
+
+                    if ((stmt != Children.Last()) && (stmt is Expr expr) && (expr.Type.Kind != CXTypeKind.CXType_Bool))
+                    {
+                        return stmt;
+                    }
+                }
+                return null;
+            });
+            _cond = new Lazy<Expr>(() => {
+                if (Children.Count != 1)
+                {
+                    if (Children.Count == 4)
+                    {
+                        return (Expr)Children.ElementAt(1);
+                    }
+
+                    var expr = Children.OfType<Expr>().Where((expr) => expr.Type.Kind == CXTypeKind.CXType_Bool).FirstOrDefault();
+
+                    if (expr != Children.Last())
+                    {
+                        return expr;
+                    }
+                }
+                return null;
+            });
+            _inc = new Lazy<Expr>(() => {
+                if (Children.Count != 1)
+                {
+                    if (Children.Count == 4)
+                    {
+                        return (Expr)Children.ElementAt(2);
+                    }
+
+                    var expr = Children.OfType<Expr>().Where((expr) => (expr != Init) && (expr != Cond)).FirstOrDefault();
+
+                    if (expr != Children.Last())
+                    {
+                        return expr;
+                    }
+                }
+                return null;
+            });
+            _body = new Lazy<Stmt>(() => Children.Last());
         }
+
+        public DeclStmt ConditionVariableDeclStmt => _conditionVariableDeclStmt.Value;
+
+        public Stmt Init => _init.Value;
+
+        public Expr Cond => _cond.Value;
+
+        public Expr Inc => _inc.Value;
+
+        public Stmt Body => _body.Value;
     }
 }

--- a/sources/ClangSharp/Cursors/Stmts/IfStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/IfStmt.cs
@@ -1,13 +1,28 @@
 // Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
 
+using System;
+using System.Linq;
 using ClangSharp.Interop;
 
 namespace ClangSharp
 {
     public sealed class IfStmt : Stmt
     {
+        private readonly Lazy<Expr> _cond;
+        private readonly Lazy<Stmt> _then;
+        private readonly Lazy<Stmt> _else;
+
         internal IfStmt(CXCursor handle) : base(handle, CXCursorKind.CXCursor_IfStmt, CX_StmtClass.CX_StmtClass_IfStmt)
         {
+            _cond = new Lazy<Expr>(() => Children.OfType<Expr>().ElementAt(0));
+            _then = new Lazy<Stmt>(() => Children.OfType<Stmt>().ElementAt(1));
+            _else = new Lazy<Stmt>(() => Children.OfType<Stmt>().ElementAtOrDefault(2));
         }
+
+        public Expr Cond => _cond.Value;
+
+        public Stmt Then => _then.Value;
+
+        public Stmt Else => _else.Value;
     }
 }

--- a/sources/ClangSharp/Cursors/Stmts/SwitchStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/SwitchStmt.cs
@@ -1,13 +1,24 @@
 // Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
 
+using System;
+using System.Linq;
 using ClangSharp.Interop;
 
 namespace ClangSharp
 {
     public sealed class SwitchStmt : Stmt
     {
+        private readonly Lazy<Expr> _cond;
+        private readonly Lazy<Stmt> _body;
+
         internal SwitchStmt(CXCursor handle) : base(handle, CXCursorKind.CXCursor_SwitchStmt, CX_StmtClass.CX_StmtClass_SwitchStmt)
         {
+            _cond = new Lazy<Expr>(() => Children.OfType<Expr>().ElementAt(0));
+            _body = new Lazy<Stmt>(() => Children.OfType<Stmt>().ElementAt(1));
         }
+
+        public Expr Cond => _cond.Value;
+
+        public Stmt Body => _body.Value;
     }
 }

--- a/sources/ClangSharp/Cursors/Stmts/WhileStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/WhileStmt.cs
@@ -1,13 +1,24 @@
 // Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
 
+using System;
+using System.Linq;
 using ClangSharp.Interop;
 
 namespace ClangSharp
 {
     public sealed class WhileStmt : Stmt
     {
+        private readonly Lazy<Expr> _cond;
+        private readonly Lazy<Stmt> _body;
+
         internal WhileStmt(CXCursor handle) : base(handle, CXCursorKind.CXCursor_WhileStmt, CX_StmtClass.CX_StmtClass_WhileStmt)
         {
+            _cond = new Lazy<Expr>(() => Children.OfType<Expr>().ElementAt(0));
+            _body = new Lazy<Stmt>(() => Children.OfType<Stmt>().ElementAt(1));
         }
+
+        public Expr Cond => _cond.Value;
+
+        public Stmt Body => _body.Value;
     }
 }

--- a/sources/ClangSharp/Types/BuiltinType.cs
+++ b/sources/ClangSharp/Types/BuiltinType.cs
@@ -9,5 +9,7 @@ namespace ClangSharp
         internal BuiltinType(CXType handle) : base(handle, handle.kind, CX_TypeClass.CX_TypeClass_Builtin)
         {
         }
+
+        public override bool IsIntegerType => (CXTypeKind.CXType_Bool <= Kind) && (Kind <= CXTypeKind.CXType_Int128);
     }
 }

--- a/sources/ClangSharp/Types/Type.cs
+++ b/sources/ClangSharp/Types/Type.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using ClangSharp.Interop;
 
 namespace ClangSharp
@@ -33,6 +32,8 @@ namespace ClangSharp
         public Type CanonicalType => _canonicalType.Value;
 
         public CXType Handle { get; }
+
+        public virtual bool IsIntegerType => false;
 
         public bool IsLocalConstQualified => Handle.IsConstQualified;
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
@@ -70,6 +70,37 @@ namespace ClangSharp.Test
         }
 
         [Fact]
+        public async Task MemberTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    int value;
+
+    int MyFunction()
+    {
+        return value;
+    }
+};
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        public int value;
+
+        public int MyFunction()
+        {
+            return value;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
         public async Task NewKeywordTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
@@ -10,6 +10,118 @@ namespace ClangSharp.UnitTests
     public sealed class CXXMethodDeclarationTest : PInvokeGeneratorTest
     {
         [Fact]
+        public async Task ConstructorTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    int _value;
+
+    MyStruct(int value)
+    {
+        _value = value;
+    }
+};
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        public int _value;
+
+        public MyStruct(int value)
+        {
+            _value = value;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task ConstructorWithInitializeTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    int _x;
+    int _y;
+    int _z;
+
+    MyStruct(int x) : _x(x)
+    {
+    }
+
+    MyStruct(int x, int y) : _x(x), _y(y)
+    {
+    }
+
+    MyStruct(int x, int y, int z) : _x(x), _y(y), _z()
+    {
+    }
+};
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        public int _x;
+
+        public int _y;
+
+        public int _z;
+
+        public MyStruct(int x)
+        {
+            _x = x;
+        }
+
+        public MyStruct(int x, int y)
+        {
+            _x = x;
+            _y = y;
+        }
+
+        public MyStruct(int x, int y, int z)
+        {
+            _x = x;
+            _y = y;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task DestructorTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    ~MyStruct()
+    {
+    }
+};
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        public void Finalize()
+        {
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
         public async Task InstanceTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
@@ -70,6 +70,82 @@ namespace ClangSharp.Test
         }
 
         [Fact]
+        public async Task MemberCallTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    int value;
+
+    int MyFunction1()
+    {
+        return value;
+    }
+
+    int MyFunction2()
+    {
+        return MyFunction1();
+    }
+
+    int MyFunction3()
+    {
+        return this->MyFunction1();
+    }
+};
+
+int MyFunctionA(MyStruct x)
+{
+    return x.MyFunction1();
+}
+
+int MyFunctionB(MyStruct* x)
+{
+    return x->MyFunction2();
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        public int value;
+
+        public int MyFunction1()
+        {
+            return value;
+        }
+
+        public int MyFunction2()
+        {
+            return MyFunction1();
+        }
+
+        public int MyFunction3()
+        {
+            return this.MyFunction1();
+        }
+    }
+
+    public static unsafe partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunctionA(MyStruct x)
+        {
+            return x.MyFunction1();
+        }
+
+        public static int MyFunctionB([NativeTypeName(""MyStruct *"")] MyStruct* x)
+        {
+            return x->MyFunction2();
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
         public async Task MemberTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
@@ -325,6 +325,37 @@ namespace ClangSharp.Test
         }
 
         [Fact]
+        public async Task ThisTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    int value;
+
+    int MyFunction()
+    {
+        return this->value;
+    }
+};
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        public int value;
+
+        public int MyFunction()
+        {
+            return this.value;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
         public async Task UnsafeDoesNotImpactDllImportTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
@@ -461,6 +461,136 @@ namespace ClangSharp.Test
         }
 
         [Fact]
+        public async Task OperatorTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    int value;
+
+    MyStruct(int value) : value(value)
+    {
+    }
+
+    MyStruct operator+(MyStruct rhs)
+    {
+        return MyStruct(value + rhs.value);
+    }
+};
+
+MyStruct operator-(MyStruct lhs, MyStruct rhs)
+{
+    return MyStruct(lhs.value - rhs.value);
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        public int value;
+
+        public MyStruct(int value)
+        {
+            this.value = value;
+        }
+
+        public MyStruct Add(MyStruct rhs)
+        {
+            return new MyStruct(value + rhs.value);
+        }
+    }
+
+    public static partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static MyStruct Subtract(MyStruct lhs, MyStruct rhs)
+        {
+            return new MyStruct(lhs.value - rhs.value);
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task OperatorCallTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    int value;
+
+    MyStruct(int value) : value(value)
+    {
+    }
+
+    MyStruct operator+(MyStruct rhs)
+    {
+        return MyStruct(value + rhs.value);
+    }
+};
+
+MyStruct MyFunction1(MyStruct lhs, MyStruct rhs)
+{
+    return lhs + rhs;
+}
+
+MyStruct operator-(MyStruct lhs, MyStruct rhs)
+{
+    return MyStruct(lhs.value - rhs.value);
+}
+
+MyStruct MyFunction2(MyStruct lhs, MyStruct rhs)
+{
+    return lhs - rhs;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        public int value;
+
+        public MyStruct(int value)
+        {
+            this.value = value;
+        }
+
+        public MyStruct Add(MyStruct rhs)
+        {
+            return new MyStruct(value + rhs.value);
+        }
+    }
+
+    public static partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static MyStruct MyFunction1(MyStruct lhs, MyStruct rhs)
+        {
+            return lhs.Add(rhs);
+        }
+
+        public static MyStruct Subtract(MyStruct lhs, MyStruct rhs)
+        {
+            return new MyStruct(lhs.value - rhs.value);
+        }
+
+        public static MyStruct MyFunction2(MyStruct lhs, MyStruct rhs)
+        {
+            return Subtract(lhs, rhs);
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
         public async Task StaticTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
@@ -175,8 +175,8 @@ namespace ClangSharp.Test
         {
             var inputContents = @"struct MyStruct
 {
-    virtual int GetType() = 0;
     virtual int GetType(int obj) = 0;
+    virtual int GetType() = 0;
     virtual int GetType(int objA, int objB) = 0;
 };";
 
@@ -200,22 +200,22 @@ namespace ClangSharp.Test
         public readonly Vtbl* lpVtbl;
 
         [UnmanagedFunctionPointer(CallingConvention.{callConv})]
-        public delegate int _GetType(MyStruct* pThis);
+        public delegate int _GetType(MyStruct* pThis, int obj);
 
         [UnmanagedFunctionPointer(CallingConvention.{callConv})]
-        public delegate int _GetType1(MyStruct* pThis, int obj);
+        public delegate int _GetType1(MyStruct* pThis);
 
         [UnmanagedFunctionPointer(CallingConvention.{callConv})]
         public delegate int _GetType2(MyStruct* pThis, int objA, int objB);
 
-        public new int GetType()
-        {{
-            return Marshal.GetDelegateForFunctionPointer<_GetType>(lpVtbl->GetType)((MyStruct*)Unsafe.AsPointer(ref this));
-        }}
-
         public int GetType(int obj)
         {{
-            return Marshal.GetDelegateForFunctionPointer<_GetType1>(lpVtbl->GetType1)((MyStruct*)Unsafe.AsPointer(ref this), obj);
+            return Marshal.GetDelegateForFunctionPointer<_GetType>(lpVtbl->GetType)((MyStruct*)Unsafe.AsPointer(ref this), obj);
+        }}
+
+        public new int GetType()
+        {{
+            return Marshal.GetDelegateForFunctionPointer<_GetType1>(lpVtbl->GetType1)((MyStruct*)Unsafe.AsPointer(ref this));
         }}
 
         public int GetType(int objA, int objB)
@@ -225,10 +225,10 @@ namespace ClangSharp.Test
 
         public partial struct Vtbl
         {{
-            [NativeTypeName(""int (){callConvAttr}"")]
+            [NativeTypeName(""int (int){callConvAttr}"")]
             public new IntPtr GetType;
 
-            [NativeTypeName(""int (int){callConvAttr}"")]
+            [NativeTypeName(""int (){callConvAttr}"")]
             public IntPtr GetType1;
 
             [NativeTypeName(""int (int, int){callConvAttr}"")]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
@@ -605,6 +605,258 @@ int MyFunction()
         }
 
         [Fact]
+        public async Task ForTest()
+        {
+            var inputContents = @"int MyFunction(int count)
+{
+    for (int i = 0; i < count; i--)
+    {
+        i += 2;
+    }
+
+    int x;
+
+    for (x = 0; x < count; x--)
+    {
+        x += 2;
+    }
+
+    x = 0;
+
+    for (; x < count; x--)
+    {
+        x += 2;
+    }
+
+    for (int i = 0;;i--)
+    {
+        i += 2;
+    }
+
+    for (x = 0;;x--)
+    {
+        x += 2;
+    }
+
+    for (int i = 0; i < count;)
+    {
+        i++;
+    }
+
+    for (x = 0; x < count;)
+    {
+        x++;
+    }
+
+    // x = 0;
+    // 
+    // for (;; x--)
+    // {
+    //     x += 2;
+    // }
+
+    x = 0;
+
+    for (; x < count;)
+    {
+        x++;
+    }
+
+    for (int i = 0;;)
+    {
+        i++;
+    }
+
+    for (x = 0;;)
+    {
+        x++;
+    }
+
+    for (;;)
+    {
+        return -1;
+    }
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction(int count)
+        {
+            for (int i = 0; i < count; i--)
+            {
+                i += 2;
+            }
+
+            int x;
+
+            for (x = 0; x < count; x--)
+            {
+                x += 2;
+            }
+
+            x = 0;
+            for (; x < count; x--)
+            {
+                x += 2;
+            }
+
+            for (int i = 0;; i--)
+            {
+                i += 2;
+            }
+
+            for (x = 0;; x--)
+            {
+                x += 2;
+            }
+
+            for (int i = 0; i < count;)
+            {
+                i++;
+            }
+
+            for (x = 0; x < count;)
+            {
+                x++;
+            }
+
+            x = 0;
+            for (; x < count;)
+            {
+                x++;
+            }
+
+            for (int i = 0;;)
+            {
+                i++;
+            }
+
+            for (x = 0;;)
+            {
+                x++;
+            }
+
+            for (;;)
+            {
+                return -1;
+            }
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task ForNonCompoundTest()
+        {
+            var inputContents = @"int MyFunction(int count)
+{
+    for (int i = 0; i < count; i--)
+        i += 2;
+
+    int x;
+
+    for (x = 0; x < count; x--)
+        x += 2;
+
+    x = 0;
+
+    for (; x < count; x--)
+        x += 2;
+
+    for (int i = 0;;i--)
+        i += 2;
+
+    for (x = 0;;x--)
+        x += 2;
+
+    for (int i = 0; i < count;)
+        i++;
+
+    for (x = 0; x < count;)
+        x++;
+
+    // x = 0;
+    // 
+    // for (;; x--)
+    //     x += 2;
+
+    x = 0;
+
+    for (; x < count;)
+        x++;
+
+    for (int i = 0;;)
+        i++;
+
+    for (x = 0;;)
+        x++;
+
+    for (;;)
+        return -1;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction(int count)
+        {
+            for (int i = 0; i < count; i--)
+                i += 2;
+
+            int x;
+
+            for (x = 0; x < count; x--)
+                x += 2;
+
+            x = 0;
+            for (; x < count; x--)
+                x += 2;
+
+            for (int i = 0;; i--)
+                i += 2;
+
+            for (x = 0;; x--)
+                x += 2;
+
+            for (int i = 0; i < count;)
+                i++;
+
+            for (x = 0; x < count;)
+                x++;
+
+            x = 0;
+            for (; x < count;)
+                x++;
+
+            for (int i = 0;;)
+                i++;
+
+            for (x = 0;;)
+                x++;
+
+            for (;;)
+                return -1;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
         public async Task IfTest()
         {
             var inputContents = @"int MyFunction(bool condition, int lhs, int rhs)

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
@@ -526,6 +526,158 @@ int MyFunction()
         }
 
         [Fact]
+        public async Task IfTest()
+        {
+            var inputContents = @"int MyFunction(bool condition, int lhs, int rhs)
+{
+    if (condition)
+    {
+        return lhs;
+    }
+
+    return rhs;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction(bool condition, int lhs, int rhs)
+        {
+            if (condition)
+            {
+                return lhs;
+            }
+
+            return rhs;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task IfElseTest()
+        {
+            var inputContents = @"int MyFunction(bool condition, int lhs, int rhs)
+{
+    if (condition)
+    {
+        return lhs;
+    }
+    else
+    {
+        return rhs;
+    }
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction(bool condition, int lhs, int rhs)
+        {
+            if (condition)
+            {
+                return lhs;
+            }
+            else
+            {
+                return rhs;
+            }
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task IfElseIfTest()
+        {
+            var inputContents = @"int MyFunction(bool condition1, int a, int b, bool condition2, int c)
+{
+    if (condition1)
+    {
+        return a;
+    }
+    else if (condition2)
+    {
+        return b;
+    }
+
+    return c;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction(bool condition1, int a, int b, bool condition2, int c)
+        {
+            if (condition1)
+            {
+                return a;
+            }
+            else if (condition2)
+            {
+                return b;
+            }
+
+            return c;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task IfElseNonCompoundTest()
+        {
+            var inputContents = @"int MyFunction(bool condition, int lhs, int rhs)
+{
+    if (condition)
+        return lhs;
+    else
+        return rhs;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction(bool condition, int lhs, int rhs)
+        {
+            if (condition)
+                return lhs;
+            else
+                return rhs;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
         public async Task MemberTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
@@ -516,6 +516,7 @@ int MyFunction()
         {
             int x = 0;
             int y = 1, z = 2;
+
             return x + y + z;
         }
     }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
@@ -251,6 +251,32 @@ static inline int MyFunction(MyEnum x)
         }
 
         [Fact]
+        public async Task ConditionalOperatorTest()
+        {
+            var inputContents = @"int MyFunction(bool condition, int lhs, int rhs)
+{
+    return condition ? lhs : rhs;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction(bool condition, int lhs, int rhs)
+        {
+            return condition ? lhs : rhs;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
         public async Task CStyleFunctionalCastTest()
         {
             var inputContents = @"int MyFunction(float input)

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
@@ -141,6 +141,42 @@ namespace ClangSharp.UnitTests
         }
 
         [Fact]
+        public async Task BreakTest()
+        {
+            var inputContents = @"int MyFunction(int value)
+{
+    while (true)
+    {
+        break;
+    }
+
+    return 0;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction(int value)
+        {
+            while (true)
+            {
+                break;
+            }
+
+            return 0;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
         public async Task CallFunctionTest()
         {
             var inputContents = @"void MyCalledFunction()
@@ -209,6 +245,106 @@ void MyFunction()
         }
 
         [Fact]
+        public async Task CaseTest()
+        {
+            var inputContents = @"int MyFunction(int value)
+{
+    switch (value)
+    {
+        case 0:
+        {
+            return 0;
+        }
+
+        case 1:
+        case 2:
+        {
+            return 3;
+        }
+    }
+
+    return -1;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction(int value)
+        {
+            switch (value)
+            {
+                case 0:
+                {
+                    return 0;
+                }
+
+                case 1:
+                case 2:
+                {
+                    return 3;
+                }
+            }
+
+            return -1;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task CaseNoCompoundTest()
+        {
+            var inputContents = @"int MyFunction(int value)
+{
+    switch (value)
+    {
+        case 0:
+            return 0;
+
+        case 2:
+        case 3:
+            return 5;
+    }
+
+    return -1;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction(int value)
+        {
+            switch (value)
+            {
+                case 0:
+                    return 0;
+
+                case 2:
+                case 3:
+                    return 5;
+            }
+
+            return -1;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
         public async Task CompareMultipleEnumTest()
         {
             var inputContents = @"enum MyEnum : int
@@ -268,6 +404,42 @@ static inline int MyFunction(MyEnum x)
         public static int MyFunction(bool condition, int lhs, int rhs)
         {
             return condition ? lhs : rhs;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task ContinueTest()
+        {
+            var inputContents = @"int MyFunction(int value)
+{
+    while (true)
+    {
+        continue;
+    }
+
+    return 0;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction(int value)
+        {
+            while (true)
+            {
+                continue;
+            }
+
+            return 0;
         }
     }
 }
@@ -1183,6 +1355,90 @@ int MyFunction2(MyStruct* instance)
         public static int MyFunction()
         {
             return -1;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task SwitchTest()
+        {
+            var inputContents = @"int MyFunction(int value)
+{
+    switch (value)
+    {
+        default:
+        {
+            return 0;
+        }
+    }
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction(int value)
+        {
+            switch (value)
+            {
+                default:
+                {
+                    return 0;
+                }
+            }
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task SwitchNonCompoundTest()
+        {
+            var inputContents = @"int MyFunction(int value)
+{
+    switch (value)
+        default:
+        {
+            return 0;
+        }
+
+    switch (value)
+        default:
+            return 0;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction(int value)
+        {
+            switch (value)
+            {
+                default:
+                {
+                    return 0;
+                }
+            }
+
+            switch (value)
+            {
+                default:
+                    return 0;
+            }
         }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
@@ -10,6 +10,32 @@ namespace ClangSharp.UnitTests
     public sealed class FunctionDeclarationBodyImportTest : PInvokeGeneratorTest
     {
         [Fact]
+        public async Task ArraySubscriptTest()
+        {
+            var inputContents = @"int MyFunction(int* pData, int index)
+{
+    return pData[index];
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static unsafe partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction([NativeTypeName(""int *"")] int* pData, int index)
+        {
+            return pData[index];
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
         public async Task BasicTest()
         {
             var inputContents = @"void MyFunction()

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
@@ -527,6 +527,84 @@ int MyFunction()
         }
 
         [Fact]
+        public async Task DoTest()
+        {
+            var inputContents = @"int MyFunction(int count)
+{
+    int i = 0;
+
+    do
+    {
+        i++;
+    }
+    while (i < count);
+
+    return i;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction(int count)
+        {
+            int i = 0;
+
+            do
+            {
+                i++;
+            }
+            while (i < count);
+
+            return i;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task DoNonCompoundTest()
+        {
+            var inputContents = @"int MyFunction(int count)
+{
+    int i = 0;
+
+    while (i < count)
+        i++;
+
+    return i;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction(int count)
+        {
+            int i = 0;
+
+            while (i < count)
+                i++;
+
+            return i;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
         public async Task IfTest()
         {
             var inputContents = @"int MyFunction(bool condition, int lhs, int rhs)
@@ -994,6 +1072,82 @@ int MyFunction2(MyStruct* instance)
         }}
     }}
 }}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task WhileTest()
+        {
+            var inputContents = @"int MyFunction(int count)
+{
+    int i = 0;
+
+    while (i < count)
+    {
+        i++;
+    }
+
+    return i;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction(int count)
+        {
+            int i = 0;
+
+            while (i < count)
+            {
+                i++;
+            }
+
+            return i;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task WhileNonCompoundTest()
+        {
+            var inputContents = @"int MyFunction(int count)
+{
+    int i = 0;
+
+    while (i < count)
+        i++;
+
+    return i;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction(int count)
+        {
+            int i = 0;
+
+            while (i < count)
+                i++;
+
+            return i;
+        }
+    }
+}
 ";
 
             await ValidateGeneratedBindings(inputContents, expectedOutputContents);

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
@@ -495,6 +495,52 @@ namespace ClangSharp.Test
         }
 
         [Fact]
+        public async Task MemberTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    int value;
+};
+
+int MyFunction1(MyStruct instance)
+{
+    return instance.value;
+}
+
+int MyFunction2(MyStruct* instance)
+{
+    return instance->value;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        public int value;
+    }
+
+    public static unsafe partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction1(MyStruct instance)
+        {
+            return instance.value;
+        }
+
+        public static int MyFunction2([NativeTypeName(""MyStruct *"")] MyStruct* instance)
+        {
+            return instance->value;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
         public async Task ReturnCXXNullPtrTest()
         {
             var inputContents = @"void* MyFunction()

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
@@ -495,6 +495,37 @@ namespace ClangSharp.Test
         }
 
         [Fact]
+        public async Task DeclTest()
+        {
+            var inputContents = @"\
+int MyFunction()
+{
+    int x = 0;
+    int y = 1, z = 2;
+    return x + y + z;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static int MyFunction()
+        {
+            int x = 0;
+            int y = 1, z = 2;
+            return x + y + z;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
         public async Task MemberTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationDllImportTest.cs
@@ -53,8 +53,17 @@ namespace ClangSharp.Test
         }
 
         [Theory]
-        [InlineData("int value = 0", "int value = 0")]
-        [InlineData("unsigned short value = '1'", @"[NativeTypeName(""unsigned short"")] ushort value = '1'")]
+        [InlineData("unsigned char value = 0", @"[NativeTypeName(""unsigned char"")] byte value = 0")]
+        [InlineData("double value = 1.0", @"double value = 1.0")]
+        [InlineData("short value = 2", @"short value = 2")]
+        [InlineData("int value = 3", @"int value = 3")]
+        [InlineData("long long value = 4", @"[NativeTypeName(""long long"")] long value = 4")]
+        [InlineData("signed char value = 5", @"[NativeTypeName(""signed char"")] sbyte value = 5")]
+        [InlineData("float value = 6.0f", @"float value = 6.0f")]
+        [InlineData("unsigned short value = 7", @"[NativeTypeName(""unsigned short"")] ushort value = 7")]
+        [InlineData("unsigned int value = 8", @"[NativeTypeName(""unsigned int"")] uint value = 8")]
+        [InlineData("unsigned long long value = 9", @"[NativeTypeName(""unsigned long long"")] ulong value = 9")]
+        [InlineData("unsigned short value = 'A'", @"[NativeTypeName(""unsigned short"")] ushort value = 'A'")]
         public async Task OptionalParameterTest(string nativeParameters, string expectedManagedParameters)
         {
             var inputContents = $@"void MyFunction({nativeParameters});";
@@ -64,6 +73,29 @@ namespace ClangSharp.Test
 namespace ClangSharp.Test
 {{
     public static partial class Methods
+    {{
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        [DllImport(LibraryPath, CallingConvention = CallingConvention.Cdecl, EntryPoint = ""MyFunction"", ExactSpelling = true)]
+        public static extern void MyFunction({expectedManagedParameters});
+    }}
+}}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Theory]
+        [InlineData("void* value = nullptr", @"[NativeTypeName(""void *"")] void* value = null")]
+        public async Task OptionalParameterUnsafeTest(string nativeParameters, string expectedManagedParameters)
+        {
+            var inputContents = $@"void MyFunction({nativeParameters});";
+
+            var expectedOutputContents = $@"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    public static unsafe partial class Methods
     {{
         private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationDllImportTest.cs
@@ -87,6 +87,7 @@ namespace ClangSharp.Test
 
         [Theory]
         [InlineData("void* value = nullptr", @"[NativeTypeName(""void *"")] void* value = null")]
+        [InlineData("void* value = 0", @"[NativeTypeName(""void *"")] void* value = null")]
         public async Task OptionalParameterUnsafeTest(string nativeParameters, string expectedManagedParameters)
         {
             var inputContents = $@"void MyFunction({nativeParameters});";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationDllImportTest.cs
@@ -52,23 +52,25 @@ namespace ClangSharp.Test
             await ValidateGeneratedBindings(inputContents, expectedOutputContents);
         }
 
-        [Fact]
-        public async Task OptionalParameterTest()
+        [Theory]
+        [InlineData("int value = 0", "int value = 0")]
+        [InlineData("unsigned short value = '1'", @"[NativeTypeName(""unsigned short"")] ushort value = '1'")]
+        public async Task OptionalParameterTest(string nativeParameters, string expectedManagedParameters)
         {
-            var inputContents = @"void MyFunction(int value = 4);";
+            var inputContents = $@"void MyFunction({nativeParameters});";
 
-            var expectedOutputContents = @"using System.Runtime.InteropServices;
+            var expectedOutputContents = $@"using System.Runtime.InteropServices;
 
 namespace ClangSharp.Test
-{
+{{
     public static partial class Methods
-    {
+    {{
         private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
 
         [DllImport(LibraryPath, CallingConvention = CallingConvention.Cdecl, EntryPoint = ""MyFunction"", ExactSpelling = true)]
-        public static extern void MyFunction(int value = 4);
-    }
-}
+        public static extern void MyFunction({expectedManagedParameters});
+    }}
+}}
 ";
 
             await ValidateGeneratedBindings(inputContents, expectedOutputContents);

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
@@ -600,6 +600,60 @@ namespace ClangSharp.Test
             await ValidateGeneratedBindings(inputContents, expectedOutputContents);
         }
 
+        [Fact]
+        public async Task InheritanceTest()
+        {
+            var inputContents = @"struct MyStruct1A
+{
+    int x;
+    int y;
+};
+
+struct MyStruct1B
+{
+    int x;
+    int y;
+};
+
+struct MyStruct2 : MyStruct1A, MyStruct1B
+{
+    int z;
+    int w;
+};
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct MyStruct1A
+    {
+        public int x;
+
+        public int y;
+    }
+
+    public partial struct MyStruct1B
+    {
+        public int x;
+
+        public int y;
+    }
+
+    public partial struct MyStruct2
+    {
+        public MyStruct1A __AnonymousBase_ClangUnsavedFile_L13_C20;
+
+        public MyStruct1B __AnonymousBase_ClangUnsavedFile_L13_C32;
+
+        public int z;
+
+        public int w;
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
         [Theory]
         [InlineData("double", "double", 7, 5)]
         [InlineData("short", "short", 7, 5)]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
@@ -956,6 +956,24 @@ struct MyStruct
             await ValidateGeneratedBindings(inputContents, expectedOutputContents);
         }
 
+        [Fact]
+        public async Task SkipNonDefinitionPointerTest()
+        {
+            var inputContents = @"typedef struct MyStruct* MyStructPtr;
+typedef struct MyStruct& MyStructRef;
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
         [Theory]
         [InlineData("unsigned char", "byte")]
         [InlineData("long long", "long")]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
@@ -1035,5 +1035,37 @@ struct MyStruct
 
             await ValidateGeneratedBindings(inputContents, expectedOutputContents);
         }
+
+        [Fact]
+        public async Task UsingDeclarationTest()
+        {
+            var inputContents = @"struct MyStruct1A
+{
+    void MyMethod() { }
+};
+
+struct MyStruct1B : MyStruct1A
+{
+    using MyStruct1A::MyMethod;
+};
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct MyStruct1A
+    {
+        public void MyMethod()
+        {
+        }
+    }
+
+    public partial struct MyStruct1B
+    {
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
     }
 }


### PR DESCRIPTION
This updates the P/Invoke generator to support walking and binding the most common kinds of statements and expressions.

This allows a number of helper methods, such as those found in the D3D11 and D2D1 headers, to be automatically bound to C#.