### PR TITLE
Ensure bitfields are still correctly handled if there is only one

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -1698,12 +1698,12 @@ namespace ClangSharp
 
                 if ((!pinvokeGenerator._config.GenerateUnixTypes && (currentSize != previousSize)) || (fieldDecl.BitWidthValue > remainingBits))
                 {
-                    index++;
-
-                    if (index > 0)
+                    if (index >= 0)
                     {
+                        index++;
                         bitfieldName += index.ToString();
                     }
+
                     remainingBits = currentSize * 8;
                     previousSize = 0;
 
@@ -1724,7 +1724,7 @@ namespace ClangSharp
                         remainingBits += (currentSize - previousSize) * 8;
                     }
 
-                    if (index > 0)
+                    if (index >= 0)
                     {
                         bitfieldName += index.ToString();
                     }
@@ -1734,8 +1734,9 @@ namespace ClangSharp
                 var bitfieldOffset = (currentSize * 8) - remainingBits;
 
                 var bitwidthHexStringBacking = ((1 << fieldDecl.BitWidthValue) - 1).ToString("X");
-                var canonicalTypeBacking = types[index - 1].CanonicalType;
-                var typeNameBacking = pinvokeGenerator.GetRemappedTypeName(fieldDecl, context: null, types[index - 1], out _);
+                var typeBacking = (index > 0) ? types[index - 1] : types[0];
+                var canonicalTypeBacking = typeBacking.CanonicalType;
+                var typeNameBacking = pinvokeGenerator.GetRemappedTypeName(fieldDecl, context: null, typeBacking, out _);
 
                 switch (canonicalTypeBacking.Kind)
                 {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
@@ -59,6 +59,12 @@ struct MyStruct2
     int x;
     unsigned int o8_b0_1 : 1;
 };
+
+struct MyStruct3
+{
+    unsigned int o0_b0_1 : 1;
+    unsigned int o0_b1_1 : 1;
+};
 ";
 
             var expectedOutputContents = @"namespace ClangSharp.Test
@@ -208,6 +214,39 @@ struct MyStruct2
             }
         }
     }
+
+    public partial struct MyStruct3
+    {
+        internal uint _bitfield;
+
+        [NativeTypeName(""unsigned int : 1"")]
+        public uint o0_b0_1
+        {
+            get
+            {
+                return _bitfield & 0x1u;
+            }
+
+            set
+            {
+                _bitfield = (_bitfield & ~0x1u) | (value & 0x1u);
+            }
+        }
+
+        [NativeTypeName(""unsigned int : 1"")]
+        public uint o0_b1_1
+        {
+            get
+            {
+                return (_bitfield >> 1) & 0x1u;
+            }
+
+            set
+            {
+                _bitfield = (_bitfield & ~(0x1u << 1)) | ((value & 0x1u) << 1);
+            }
+        }
+    }
 }
 ";
 
@@ -233,6 +272,12 @@ struct MyStruct2
     unsigned int o0_b0_1 : 1;
     int x;
     unsigned int o8_b0_1 : 1;
+};
+
+struct MyStruct3
+{
+    unsigned int o0_b0_1 : 1;
+    unsigned int o0_b1_1 : 1;
 };
 ";
 
@@ -376,6 +421,39 @@ struct MyStruct2
             set
             {
                 _bitfield2 = (_bitfield2 & ~0x1u) | (value & 0x1u);
+            }
+        }
+    }
+
+    public partial struct MyStruct3
+    {
+        internal uint _bitfield;
+
+        [NativeTypeName(""unsigned int : 1"")]
+        public uint o0_b0_1
+        {
+            get
+            {
+                return _bitfield & 0x1u;
+            }
+
+            set
+            {
+                _bitfield = (_bitfield & ~0x1u) | (value & 0x1u);
+            }
+        }
+
+        [NativeTypeName(""unsigned int : 1"")]
+        public uint o0_b1_1
+        {
+            get
+            {
+                return (_bitfield >> 1) & 0x1u;
+            }
+
+            set
+            {
+                _bitfield = (_bitfield & ~(0x1u << 1)) | ((value & 0x1u) << 1);
             }
         }
     }


### PR DESCRIPTION
This should resolve what I believe the error is for https://github.com/microsoft/ClangSharp/issues/155, however there aren't any repro steps so I can't be for certain.