### PR TITLE
Adds a 'preview-codegen' config option

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -824,7 +824,7 @@ namespace ClangSharp
 
                 if (hasVtbl)
                 {
-                    _outputBuilder.WriteIndentedLine("public readonly Vtbl* lpVtbl;");
+                    _outputBuilder.WriteIndentedLine("public Vtbl* lpVtbl;");
                     _outputBuilder.NeedsNewline = true;
                 }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -842,9 +842,35 @@ namespace ClangSharp
             {
                 name = GetTypeName(cursor, elaboratedType.NamedType, out var nativeNamedTypeName);
             }
-            else if (type is FunctionType)
+            else if (type is FunctionType functionType)
             {
-                name = "IntPtr";
+                if (_config.GeneratePreviewCode && (functionType is FunctionProtoType functionProtoType))
+                {
+                    var remappedName = GetRemappedName(name, cursor, tryRemapOperatorName: false);
+                    var callConv = GetCallingConventionName(cursor, functionType.CallConv, remappedName).ToLower();
+
+                    var nameBuilder = new StringBuilder();
+                    nameBuilder.Append("delegate");
+                    nameBuilder.Append('*');
+                    nameBuilder.Append(' ');
+                    nameBuilder.Append((callConv != "winapi") ? callConv : "unmanaged");
+                    nameBuilder.Append('<');
+
+                    foreach (var paramType in functionProtoType.ParamTypes)
+                    {
+                        nameBuilder.Append(GetRemappedTypeName(cursor, paramType, out _));
+                        nameBuilder.Append(',');
+                        nameBuilder.Append(' ');
+                    }
+
+                    nameBuilder.Append(GetRemappedTypeName(cursor, functionType.ReturnType, out _));
+                    nameBuilder.Append('>');
+                    name = nameBuilder.ToString();
+                }
+                else
+                {
+                    name = "IntPtr";
+                }
             }
             else if (type is PointerType pointerType)
             {
@@ -909,10 +935,6 @@ namespace ClangSharp
             if (pointeeType is AttributedType attributedType)
             {
                 name = GetTypeNameForPointeeType(cursor, attributedType.ModifiedType, out var nativeModifiedTypeName);
-            }
-            else if (pointeeType is FunctionType)
-            {
-                name = "IntPtr";
             }
             else
             {

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -754,7 +754,7 @@ namespace ClangSharp
                     {
                         if (_config.GenerateUnixTypes)
                         {
-                            name = "UIntPtr";
+                            name = _config.GeneratePreviewCode ? "nuint" : "UIntPtr";
                         }
                         else
                         {
@@ -804,7 +804,7 @@ namespace ClangSharp
                     {
                         if (_config.GenerateUnixTypes)
                         {
-                            name = "IntPtr";
+                            name = _config.GeneratePreviewCode ? "nint" : "IntPtr";
                         }
                         else
                         {

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -44,6 +44,11 @@ namespace ClangSharp
                 throw new ArgumentNullException(nameof(namespaceName));
             }
 
+            if (options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateCompatibleCode) && options.HasFlag(PInvokeGeneratorConfigurationOptions.GeneratePreviewCode))
+            {
+                throw new ArgumentOutOfRangeException(nameof(options));
+            }
+
             if (string.IsNullOrWhiteSpace(outputLocation))
             {
                 throw new ArgumentNullException(nameof(outputLocation));
@@ -72,10 +77,20 @@ namespace ClangSharp
 
             if (!_options.HasFlag(PInvokeGeneratorConfigurationOptions.NoDefaultRemappings))
             {
-                _remappedNames.Add("intptr_t", "IntPtr");
-                _remappedNames.Add("ptrdiff_t", "IntPtr");
-                _remappedNames.Add("size_t", "UIntPtr");
-                _remappedNames.Add("uintptr_t", "UIntPtr");
+                if (GeneratePreviewCode)
+                {
+                    _remappedNames.Add("intptr_t", "nint");
+                    _remappedNames.Add("ptrdiff_t", "nint");
+                    _remappedNames.Add("size_t", "nuint");
+                    _remappedNames.Add("uintptr_t", "nuint");
+                }
+                else
+                {
+                    _remappedNames.Add("intptr_t", "IntPtr");
+                    _remappedNames.Add("ptrdiff_t", "IntPtr");
+                    _remappedNames.Add("size_t", "UIntPtr");
+                    _remappedNames.Add("uintptr_t", "UIntPtr");
+                }
             }
 
             AddRange(_remappedNames, remappedNames);
@@ -88,6 +103,8 @@ namespace ClangSharp
         public string[] ExcludedNames { get; }
 
         public bool GenerateCompatibleCode => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateCompatibleCode);
+
+        public bool GeneratePreviewCode => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GeneratePreviewCode);
 
         public bool GenerateMultipleFiles => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateMultipleFiles);
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
@@ -16,5 +16,7 @@ namespace ClangSharp
         NoDefaultRemappings = 0x00000004,
 
         GenerateCompatibleCode = 0x00000008,
+
+        GeneratePreviewCode = 0x00000010,
     }
 }

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -110,6 +110,7 @@ namespace ClangSharp
                     case "compatible-codegen":
                     {
                         configOptions |= PInvokeGeneratorConfigurationOptions.GenerateCompatibleCode;
+                        configOptions &= ~PInvokeGeneratorConfigurationOptions.GeneratePreviewCode;
                         break;
                     }
 
@@ -122,6 +123,7 @@ namespace ClangSharp
                     case "latest-codegen":
                     {
                         configOptions &= ~PInvokeGeneratorConfigurationOptions.GenerateCompatibleCode;
+                        configOptions &= ~PInvokeGeneratorConfigurationOptions.GeneratePreviewCode;
                         break;
                     }
 
@@ -134,6 +136,13 @@ namespace ClangSharp
                     case "no-default-remappings":
                     {
                         configOptions |= PInvokeGeneratorConfigurationOptions.NoDefaultRemappings;
+                        break;
+                    }
+
+                    case "preview-codegen":
+                    {
+                        configOptions &= ~PInvokeGeneratorConfigurationOptions.GenerateCompatibleCode;
+                        configOptions |= PInvokeGeneratorConfigurationOptions.GeneratePreviewCode;
                         break;
                     }
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
@@ -447,7 +447,7 @@ namespace ClangSharp.Test
 {{
     public unsafe partial struct MyStruct
     {{
-        public readonly Vtbl* lpVtbl;
+        public Vtbl* lpVtbl;
 
         [UnmanagedFunctionPointer(CallingConvention.{callConv})]
         public delegate int _GetType(MyStruct* pThis, int obj);
@@ -775,7 +775,7 @@ namespace ClangSharp.Test
 {{
     public unsafe partial struct MyStruct
     {{
-        public readonly Vtbl* lpVtbl;
+        public Vtbl* lpVtbl;
 
         [UnmanagedFunctionPointer(CallingConvention.{callConv})]
         public delegate void _MyVoidMethod(MyStruct* pThis);
@@ -865,7 +865,7 @@ namespace ClangSharp.Test
 {{
     public unsafe partial struct MyStruct
     {{
-        public readonly Vtbl* lpVtbl;
+        public Vtbl* lpVtbl;
 
         [UnmanagedFunctionPointer(CallingConvention.{callConv})]
         public delegate void _MyVoidMethod(MyStruct* pThis);

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
@@ -560,7 +560,7 @@ namespace ClangSharp.Test
 {{
     public unsafe partial struct MyStructA
     {{
-        public readonly Vtbl* lpVtbl;
+        public Vtbl* lpVtbl;
 
         [UnmanagedFunctionPointer(CallingConvention.{callConv})]
         public delegate void _MyMethod(MyStructA* pThis);
@@ -579,7 +579,7 @@ namespace ClangSharp.Test
 
     public unsafe partial struct MyStructB
     {{
-        public readonly Vtbl* lpVtbl;
+        public Vtbl* lpVtbl;
 
         [UnmanagedFunctionPointer(CallingConvention.{callConv})]
         public delegate void _MyMethod(MyStructB* pThis);


### PR DESCRIPTION
This adds a 'preview-codegen' config option that can be used to generate code compatible with the latest C# Preview Compiler. For example, it supports this PR allows it to use the `nint`/`nuint` types and `function pointers`.