### PR TITLE
Fixing some pain points around paths and ensure a couple of edge scenarios are handled

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/Diagnostic.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Diagnostic.cs
@@ -11,7 +11,7 @@ namespace ClangSharp
         private readonly string _message;
         private readonly string _location;
 
-        public Diagnostic(DiagnosticLevel level, string message, CXSourceLocation location) : this(level, message, location.ToString())
+        public Diagnostic(DiagnosticLevel level, string message, CXSourceLocation location) : this(level, message, location.ToString().Replace('\\', '/'))
         {
         }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -1727,7 +1727,11 @@ namespace ClangSharp
 
         private void VisitTypedefDeclForUnderlyingType(TypedefDecl typedefDecl, Type underlyingType)
         {
-            if (underlyingType is ElaboratedType elaboratedType)
+            if (underlyingType is AttributedType attributedType)
+            {
+                VisitTypedefDeclForUnderlyingType(typedefDecl, attributedType.ModifiedType);
+            }
+            else if (underlyingType is ElaboratedType elaboratedType)
             {
                 VisitTypedefDeclForUnderlyingType(typedefDecl, elaboratedType.NamedType);
             }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -258,7 +258,7 @@ namespace ClangSharp
                 else
                 {
                     decl.Location.GetFileLocation(out CXFile file, out _, out _, out _);
-                    var fileName = file.Name.ToString();
+                    var fileName = file.Name.ToString().Replace('\\', '/'); // Normalize paths to be `/` for comparison
 
                     if (!_config.TraversalNames.Contains(fileName))
                     {
@@ -267,7 +267,7 @@ namespace ClangSharp
                         // in the main file to catch these cases and ensure we still generate bindings for them.
 
                         decl.Location.GetExpansionLocation(out CXFile expansionFile, out _, out _, out _);
-                        fileName = expansionFile.Name.ToString();
+                        fileName = expansionFile.Name.ToString().Replace('\\', '/'); // Normalize paths to be `/` for comparison
 
                         if (!_config.TraversalNames.Contains(fileName))
                         {

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -238,6 +238,13 @@ namespace ClangSharp
         {
             foreach (var decl in decls)
             {
+                if (decl is LinkageSpecDecl)
+                {
+                    // Traverse these decl types as they may contain nested includes
+                    Visit(decl);
+                    continue;
+                }
+
                 if (_config.TraversalNames.Length == 0)
                 {
                     if (!decl.Location.IsFromMainFile)
@@ -275,6 +282,7 @@ namespace ClangSharp
                         }
                     }
                 }
+
                 Visit(decl);
             }
         }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -609,12 +609,13 @@ namespace ClangSharp
 
         private void VisitReturnStmt(ReturnStmt returnStmt)
         {
-            Debug.Assert(returnStmt.RetValue != null);
-
             _outputBuilder.Write("return");
-            _outputBuilder.Write(' ');
 
-            Visit(returnStmt.RetValue);
+            if (returnStmt.RetValue != null)
+            {
+                _outputBuilder.Write(' ');
+                Visit(returnStmt.RetValue);
+            }
         }
 
         private void VisitStmt(Stmt stmt)

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -590,6 +590,18 @@ namespace ClangSharp
                 {
                     name = "param";
                 }
+                else if (namedDecl is FieldDecl fieldDecl)
+                {
+                    name = GetAnonymousName(fieldDecl, fieldDecl.CursorKindSpelling);
+
+                    if (!_config.RemappedNames.ContainsKey(name))
+                    {
+                        AddDiagnostic(DiagnosticLevel.Info, $"Anonymous declaration found in '{nameof(GetCursorName)}'. Falling back to '{name}'.", namedDecl);
+                    }
+
+                    name = "field";
+                    AddDiagnostic(DiagnosticLevel.Warning, $"Unsupported anonymous named declaration: '{namedDecl.Kind}'.", namedDecl);
+                }
                 else
                 {
                     AddDiagnostic(DiagnosticLevel.Error, $"Unsupported anonymous named declaration: '{namedDecl.Kind}'.", namedDecl);

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -224,7 +224,7 @@ namespace ClangSharp
 
             _outputBuilder.Write("NativeTypeName(");
             _outputBuilder.Write('"');
-            _outputBuilder.Write(nativeTypeName);
+            _outputBuilder.Write(nativeTypeName.Replace('\\', '/'));
             _outputBuilder.Write('"');
             _outputBuilder.Write(")]");
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace ClangSharp
 {
@@ -73,7 +74,9 @@ namespace ClangSharp
             MethodPrefixToStrip = methodPrefixToStrip;
             Namespace = namespaceName;
             OutputLocation = Path.GetFullPath(outputLocation);
-            TraversalNames = traversalNames;
+
+            // Normalize the traversal names to use \ rather than / so path comparisons are simpler
+            TraversalNames = traversalNames.Select(traversalName => traversalName.Replace('\\', '/')).ToArray();
 
             if (!_options.HasFlag(PInvokeGeneratorConfigurationOptions.NoDefaultRemappings))
             {

--- a/sources/ClangSharp/Cursors/Stmts/ReturnStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/ReturnStmt.cs
@@ -12,7 +12,7 @@ namespace ClangSharp
 
         internal ReturnStmt(CXCursor handle) : base(handle, CXCursorKind.CXCursor_ReturnStmt, CX_StmtClass.CX_StmtClass_ReturnStmt)
         {
-            _retValue = new Lazy<Expr>(() => Children.OfType<Expr>().Single());
+            _retValue = new Lazy<Expr>(() => Children.OfType<Expr>().SingleOrDefault());
         }
 
         public Expr RetValue => _retValue.Value;

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -553,7 +553,7 @@ namespace ClangSharp
                 Argument = new Argument("<name>=<value>")
                 {
                     ArgumentType = typeof(string),
-                    Arity = ArgumentArity.OneOrMore,
+                    Arity = new ArgumentArity(1, ushort.MaxValue),
                 }
             };
             option.Argument.SetDefaultValue(Array.Empty<string>());

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
@@ -1451,6 +1451,32 @@ int MyFunction2(MyStruct* instance)
         }
 
         [Fact]
+        public async Task ReturnEmptyTest()
+        {
+            var inputContents = @"void MyFunction()
+{
+    return;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        private const string LibraryPath = ""ClangSharpPInvokeGenerator"";
+
+        public static void MyFunction()
+        {
+            return;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
         public async Task ReturnIntegerLiteralInt32Test()
         {
             var inputContents = @"int MyFunction()


### PR DESCRIPTION
This fixes some pain paints around paths where Clang ends up with a mix of `\` and `/`, this ensures we don't miss any #includes we should be traversing by forcing traversal of `extern "C" { }` blocks, and ensures we handle empty return statements, anonymous fields, and attributed typedefs.