### PR TITLE
Ensuring typedefs to all kinds of arrays work as expected

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -1735,7 +1735,7 @@ namespace ClangSharp
             {
                 VisitTypedefDeclForUnderlyingType(typedefDecl, typedefType.Decl.UnderlyingType);
             }
-            else if (!(underlyingType is BuiltinType) && !(underlyingType is IncompleteArrayType) && !(underlyingType is TagType))
+            else if (!(underlyingType is ArrayType) && !(underlyingType is BuiltinType) && !(underlyingType is TagType))
             {
                 AddDiagnostic(DiagnosticLevel.Error, $"Unsupported underlying type: '{underlyingType.TypeClass}'. Generating bindings may be incomplete.", typedefDecl);
             }


### PR DESCRIPTION
This ensures cases like `typedef BYTE SPC_UUID[SPC_UUID_LENGTH];` from `um/WinTrust.h` can bind successfully.