### PR TITLE
Support implicit VTBLs and generating basic interop tests

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/OutputBuilder.cs
+++ b/sources/ClangSharp.PInvokeGenerator/OutputBuilder.cs
@@ -16,10 +16,11 @@ namespace ClangSharp
         private readonly SortedSet<string> _usingDirectives;
         private readonly SortedSet<string> _staticUsingDirectives;
         private readonly string _indentationString;
+        private readonly bool _isTestOutput;
 
         private int _indentationLevel;
 
-        public OutputBuilder(string name, string indentationString = DefaultIndentationString)
+        public OutputBuilder(string name, string indentationString = DefaultIndentationString, bool isTestOutput = false)
         {
             _name = name;
             _contents = new List<string>();
@@ -27,11 +28,14 @@ namespace ClangSharp
             _usingDirectives = new SortedSet<string>();
             _staticUsingDirectives = new SortedSet<string>();
             _indentationString = indentationString;
+            _isTestOutput = isTestOutput;
         }
 
         public IEnumerable<string> Contents => _contents;
 
         public string IndentationString => _indentationString;
+
+        public bool IsTestOutput => _isTestOutput;
 
         public string Name => _name;
 

--- a/sources/ClangSharp.PInvokeGenerator/OutputBuilderFactory.cs
+++ b/sources/ClangSharp.PInvokeGenerator/OutputBuilderFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,14 +21,14 @@ namespace ClangSharp
             _outputBuilders.Clear();
         }
 
-        public OutputBuilder Create(string name)
+        public OutputBuilder Create(string name, bool isTestOutput = false)
         {
             if (string.IsNullOrWhiteSpace(name))
             {
                 throw new ArgumentNullException(nameof(name));
             }
 
-            var outputBuilder = new OutputBuilder(name);
+            var outputBuilder = new OutputBuilder(name, isTestOutput: isTestOutput);
             _outputBuilders.Add(name, outputBuilder);
             return outputBuilder;
         }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -180,7 +180,7 @@ namespace ClangSharp
                 _outputBuilder.Write(' ');
 
                 var type = cxxFunctionalCastExpr.Type;
-                var typeName = GetRemappedTypeName(cxxFunctionalCastExpr, type, out var nativeTypeName);
+                var typeName = GetRemappedTypeName(cxxFunctionalCastExpr, context: null, type, out var nativeTypeName);
 
                 _outputBuilder.Write(typeName);
                 _outputBuilder.Write('(');
@@ -337,7 +337,7 @@ namespace ClangSharp
         private void VisitExplicitCastExpr(ExplicitCastExpr explicitCastExpr)
         {
             var type = explicitCastExpr.Type;
-            var typeName = GetRemappedTypeName(explicitCastExpr, type, out var nativeTypeName);
+            var typeName = GetRemappedTypeName(explicitCastExpr, context: null, type, out var nativeTypeName);
 
             _outputBuilder.Write('(');
             _outputBuilder.Write(typeName);
@@ -506,12 +506,12 @@ namespace ClangSharp
             if (implicitCastExpr.DeclContext is EnumDecl enumDecl)
             {
                 var enumDeclName = GetRemappedCursorName(enumDecl);
-                var enumDeclIntegerTypeName = GetRemappedTypeName(enumDecl, enumDecl.IntegerType, out var nativeTypeName);
+                var enumDeclIntegerTypeName = GetRemappedTypeName(enumDecl, context: null, enumDecl.IntegerType, out var nativeTypeName);
 
                 WithType("*", ref enumDeclIntegerTypeName, ref nativeTypeName);
                 WithType(enumDeclName, ref enumDeclIntegerTypeName, ref nativeTypeName);
 
-                var integerLiteralTypeName = GetRemappedTypeName(integerLiteral, integerLiteral.Type, out _);
+                var integerLiteralTypeName = GetRemappedTypeName(integerLiteral, context: null, integerLiteral.Type, out _);
 
                 if (enumDeclIntegerTypeName == integerLiteralTypeName)
                 {
@@ -554,7 +554,7 @@ namespace ClangSharp
             _outputBuilder.Write(' ');
 
             var type = initListExpr.Type;
-            var typeName = GetRemappedTypeName(initListExpr, type, out var nativeTypeName);
+            var typeName = GetRemappedTypeName(initListExpr, context: null, type, out var nativeTypeName);
 
             _outputBuilder.Write(typeName);
             _outputBuilder.Write('[');
@@ -604,7 +604,7 @@ namespace ClangSharp
             _outputBuilder.Write(' ');
 
             var type = initListExpr.Type;
-            var typeName = GetRemappedTypeName(initListExpr, type, out var nativeTypeName);
+            var typeName = GetRemappedTypeName(initListExpr, context: null, type, out var nativeTypeName);
 
             _outputBuilder.WriteLine(typeName);
             _outputBuilder.WriteBlockStart();
@@ -1206,7 +1206,7 @@ namespace ClangSharp
                     _outputBuilder.Write("sizeof");
                     _outputBuilder.Write('(');
 
-                    var typeName = GetRemappedTypeName(unaryExprOrTypeTraitExpr, argumentType, out _);
+                    var typeName = GetRemappedTypeName(unaryExprOrTypeTraitExpr, context: null, argumentType, out _);
                     _outputBuilder.Write(typeName);
 
                     _outputBuilder.Write(')');

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -2253,6 +2253,7 @@ namespace ClangSharp
                 _testOutputBuilder.Write(',');
                 _testOutputBuilder.Write(' ');
                 _testOutputBuilder.Write("Is.True");
+                _testOutputBuilder.Write(')');
                 _testOutputBuilder.WriteLine(';');
             }
             else if (_config.GenerateTestsXUnit)

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -19,7 +19,7 @@ namespace ClangSharp
         private readonly Dictionary<string, IReadOnlyList<string>> _withUsings;
         private readonly PInvokeGeneratorConfigurationOptions _options;
 
-        public PInvokeGeneratorConfiguration(string libraryPath, string namespaceName, string outputLocation, PInvokeGeneratorConfigurationOptions options = PInvokeGeneratorConfigurationOptions.None, string[] excludedNames = null, string headerFile = null, string methodClassName = null, string methodPrefixToStrip = null, IReadOnlyDictionary<string, string> remappedNames = null, string[] traversalNames = null, IReadOnlyDictionary<string, IReadOnlyList<string>> withAttributes = null, IReadOnlyDictionary<string, string> withCallConvs = null, IReadOnlyDictionary<string, string> withLibraryPaths = null, string[] withSetLastErrors = null, IReadOnlyDictionary<string, string> withTypes = null, IReadOnlyDictionary<string, IReadOnlyList<string>> withUsings = null)
+        public PInvokeGeneratorConfiguration(string libraryPath, string namespaceName, string outputLocation, string testOutputLocation, PInvokeGeneratorConfigurationOptions options = PInvokeGeneratorConfigurationOptions.None, string[] excludedNames = null, string headerFile = null, string methodClassName = null, string methodPrefixToStrip = null, IReadOnlyDictionary<string, string> remappedNames = null, string[] traversalNames = null, IReadOnlyDictionary<string, IReadOnlyList<string>> withAttributes = null, IReadOnlyDictionary<string, string> withCallConvs = null, IReadOnlyDictionary<string, string> withLibraryPaths = null, string[] withSetLastErrors = null, IReadOnlyDictionary<string, string> withTypes = null, IReadOnlyDictionary<string, IReadOnlyList<string>> withUsings = null)
         {
             if (excludedNames is null)
             {
@@ -81,6 +81,7 @@ namespace ClangSharp
             MethodPrefixToStrip = methodPrefixToStrip;
             Namespace = namespaceName;
             OutputLocation = Path.GetFullPath(outputLocation);
+            TestOutputLocation = !string.IsNullOrWhiteSpace(testOutputLocation) ? Path.GetFullPath(testOutputLocation) : string.Empty;
 
             // Normalize the traversal names to use \ rather than / so path comparisons are simpler
             TraversalNames = traversalNames.Select(traversalName => traversalName.Replace('\\', '/')).ToArray();
@@ -124,6 +125,10 @@ namespace ClangSharp
 
         public bool GenerateMultipleFiles => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateMultipleFiles);
 
+        public bool GenerateTestsNUnit => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateTestsNUnit);
+
+        public bool GenerateTestsXUnit => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateTestsXUnit);
+
         public bool GenerateUnixTypes => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateUnixTypes);
 
         public string HeaderText { get; }
@@ -143,6 +148,8 @@ namespace ClangSharp
         public string OutputLocation { get; }
 
         public IReadOnlyDictionary<string, string> RemappedNames => _remappedNames;
+
+        public string TestOutputLocation { get; }
 
         public string[] TraversalNames { get; }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -116,6 +116,8 @@ namespace ClangSharp
 
         public bool GenerateCompatibleCode => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateCompatibleCode);
 
+        public bool GenerateExplicitVtbls => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateExplicitVtbls);
+
         public bool GeneratePreviewCodeFnptr => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GeneratePreviewCodeFnptr);
 
         public bool GeneratePreviewCodeNint => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GeneratePreviewCodeNint);

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
@@ -26,5 +26,7 @@ namespace ClangSharp
         LogExclusions = 0x00000040,
 
         LogVisitedFiles = 0x00000080,
+
+        GenerateExplicitVtbls = 0x00000100,
     }
 }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
@@ -28,5 +28,9 @@ namespace ClangSharp
         LogVisitedFiles = 0x00000080,
 
         GenerateExplicitVtbls = 0x00000100,
+
+        GenerateTestsNUnit = 0x00000200,
+
+        GenerateTestsXUnit = 0x00000400,
     }
 }

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -120,6 +120,18 @@ namespace ClangSharp
                         break;
                     }
 
+                    case "explicit-vtbls":
+                    {
+                        configOptions |= PInvokeGeneratorConfigurationOptions.GenerateExplicitVtbls;
+                        break;
+                    }
+
+                    case "implicit-vtbls":
+                    {
+                        configOptions &= ~PInvokeGeneratorConfigurationOptions.GenerateExplicitVtbls;
+                        break;
+                    }
+
                     case "latest-codegen":
                     {
                         configOptions &= ~PInvokeGeneratorConfigurationOptions.GenerateCompatibleCode;

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -40,6 +40,7 @@ namespace ClangSharp
             AddPrefixStripOption(s_rootCommand);
             AddRemapOption(s_rootCommand);
             AddStdOption(s_rootCommand);
+            AddTestOutputOption(s_rootCommand);
             AddTraverseOption(s_rootCommand);
             AddWithAttributeOption(s_rootCommand);
             AddWithCallConvOption(s_rootCommand);
@@ -69,6 +70,7 @@ namespace ClangSharp
             var outputLocation = context.ParseResult.ValueForOption<string>("output");
             var remappedNameValuePairs = context.ParseResult.ValueForOption<string[]>("remap");
             var std = context.ParseResult.ValueForOption<string>("std");
+            var testOutputLocation = context.ParseResult.ValueForOption<string>("test-output");
             var traversalNames = context.ParseResult.ValueForOption<string[]>("traverse");
             var withAttributeNameValuePairs = context.ParseResult.ValueForOption<string[]>("with-attribute");
             var withCallConvNameValuePairs = context.ParseResult.ValueForOption<string[]>("with-callconv");
@@ -123,6 +125,36 @@ namespace ClangSharp
                     case "explicit-vtbls":
                     {
                         configOptions |= PInvokeGeneratorConfigurationOptions.GenerateExplicitVtbls;
+                        break;
+                    }
+
+                    case "generate-tests-nunit":
+                    {
+                        if (string.IsNullOrWhiteSpace(testOutputLocation))
+                        {
+                            errorList.Add("Error: No test output file location provided. Use --test-output or -to");
+                        }
+
+                        if (configOptions.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateTestsXUnit))
+                        {
+                            errorList.Add("Cannot generate both NUnit and XUnit tests.");
+                        }
+                        configOptions |= PInvokeGeneratorConfigurationOptions.GenerateTestsNUnit;
+                        break;
+                    }
+
+                    case "generate-tests-xunit":
+                    {
+                        if (string.IsNullOrWhiteSpace(testOutputLocation))
+                        {
+                            errorList.Add("Error: No test output file location provided. Use --test-output or -to");
+                        }
+
+                        if (configOptions.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateTestsNUnit))
+                        {
+                            errorList.Add("Cannot generate both NUnit and XUnit tests.");
+                        }
+                        configOptions |= PInvokeGeneratorConfigurationOptions.GenerateTestsXUnit;
                         break;
                     }
 
@@ -210,6 +242,11 @@ namespace ClangSharp
                 }
             }
 
+            if (!string.IsNullOrWhiteSpace(testOutputLocation) && !configOptions.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateTestsNUnit) && !configOptions.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateTestsXUnit))
+            {
+                errorList.Add("Error: No test format provided. Use --config generate-tests-nunit or --config generate-tests-xunit");
+            }
+
             if (errorList.Any())
             {
                 foreach (var error in errorList)
@@ -239,7 +276,7 @@ namespace ClangSharp
             translationFlags |= CXTranslationUnit_Flags.CXTranslationUnit_IncludeAttributedTypes;               // Include attributed types in CXType
             translationFlags |= CXTranslationUnit_Flags.CXTranslationUnit_VisitImplicitAttributes;              // Implicit attributes should be visited
 
-            var config = new PInvokeGeneratorConfiguration(libraryPath, namespaceName, outputLocation, configOptions, excludedNames, headerFile, methodClassName, methodPrefixToStrip, remappedNames, traversalNames, withAttributes, withCallConvs, withLibraryPath, withSetLastErrors, withTypes, withUsings);
+            var config = new PInvokeGeneratorConfiguration(libraryPath, namespaceName, outputLocation, testOutputLocation, configOptions, excludedNames, headerFile, methodClassName, methodPrefixToStrip, remappedNames, traversalNames, withAttributes, withCallConvs, withLibraryPath, withSetLastErrors, withTypes, withUsings);
 
             int exitCode = 0;
 
@@ -610,6 +647,21 @@ namespace ClangSharp
                 }
             };
             option.Argument.SetDefaultValue("c++17");
+
+            rootCommand.AddOption(option);
+        }
+
+        private static void AddTestOutputOption(RootCommand rootCommand)
+        {
+            var option = new Option(new string[] { "--test-output", "-to" }, "The output location to write the generated tests to.")
+            {
+                Argument = new Argument("<file>")
+                {
+                    ArgumentType = typeof(string),
+                    Arity = ArgumentArity.ExactlyOne,
+                }
+            };
+            option.Argument.SetDefaultValue(string.Empty);
 
             rootCommand.AddOption(option);
         }

--- a/sources/ClangSharpPInvokeGenerator/Properties/GenerateClang.rsp
+++ b/sources/ClangSharpPInvokeGenerator/Properties/GenerateClang.rsp
@@ -1,5 +1,6 @@
 --config
 compatible-codegen
+generate-tests-xunit
 multi-file
 --file
 clang-c/BuildSystem.h
@@ -18,6 +19,8 @@ clang
 --namespace
 ClangSharp.Interop
 --output
-./ClangSharp/Interop
+./sources/ClangSharp/Interop
+--test-output
+./tests/ClangSharp/Interop
 --prefixStrip
 clang_

--- a/sources/ClangSharpPInvokeGenerator/Properties/GenerateClangSharp.rsp
+++ b/sources/ClangSharpPInvokeGenerator/Properties/GenerateClangSharp.rsp
@@ -1,5 +1,6 @@
 --config
 compatible-codegen
+generate-tests-xunit
 multi-file
 --file
 libClangSharp/ClangSharp.h
@@ -10,6 +11,8 @@ clangsharp
 --namespace
 ClangSharp.Interop
 --output
-./ClangSharp/Interop
+./sources/ClangSharp/Interop
+--test-output
+./tests/ClangSharp/Interop
 --prefixStrip
 clangsharp_

--- a/sources/ClangSharpPInvokeGenerator/Properties/GenerateLLVM.rsp
+++ b/sources/ClangSharpPInvokeGenerator/Properties/GenerateLLVM.rsp
@@ -1,5 +1,6 @@
 --config
 compatible-codegen
+generate-tests-nunit
 multi-file
 --file
 llvm-c/Analysis.h
@@ -42,7 +43,9 @@ LLVM
 --namespace
 LLVMSharp
 --output
-./LLVMSharp/Interop
+./sources/LLVMSharp/Interop
+--test-output
+./tests/LLVMSharp/Interop
 --prefixStrip
 LLVM
 --remap

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
@@ -429,12 +429,10 @@ int MyFunctionB(MyStruct* x)
 };";
 
             var callConv = "Cdecl";
-            var callConvAttr = "";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
             {
                 callConv = "ThisCall";
-                callConvAttr = " __attribute__((thiscall))";
             }
 
             var expectedOutputContents = $@"using System;
@@ -445,7 +443,7 @@ namespace ClangSharp.Test
 {{
     public unsafe partial struct MyStruct
     {{
-        public Vtbl* lpVtbl;
+        public void** lpVtbl;
 
         [UnmanagedFunctionPointer(CallingConvention.{callConv})]
         public delegate int _GetType(MyStruct* pThis, int obj);
@@ -458,29 +456,17 @@ namespace ClangSharp.Test
 
         public int GetType(int obj)
         {{
-            return Marshal.GetDelegateForFunctionPointer<_GetType>(lpVtbl->GetType)((MyStruct*)Unsafe.AsPointer(ref this), obj);
+            return Marshal.GetDelegateForFunctionPointer<_GetType>((IntPtr)(lpVtbl[0]))((MyStruct*)Unsafe.AsPointer(ref this), obj);
         }}
 
         public new int GetType()
         {{
-            return Marshal.GetDelegateForFunctionPointer<_GetType1>(lpVtbl->GetType1)((MyStruct*)Unsafe.AsPointer(ref this));
+            return Marshal.GetDelegateForFunctionPointer<_GetType1>((IntPtr)(lpVtbl[1]))((MyStruct*)Unsafe.AsPointer(ref this));
         }}
 
         public int GetType(int objA, int objB)
         {{
-            return Marshal.GetDelegateForFunctionPointer<_GetType2>(lpVtbl->GetType2)((MyStruct*)Unsafe.AsPointer(ref this), objA, objB);
-        }}
-
-        public partial struct Vtbl
-        {{
-            [NativeTypeName(""int (int){callConvAttr}"")]
-            public new IntPtr GetType;
-
-            [NativeTypeName(""int (){callConvAttr}"")]
-            public IntPtr GetType1;
-
-            [NativeTypeName(""int (int, int){callConvAttr}"")]
-            public IntPtr GetType2;
+            return Marshal.GetDelegateForFunctionPointer<_GetType2>((IntPtr)(lpVtbl[2]))((MyStruct*)Unsafe.AsPointer(ref this), objA, objB);
         }}
     }}
 }}
@@ -752,12 +738,10 @@ namespace ClangSharp.Test
 ";
 
             var callConv = "Cdecl";
-            var callConvAttr = "";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
             {
                 callConv = "ThisCall";
-                callConvAttr = " __attribute__((thiscall))";
             }
 
             var expectedOutputContents = $@"using System;
@@ -767,7 +751,7 @@ namespace ClangSharp.Test
 {{
     public unsafe partial struct MyStruct
     {{
-        public Vtbl* lpVtbl;
+        public void** lpVtbl;
 
         [UnmanagedFunctionPointer(CallingConvention.{callConv})]
         public delegate void _MyVoidMethod(MyStruct* pThis);
@@ -783,7 +767,7 @@ namespace ClangSharp.Test
         {{
             fixed (MyStruct* pThis = &this)
             {{
-                Marshal.GetDelegateForFunctionPointer<_MyVoidMethod>(lpVtbl->MyVoidMethod)(pThis);
+                Marshal.GetDelegateForFunctionPointer<_MyVoidMethod>((IntPtr)(lpVtbl[0]))(pThis);
             }}
         }}
 
@@ -792,7 +776,7 @@ namespace ClangSharp.Test
         {{
             fixed (MyStruct* pThis = &this)
             {{
-                return Marshal.GetDelegateForFunctionPointer<_MyInt8Method>(lpVtbl->MyInt8Method)(pThis);
+                return Marshal.GetDelegateForFunctionPointer<_MyInt8Method>((IntPtr)(lpVtbl[1]))(pThis);
             }}
         }}
 
@@ -800,20 +784,8 @@ namespace ClangSharp.Test
         {{
             fixed (MyStruct* pThis = &this)
             {{
-                return Marshal.GetDelegateForFunctionPointer<_MyInt32Method>(lpVtbl->MyInt32Method)(pThis);
+                return Marshal.GetDelegateForFunctionPointer<_MyInt32Method>((IntPtr)(lpVtbl[2]))(pThis);
             }}
-        }}
-
-        public partial struct Vtbl
-        {{
-            [NativeTypeName(""void (){callConvAttr}"")]
-            public IntPtr MyVoidMethod;
-
-            [NativeTypeName(""char (){callConvAttr}"")]
-            public IntPtr MyInt8Method;
-
-            [NativeTypeName(""int (){callConvAttr}"")]
-            public IntPtr MyInt32Method;
         }}
     }}
 }}
@@ -841,12 +813,10 @@ namespace ClangSharp.Test
 ";
 
             var callConv = "Cdecl";
-            var callConvAttr = "";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
             {
                 callConv = "ThisCall";
-                callConvAttr = " __attribute__((thiscall))";
             }
 
             var expectedOutputContents = $@"using System;
@@ -857,7 +827,7 @@ namespace ClangSharp.Test
 {{
     public unsafe partial struct MyStruct
     {{
-        public Vtbl* lpVtbl;
+        public void** lpVtbl;
 
         [UnmanagedFunctionPointer(CallingConvention.{callConv})]
         public delegate void _MyVoidMethod(MyStruct* pThis);
@@ -875,39 +845,24 @@ namespace ClangSharp.Test
 
         public void MyVoidMethod()
         {{
-            Marshal.GetDelegateForFunctionPointer<_MyVoidMethod>(lpVtbl->MyVoidMethod)((MyStruct*)Unsafe.AsPointer(ref this));
+            Marshal.GetDelegateForFunctionPointer<_MyVoidMethod>((IntPtr)(lpVtbl[0]))((MyStruct*)Unsafe.AsPointer(ref this));
         }}
 
         [return: NativeTypeName(""char"")]
         public sbyte MyInt8Method()
         {{
-            return Marshal.GetDelegateForFunctionPointer<_MyInt8Method>(lpVtbl->MyInt8Method)((MyStruct*)Unsafe.AsPointer(ref this));
+            return Marshal.GetDelegateForFunctionPointer<_MyInt8Method>((IntPtr)(lpVtbl[1]))((MyStruct*)Unsafe.AsPointer(ref this));
         }}
 
         public int MyInt32Method()
         {{
-            return Marshal.GetDelegateForFunctionPointer<_MyInt32Method>(lpVtbl->MyInt32Method)((MyStruct*)Unsafe.AsPointer(ref this));
+            return Marshal.GetDelegateForFunctionPointer<_MyInt32Method>((IntPtr)(lpVtbl[2]))((MyStruct*)Unsafe.AsPointer(ref this));
         }}
 
         [return: NativeTypeName(""void *"")]
         public void* MyVoidStarMethod()
         {{
-            return Marshal.GetDelegateForFunctionPointer<_MyVoidStarMethod>(lpVtbl->MyVoidStarMethod)((MyStruct*)Unsafe.AsPointer(ref this));
-        }}
-
-        public partial struct Vtbl
-        {{
-            [NativeTypeName(""void (){callConvAttr}"")]
-            public IntPtr MyVoidMethod;
-
-            [NativeTypeName(""char (){callConvAttr}"")]
-            public IntPtr MyInt8Method;
-
-            [NativeTypeName(""int (){callConvAttr}"")]
-            public IntPtr MyInt32Method;
-
-            [NativeTypeName(""void *(){callConvAttr}"")]
-            public IntPtr MyVoidStarMethod;
+            return Marshal.GetDelegateForFunctionPointer<_MyVoidStarMethod>((IntPtr)(lpVtbl[3]))((MyStruct*)Unsafe.AsPointer(ref this));
         }}
     }}
 }}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
@@ -514,12 +514,10 @@ MyStructB* MyFunction(MyStructA* input)
 ";
 
             var callConv = "Cdecl";
-            var callConvAttr = "";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
             {
                 callConv = "ThisCall";
-                callConvAttr = " __attribute__((thiscall))";
             }
 
             var expectedOutputContents = $@"using System;
@@ -530,39 +528,27 @@ namespace ClangSharp.Test
 {{
     public unsafe partial struct MyStructA
     {{
-        public Vtbl* lpVtbl;
+        public void** lpVtbl;
 
         [UnmanagedFunctionPointer(CallingConvention.{callConv})]
         public delegate void _MyMethod(MyStructA* pThis);
 
         public void MyMethod()
         {{
-            Marshal.GetDelegateForFunctionPointer<_MyMethod>(lpVtbl->MyMethod)((MyStructA*)Unsafe.AsPointer(ref this));
-        }}
-
-        public partial struct Vtbl
-        {{
-            [NativeTypeName(""void (){callConvAttr}"")]
-            public IntPtr MyMethod;
+            Marshal.GetDelegateForFunctionPointer<_MyMethod>((IntPtr)(lpVtbl[0]))((MyStructA*)Unsafe.AsPointer(ref this));
         }}
     }}
 
     public unsafe partial struct MyStructB
     {{
-        public Vtbl* lpVtbl;
+        public void** lpVtbl;
 
         [UnmanagedFunctionPointer(CallingConvention.{callConv})]
         public delegate void _MyMethod(MyStructB* pThis);
 
         public void MyMethod()
         {{
-            Marshal.GetDelegateForFunctionPointer<_MyMethod>(lpVtbl->MyMethod)((MyStructB*)Unsafe.AsPointer(ref this));
-        }}
-
-        public partial struct Vtbl
-        {{
-            [NativeTypeName(""void (){callConvAttr}"")]
-            public IntPtr MyMethod;
+            Marshal.GetDelegateForFunctionPointer<_MyMethod>((IntPtr)(lpVtbl[0]))((MyStructB*)Unsafe.AsPointer(ref this));
         }}
     }}
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/PInvokeGeneratorTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/PInvokeGeneratorTest.cs
@@ -43,7 +43,7 @@ namespace ClangSharp.UnitTests
             using var unsavedFile = CXUnsavedFile.Create(DefaultInputFileName, inputContents);
 
             var unsavedFiles = new CXUnsavedFile[] { unsavedFile };
-            var config = new PInvokeGeneratorConfiguration(libraryPath, DefaultNamespaceName, Path.GetRandomFileName(), configOptions, excludedNames, headerFile: null, methodClassName: null, methodPrefixToStrip: null, remappedNames, traversalNames: null, withAttributes, withCallConvs, withLibraryPaths, withSetLastErrors, withTypes, withUsings);
+            var config = new PInvokeGeneratorConfiguration(libraryPath, DefaultNamespaceName, Path.GetRandomFileName(), testOutputLocation: null, configOptions, excludedNames, headerFile: null, methodClassName: null, methodPrefixToStrip: null, remappedNames, traversalNames: null, withAttributes, withCallConvs, withLibraryPaths, withSetLastErrors, withTypes, withUsings);
 
             using (var pinvokeGenerator = new PInvokeGenerator(config, (path) => outputStream))
             {

--- a/tests/ClangSharp.UnitTests/InteropTests/CXCodeCompleteResultsTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXCodeCompleteResultsTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXCodeCompleteResults" /> struct.</summary>
+    public static unsafe class CXCodeCompleteResultsTests
+    {
+        /// <summary>Validates that the <see cref="CXCodeCompleteResults" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXCodeCompleteResults), Marshal.SizeOf<CXCodeCompleteResults>());
+        }
+
+        /// <summary>Validates that the <see cref="CXCodeCompleteResults" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXCodeCompleteResults).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXCodeCompleteResults" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(16, sizeof(CXCodeCompleteResults));
+            }
+            else
+            {
+                Assert.Equal(8, sizeof(CXCodeCompleteResults));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXCommentTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXCommentTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXComment" /> struct.</summary>
+    public static unsafe class CXCommentTests
+    {
+        /// <summary>Validates that the <see cref="CXComment" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXComment), Marshal.SizeOf<CXComment>());
+        }
+
+        /// <summary>Validates that the <see cref="CXComment" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXComment).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXComment" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(16, sizeof(CXComment));
+            }
+            else
+            {
+                Assert.Equal(8, sizeof(CXComment));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXCompletionResultTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXCompletionResultTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXCompletionResult" /> struct.</summary>
+    public static unsafe class CXCompletionResultTests
+    {
+        /// <summary>Validates that the <see cref="CXCompletionResult" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXCompletionResult), Marshal.SizeOf<CXCompletionResult>());
+        }
+
+        /// <summary>Validates that the <see cref="CXCompletionResult" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXCompletionResult).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXCompletionResult" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(16, sizeof(CXCompletionResult));
+            }
+            else
+            {
+                Assert.Equal(8, sizeof(CXCompletionResult));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXCursorAndRangeVisitorTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXCursorAndRangeVisitorTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXCursorAndRangeVisitor" /> struct.</summary>
+    public static unsafe class CXCursorAndRangeVisitorTests
+    {
+        /// <summary>Validates that the <see cref="CXCursorAndRangeVisitor" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXCursorAndRangeVisitor), Marshal.SizeOf<CXCursorAndRangeVisitor>());
+        }
+
+        /// <summary>Validates that the <see cref="CXCursorAndRangeVisitor" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXCursorAndRangeVisitor).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXCursorAndRangeVisitor" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(16, sizeof(CXCursorAndRangeVisitor));
+            }
+            else
+            {
+                Assert.Equal(8, sizeof(CXCursorAndRangeVisitor));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXCursorTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXCursorTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXCursor" /> struct.</summary>
+    public static unsafe class CXCursorTests
+    {
+        /// <summary>Validates that the <see cref="CXCursor" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXCursor), Marshal.SizeOf<CXCursor>());
+        }
+
+        /// <summary>Validates that the <see cref="CXCursor" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXCursor).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXCursor" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(32, sizeof(CXCursor));
+            }
+            else
+            {
+                Assert.Equal(20, sizeof(CXCursor));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXFileUniqueIDTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXFileUniqueIDTests.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXFileUniqueID" /> struct.</summary>
+    public static unsafe class CXFileUniqueIDTests
+    {
+        /// <summary>Validates that the <see cref="CXFileUniqueID" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXFileUniqueID), Marshal.SizeOf<CXFileUniqueID>());
+        }
+
+        /// <summary>Validates that the <see cref="CXFileUniqueID" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXFileUniqueID).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXFileUniqueID" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            Assert.Equal(24, sizeof(CXFileUniqueID));
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXIdxAttrInfoTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXIdxAttrInfoTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXIdxAttrInfo" /> struct.</summary>
+    public static unsafe class CXIdxAttrInfoTests
+    {
+        /// <summary>Validates that the <see cref="CXIdxAttrInfo" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXIdxAttrInfo), Marshal.SizeOf<CXIdxAttrInfo>());
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxAttrInfo" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXIdxAttrInfo).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxAttrInfo" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(64, sizeof(CXIdxAttrInfo));
+            }
+            else
+            {
+                Assert.Equal(36, sizeof(CXIdxAttrInfo));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXIdxBaseClassInfoTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXIdxBaseClassInfoTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXIdxBaseClassInfo" /> struct.</summary>
+    public static unsafe class CXIdxBaseClassInfoTests
+    {
+        /// <summary>Validates that the <see cref="CXIdxBaseClassInfo" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXIdxBaseClassInfo), Marshal.SizeOf<CXIdxBaseClassInfo>());
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxBaseClassInfo" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXIdxBaseClassInfo).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxBaseClassInfo" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(64, sizeof(CXIdxBaseClassInfo));
+            }
+            else
+            {
+                Assert.Equal(36, sizeof(CXIdxBaseClassInfo));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXIdxCXXClassDeclInfoTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXIdxCXXClassDeclInfoTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXIdxCXXClassDeclInfo" /> struct.</summary>
+    public static unsafe class CXIdxCXXClassDeclInfoTests
+    {
+        /// <summary>Validates that the <see cref="CXIdxCXXClassDeclInfo" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXIdxCXXClassDeclInfo), Marshal.SizeOf<CXIdxCXXClassDeclInfo>());
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxCXXClassDeclInfo" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXIdxCXXClassDeclInfo).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxCXXClassDeclInfo" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(24, sizeof(CXIdxCXXClassDeclInfo));
+            }
+            else
+            {
+                Assert.Equal(12, sizeof(CXIdxCXXClassDeclInfo));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXIdxContainerInfoTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXIdxContainerInfoTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXIdxContainerInfo" /> struct.</summary>
+    public static unsafe class CXIdxContainerInfoTests
+    {
+        /// <summary>Validates that the <see cref="CXIdxContainerInfo" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXIdxContainerInfo), Marshal.SizeOf<CXIdxContainerInfo>());
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxContainerInfo" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXIdxContainerInfo).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxContainerInfo" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(32, sizeof(CXIdxContainerInfo));
+            }
+            else
+            {
+                Assert.Equal(20, sizeof(CXIdxContainerInfo));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXIdxDeclInfoTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXIdxDeclInfoTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXIdxDeclInfo" /> struct.</summary>
+    public static unsafe class CXIdxDeclInfoTests
+    {
+        /// <summary>Validates that the <see cref="CXIdxDeclInfo" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXIdxDeclInfo), Marshal.SizeOf<CXIdxDeclInfo>());
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxDeclInfo" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXIdxDeclInfo).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxDeclInfo" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(128, sizeof(CXIdxDeclInfo));
+            }
+            else
+            {
+                Assert.Equal(76, sizeof(CXIdxDeclInfo));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXIdxEntityInfoTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXIdxEntityInfoTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXIdxEntityInfo" /> struct.</summary>
+    public static unsafe class CXIdxEntityInfoTests
+    {
+        /// <summary>Validates that the <see cref="CXIdxEntityInfo" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXIdxEntityInfo), Marshal.SizeOf<CXIdxEntityInfo>());
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxEntityInfo" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXIdxEntityInfo).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxEntityInfo" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(80, sizeof(CXIdxEntityInfo));
+            }
+            else
+            {
+                Assert.Equal(48, sizeof(CXIdxEntityInfo));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXIdxEntityRefInfoTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXIdxEntityRefInfoTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXIdxEntityRefInfo" /> struct.</summary>
+    public static unsafe class CXIdxEntityRefInfoTests
+    {
+        /// <summary>Validates that the <see cref="CXIdxEntityRefInfo" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXIdxEntityRefInfo), Marshal.SizeOf<CXIdxEntityRefInfo>());
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxEntityRefInfo" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXIdxEntityRefInfo).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxEntityRefInfo" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(96, sizeof(CXIdxEntityRefInfo));
+            }
+            else
+            {
+                Assert.Equal(52, sizeof(CXIdxEntityRefInfo));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXIdxIBOutletCollectionAttrInfoTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXIdxIBOutletCollectionAttrInfoTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXIdxIBOutletCollectionAttrInfo" /> struct.</summary>
+    public static unsafe class CXIdxIBOutletCollectionAttrInfoTests
+    {
+        /// <summary>Validates that the <see cref="CXIdxIBOutletCollectionAttrInfo" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXIdxIBOutletCollectionAttrInfo), Marshal.SizeOf<CXIdxIBOutletCollectionAttrInfo>());
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxIBOutletCollectionAttrInfo" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXIdxIBOutletCollectionAttrInfo).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxIBOutletCollectionAttrInfo" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(72, sizeof(CXIdxIBOutletCollectionAttrInfo));
+            }
+            else
+            {
+                Assert.Equal(40, sizeof(CXIdxIBOutletCollectionAttrInfo));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXIdxImportedASTFileInfoTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXIdxImportedASTFileInfoTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXIdxImportedASTFileInfo" /> struct.</summary>
+    public static unsafe class CXIdxImportedASTFileInfoTests
+    {
+        /// <summary>Validates that the <see cref="CXIdxImportedASTFileInfo" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXIdxImportedASTFileInfo), Marshal.SizeOf<CXIdxImportedASTFileInfo>());
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxImportedASTFileInfo" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXIdxImportedASTFileInfo).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxImportedASTFileInfo" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(48, sizeof(CXIdxImportedASTFileInfo));
+            }
+            else
+            {
+                Assert.Equal(24, sizeof(CXIdxImportedASTFileInfo));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXIdxIncludedFileInfoTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXIdxIncludedFileInfoTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXIdxIncludedFileInfo" /> struct.</summary>
+    public static unsafe class CXIdxIncludedFileInfoTests
+    {
+        /// <summary>Validates that the <see cref="CXIdxIncludedFileInfo" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXIdxIncludedFileInfo), Marshal.SizeOf<CXIdxIncludedFileInfo>());
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxIncludedFileInfo" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXIdxIncludedFileInfo).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxIncludedFileInfo" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(56, sizeof(CXIdxIncludedFileInfo));
+            }
+            else
+            {
+                Assert.Equal(32, sizeof(CXIdxIncludedFileInfo));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXIdxLocTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXIdxLocTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXIdxLoc" /> struct.</summary>
+    public static unsafe class CXIdxLocTests
+    {
+        /// <summary>Validates that the <see cref="CXIdxLoc" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXIdxLoc), Marshal.SizeOf<CXIdxLoc>());
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxLoc" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXIdxLoc).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxLoc" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(24, sizeof(CXIdxLoc));
+            }
+            else
+            {
+                Assert.Equal(12, sizeof(CXIdxLoc));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXIdxObjCCategoryDeclInfoTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXIdxObjCCategoryDeclInfoTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXIdxObjCCategoryDeclInfo" /> struct.</summary>
+    public static unsafe class CXIdxObjCCategoryDeclInfoTests
+    {
+        /// <summary>Validates that the <see cref="CXIdxObjCCategoryDeclInfo" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXIdxObjCCategoryDeclInfo), Marshal.SizeOf<CXIdxObjCCategoryDeclInfo>());
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxObjCCategoryDeclInfo" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXIdxObjCCategoryDeclInfo).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxObjCCategoryDeclInfo" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(80, sizeof(CXIdxObjCCategoryDeclInfo));
+            }
+            else
+            {
+                Assert.Equal(44, sizeof(CXIdxObjCCategoryDeclInfo));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXIdxObjCContainerDeclInfoTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXIdxObjCContainerDeclInfoTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXIdxObjCContainerDeclInfo" /> struct.</summary>
+    public static unsafe class CXIdxObjCContainerDeclInfoTests
+    {
+        /// <summary>Validates that the <see cref="CXIdxObjCContainerDeclInfo" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXIdxObjCContainerDeclInfo), Marshal.SizeOf<CXIdxObjCContainerDeclInfo>());
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxObjCContainerDeclInfo" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXIdxObjCContainerDeclInfo).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxObjCContainerDeclInfo" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(16, sizeof(CXIdxObjCContainerDeclInfo));
+            }
+            else
+            {
+                Assert.Equal(8, sizeof(CXIdxObjCContainerDeclInfo));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXIdxObjCInterfaceDeclInfoTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXIdxObjCInterfaceDeclInfoTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXIdxObjCInterfaceDeclInfo" /> struct.</summary>
+    public static unsafe class CXIdxObjCInterfaceDeclInfoTests
+    {
+        /// <summary>Validates that the <see cref="CXIdxObjCInterfaceDeclInfo" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXIdxObjCInterfaceDeclInfo), Marshal.SizeOf<CXIdxObjCInterfaceDeclInfo>());
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxObjCInterfaceDeclInfo" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXIdxObjCInterfaceDeclInfo).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxObjCInterfaceDeclInfo" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(24, sizeof(CXIdxObjCInterfaceDeclInfo));
+            }
+            else
+            {
+                Assert.Equal(12, sizeof(CXIdxObjCInterfaceDeclInfo));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXIdxObjCPropertyDeclInfoTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXIdxObjCPropertyDeclInfoTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXIdxObjCPropertyDeclInfo" /> struct.</summary>
+    public static unsafe class CXIdxObjCPropertyDeclInfoTests
+    {
+        /// <summary>Validates that the <see cref="CXIdxObjCPropertyDeclInfo" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXIdxObjCPropertyDeclInfo), Marshal.SizeOf<CXIdxObjCPropertyDeclInfo>());
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxObjCPropertyDeclInfo" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXIdxObjCPropertyDeclInfo).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxObjCPropertyDeclInfo" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(24, sizeof(CXIdxObjCPropertyDeclInfo));
+            }
+            else
+            {
+                Assert.Equal(12, sizeof(CXIdxObjCPropertyDeclInfo));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXIdxObjCProtocolRefInfoTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXIdxObjCProtocolRefInfoTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXIdxObjCProtocolRefInfo" /> struct.</summary>
+    public static unsafe class CXIdxObjCProtocolRefInfoTests
+    {
+        /// <summary>Validates that the <see cref="CXIdxObjCProtocolRefInfo" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXIdxObjCProtocolRefInfo), Marshal.SizeOf<CXIdxObjCProtocolRefInfo>());
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxObjCProtocolRefInfo" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXIdxObjCProtocolRefInfo).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxObjCProtocolRefInfo" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(64, sizeof(CXIdxObjCProtocolRefInfo));
+            }
+            else
+            {
+                Assert.Equal(36, sizeof(CXIdxObjCProtocolRefInfo));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXIdxObjCProtocolRefListInfoTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXIdxObjCProtocolRefListInfoTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXIdxObjCProtocolRefListInfo" /> struct.</summary>
+    public static unsafe class CXIdxObjCProtocolRefListInfoTests
+    {
+        /// <summary>Validates that the <see cref="CXIdxObjCProtocolRefListInfo" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXIdxObjCProtocolRefListInfo), Marshal.SizeOf<CXIdxObjCProtocolRefListInfo>());
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxObjCProtocolRefListInfo" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXIdxObjCProtocolRefListInfo).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXIdxObjCProtocolRefListInfo" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(16, sizeof(CXIdxObjCProtocolRefListInfo));
+            }
+            else
+            {
+                Assert.Equal(8, sizeof(CXIdxObjCProtocolRefListInfo));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXPlatformAvailabilityTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXPlatformAvailabilityTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXPlatformAvailability" /> struct.</summary>
+    public static unsafe class CXPlatformAvailabilityTests
+    {
+        /// <summary>Validates that the <see cref="CXPlatformAvailability" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXPlatformAvailability), Marshal.SizeOf<CXPlatformAvailability>());
+        }
+
+        /// <summary>Validates that the <see cref="CXPlatformAvailability" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXPlatformAvailability).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXPlatformAvailability" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(72, sizeof(CXPlatformAvailability));
+            }
+            else
+            {
+                Assert.Equal(56, sizeof(CXPlatformAvailability));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXSourceLocationTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXSourceLocationTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXSourceLocation" /> struct.</summary>
+    public static unsafe class CXSourceLocationTests
+    {
+        /// <summary>Validates that the <see cref="CXSourceLocation" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXSourceLocation), Marshal.SizeOf<CXSourceLocation>());
+        }
+
+        /// <summary>Validates that the <see cref="CXSourceLocation" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXSourceLocation).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXSourceLocation" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(24, sizeof(CXSourceLocation));
+            }
+            else
+            {
+                Assert.Equal(12, sizeof(CXSourceLocation));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXSourceRangeListTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXSourceRangeListTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXSourceRangeList" /> struct.</summary>
+    public static unsafe class CXSourceRangeListTests
+    {
+        /// <summary>Validates that the <see cref="CXSourceRangeList" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXSourceRangeList), Marshal.SizeOf<CXSourceRangeList>());
+        }
+
+        /// <summary>Validates that the <see cref="CXSourceRangeList" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXSourceRangeList).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXSourceRangeList" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(16, sizeof(CXSourceRangeList));
+            }
+            else
+            {
+                Assert.Equal(8, sizeof(CXSourceRangeList));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXSourceRangeTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXSourceRangeTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXSourceRange" /> struct.</summary>
+    public static unsafe class CXSourceRangeTests
+    {
+        /// <summary>Validates that the <see cref="CXSourceRange" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXSourceRange), Marshal.SizeOf<CXSourceRange>());
+        }
+
+        /// <summary>Validates that the <see cref="CXSourceRange" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXSourceRange).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXSourceRange" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(24, sizeof(CXSourceRange));
+            }
+            else
+            {
+                Assert.Equal(16, sizeof(CXSourceRange));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXStringSetTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXStringSetTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXStringSet" /> struct.</summary>
+    public static unsafe class CXStringSetTests
+    {
+        /// <summary>Validates that the <see cref="CXStringSet" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXStringSet), Marshal.SizeOf<CXStringSet>());
+        }
+
+        /// <summary>Validates that the <see cref="CXStringSet" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXStringSet).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXStringSet" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(16, sizeof(CXStringSet));
+            }
+            else
+            {
+                Assert.Equal(8, sizeof(CXStringSet));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXStringTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXStringTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXString" /> struct.</summary>
+    public static unsafe class CXStringTests
+    {
+        /// <summary>Validates that the <see cref="CXString" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXString), Marshal.SizeOf<CXString>());
+        }
+
+        /// <summary>Validates that the <see cref="CXString" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXString).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXString" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(16, sizeof(CXString));
+            }
+            else
+            {
+                Assert.Equal(8, sizeof(CXString));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXTUResourceUsageEntryTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXTUResourceUsageEntryTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXTUResourceUsageEntry" /> struct.</summary>
+    public static unsafe class CXTUResourceUsageEntryTests
+    {
+        /// <summary>Validates that the <see cref="CXTUResourceUsageEntry" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXTUResourceUsageEntry), Marshal.SizeOf<CXTUResourceUsageEntry>());
+        }
+
+        /// <summary>Validates that the <see cref="CXTUResourceUsageEntry" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXTUResourceUsageEntry).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXTUResourceUsageEntry" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(16, sizeof(CXTUResourceUsageEntry));
+            }
+            else
+            {
+                Assert.Equal(8, sizeof(CXTUResourceUsageEntry));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXTUResourceUsageTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXTUResourceUsageTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXTUResourceUsage" /> struct.</summary>
+    public static unsafe class CXTUResourceUsageTests
+    {
+        /// <summary>Validates that the <see cref="CXTUResourceUsage" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXTUResourceUsage), Marshal.SizeOf<CXTUResourceUsage>());
+        }
+
+        /// <summary>Validates that the <see cref="CXTUResourceUsage" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXTUResourceUsage).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXTUResourceUsage" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(24, sizeof(CXTUResourceUsage));
+            }
+            else
+            {
+                Assert.Equal(12, sizeof(CXTUResourceUsage));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXTokenTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXTokenTests.cs
@@ -3,6 +3,7 @@
 // Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
+using System;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -29,7 +30,14 @@ namespace ClangSharp.Interop.UnitTests
         [Fact]
         public static void SizeOfTest()
         {
-            Assert.Equal(20, sizeof(CXToken));
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(24, sizeof(CXToken));
+            }
+            else
+            {
+                Assert.Equal(20, sizeof(CXToken));
+            }
         }
     }
 }

--- a/tests/ClangSharp.UnitTests/InteropTests/CXTokenTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXTokenTests.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXToken" /> struct.</summary>
+    public static unsafe class CXTokenTests
+    {
+        /// <summary>Validates that the <see cref="CXToken" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXToken), Marshal.SizeOf<CXToken>());
+        }
+
+        /// <summary>Validates that the <see cref="CXToken" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXToken).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXToken" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            Assert.Equal(20, sizeof(CXToken));
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXTypeTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXTypeTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXType" /> struct.</summary>
+    public static unsafe class CXTypeTests
+    {
+        /// <summary>Validates that the <see cref="CXType" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXType), Marshal.SizeOf<CXType>());
+        }
+
+        /// <summary>Validates that the <see cref="CXType" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXType).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXType" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(24, sizeof(CXType));
+            }
+            else
+            {
+                Assert.Equal(12, sizeof(CXType));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXUnsavedFileTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXUnsavedFileTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXUnsavedFile" /> struct.</summary>
+    public static unsafe class CXUnsavedFileTests
+    {
+        /// <summary>Validates that the <see cref="CXUnsavedFile" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXUnsavedFile), Marshal.SizeOf<CXUnsavedFile>());
+        }
+
+        /// <summary>Validates that the <see cref="CXUnsavedFile" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXUnsavedFile).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXUnsavedFile" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(24, sizeof(CXUnsavedFile));
+            }
+            else
+            {
+                Assert.Equal(12, sizeof(CXUnsavedFile));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/CXVersionTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/CXVersionTests.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="CXVersion" /> struct.</summary>
+    public static unsafe class CXVersionTests
+    {
+        /// <summary>Validates that the <see cref="CXVersion" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(CXVersion), Marshal.SizeOf<CXVersion>());
+        }
+
+        /// <summary>Validates that the <see cref="CXVersion" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(CXVersion).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="CXVersion" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            Assert.Equal(12, sizeof(CXVersion));
+        }
+    }
+}

--- a/tests/ClangSharp.UnitTests/InteropTests/IndexerCallbacksTests.cs
+++ b/tests/ClangSharp.UnitTests/InteropTests/IndexerCallbacksTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0/clang/include/clang-c
+// Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IndexerCallbacks" /> struct.</summary>
+    public static unsafe class IndexerCallbacksTests
+    {
+        /// <summary>Validates that the <see cref="IndexerCallbacks" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(IndexerCallbacks), Marshal.SizeOf<IndexerCallbacks>());
+        }
+
+        /// <summary>Validates that the <see cref="IndexerCallbacks" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(IndexerCallbacks).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref="IndexerCallbacks" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(64, sizeof(IndexerCallbacks));
+            }
+            else
+            {
+                Assert.Equal(32, sizeof(IndexerCallbacks));
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds an option to generate strongly-typed VTBLs vs simple VTBLs where each slot is merely indexed as needed. The latter can help with AOT scenarios as there are less types that need to be kept around.

This additionally adds basic support for generating XUnit or NUnit tests that perform basic validation of the generated interop structs. This validation includes checking the size, layout, and blittability of the type.