### PR TITLE
Massively improve the perf of MacroDefinitionRecord handling

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -2431,7 +2431,7 @@ namespace ClangSharp
             {
                 ForDeclStmt(varDecl, declStmt);
             }
-            else if ((previousContext is TranslationUnitDecl) || (previousContext is LinkageSpecDecl) || (previousContext is MacroDefinitionRecord) || (previousContext is RecordDecl))
+            else if ((previousContext is TranslationUnitDecl) || (previousContext is LinkageSpecDecl) || (previousContext is RecordDecl))
             {
                 if (!varDecl.HasInit)
                 {

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -721,9 +721,17 @@ namespace ClangSharp
             {
                 valueString = valueString.Substring(0, valueString.Length - 1);
             }
+            else if (valueString.EndsWith("ui8", StringComparison.OrdinalIgnoreCase))
+            {
+                valueString = valueString.Substring(0, valueString.Length - 3);
+            }
             else if (valueString.EndsWith("i8", StringComparison.OrdinalIgnoreCase))
             {
                 valueString = valueString.Substring(0, valueString.Length - 2);
+            }
+            else if (valueString.EndsWith("ui16", StringComparison.OrdinalIgnoreCase))
+            {
+                valueString = valueString.Substring(0, valueString.Length - 4);
             }
             else if (valueString.EndsWith("i16", StringComparison.OrdinalIgnoreCase))
             {

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -716,9 +717,25 @@ namespace ClangSharp
         {
             var valueString = integerLiteral.ValueString;
 
-            if (valueString.EndsWith("l") || valueString.EndsWith("L"))
+            if (valueString.EndsWith("L", StringComparison.OrdinalIgnoreCase))
             {
                 valueString = valueString.Substring(0, valueString.Length - 1);
+            }
+            else if (valueString.EndsWith("i8", StringComparison.OrdinalIgnoreCase))
+            {
+                valueString = valueString.Substring(0, valueString.Length - 2);
+            }
+            else if (valueString.EndsWith("i16", StringComparison.OrdinalIgnoreCase))
+            {
+                valueString = valueString.Substring(0, valueString.Length - 3);
+            }
+            else if (valueString.EndsWith("i32", StringComparison.OrdinalIgnoreCase))
+            {
+                valueString = valueString.Substring(0, valueString.Length - 3);
+            }
+            else if (valueString.EndsWith("i64", StringComparison.OrdinalIgnoreCase))
+            {
+                valueString = valueString.Substring(0, valueString.Length - 3);
             }
 
             _outputBuilder.Write(valueString);

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -854,6 +854,93 @@ namespace ClangSharp
             }
         }
 
+        private bool GetIsUncheckedCastNeeded(string typeName, Expr subExpr)
+        {
+            var isUncheckedCastNeeded = false;
+
+            if (subExpr is ImplicitCastExpr implicitCastExpr)
+            {
+                subExpr = implicitCastExpr.SubExprAsWritten;
+            }
+
+            if (subExpr is IntegerLiteral integerLiteral)
+            {
+                var signedValue = integerLiteral.Value;
+
+                switch (typeName)
+                {
+                    case "byte":
+                    case "Byte":
+                    {
+                        var unsignedValue = unchecked((uint)signedValue);
+                        isUncheckedCastNeeded = (unsignedValue < byte.MinValue) || (byte.MaxValue < unsignedValue);
+                        break;
+                    }
+
+                    case "ushort":
+                    case "UInt16":
+                    {
+                        var unsignedValue = unchecked((uint)signedValue);
+                        isUncheckedCastNeeded = (unsignedValue < ushort.MinValue) || (ushort.MaxValue < unsignedValue);
+                        break;
+                    }
+
+                    case "uint":
+                    case "UInt32":
+                    case "nuint":
+                    {
+                        var unsignedValue = unchecked((uint)signedValue);
+                        isUncheckedCastNeeded = (unsignedValue < uint.MinValue) || (uint.MaxValue < unsignedValue);
+                        break;
+                    }
+
+                    case "ulong":
+                    case "UInt64":
+                    {
+                        var unsignedValue = unchecked((ulong)signedValue);
+                        isUncheckedCastNeeded = (unsignedValue < ulong.MinValue) || (ulong.MaxValue < unsignedValue);
+                        break;
+                    }
+
+                    case "sbyte":
+                    case "SByte":
+                    {
+                        isUncheckedCastNeeded = (signedValue < sbyte.MinValue) || (sbyte.MaxValue < signedValue) || ((integerLiteral.IsNegative) && (integerLiteral.ValueString.StartsWith("0x")));
+                        break;
+                    }
+
+                    case "short":
+                    case "Int16":
+                    {
+                        isUncheckedCastNeeded = (signedValue < short.MinValue) || (short.MaxValue < signedValue) || ((integerLiteral.IsNegative) && (integerLiteral.ValueString.StartsWith("0x")));
+                        break;
+                    }
+
+                    case "int":
+                    case "Int32":
+                    case "nint":
+                    {
+                        isUncheckedCastNeeded = (signedValue < int.MinValue) || (int.MaxValue < signedValue) || ((integerLiteral.IsNegative) && (integerLiteral.ValueString.StartsWith("0x")));
+                        break;
+                    }
+
+                    case "long":
+                    case "Int64":
+                    {
+                        isUncheckedCastNeeded = (signedValue < long.MinValue) || (long.MaxValue < signedValue) || ((integerLiteral.IsNegative) && (integerLiteral.ValueString.StartsWith("0x")));
+                        break;
+                    }
+
+                    default:
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return isUncheckedCastNeeded;
+        }
+
         private static CXXRecordDecl GetRecordDeclForBaseSpecifier(CXXBaseSpecifier cxxBaseSpecifier)
         {
             Type baseType = cxxBaseSpecifier.Type;

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -19,6 +19,7 @@ namespace ClangSharp
         private readonly CXIndex _index;
         private readonly OutputBuilderFactory _outputBuilderFactory;
         private readonly Func<string, Stream> _outputStreamFactory;
+        private readonly StringBuilder _fileContentsBuilder;
         private readonly HashSet<string> _visitedFiles;
         private readonly List<Diagnostic> _diagnostics;
         private readonly LinkedList<Cursor> _context;
@@ -48,6 +49,7 @@ namespace ClangSharp
                 Directory.CreateDirectory(directoryPath);
                 return new FileStream(path, FileMode.Create);
             });
+            _fileContentsBuilder = new StringBuilder();
             _visitedFiles = new HashSet<string>();
             _diagnostics = new List<Diagnostic>();
             _context = new LinkedList<Cursor>();
@@ -198,7 +200,39 @@ namespace ClangSharp
                 }
             }
 
-            Visit(translationUnit.TranslationUnitDecl);
+            if (_config.GenerateMacroBindings)
+            {
+                var translationUnitHandle = translationUnit.Handle;
+
+                var file = translationUnitHandle.GetFile(_filePath);
+                var fileContents = translationUnitHandle.GetFileContents(file, out var size);
+#if NETCOREAPP
+                _fileContentsBuilder.Append(Encoding.UTF8.GetString(fileContents));
+#else
+                _fileContentsBuilder.Append(Encoding.UTF8.GetString(fileContents.ToArray()));
+#endif
+
+                foreach (var cursor in translationUnit.TranslationUnitDecl.CursorChildren)
+                {
+                    if (cursor is PreprocessedEntity preprocessedEntity)
+                    {
+                        VisitPreprocessedEntity(preprocessedEntity);
+                    }
+                }
+
+                using var unsavedFile = CXUnsavedFile.Create(_filePath, _fileContentsBuilder.ToString());
+                var unsavedFiles = new CXUnsavedFile[] { unsavedFile };
+
+                translationFlags = _translationFlags & ~CXTranslationUnit_Flags.CXTranslationUnit_DetailedPreprocessingRecord;
+                var handle = CXTranslationUnit.Parse(IndexHandle, _filePath, _clangCommandLineArgs, unsavedFiles, translationFlags);
+
+                using var nestedTranslationUnit = TranslationUnit.GetOrCreate(handle);
+                Visit(nestedTranslationUnit.TranslationUnitDecl);
+            }
+            else
+            {
+                Visit(translationUnit.TranslationUnitDecl);
+            }
         }
 
         private void AddDiagnostic(DiagnosticLevel level, string message)
@@ -1611,7 +1645,7 @@ namespace ClangSharp
 
             bool IsAlwaysIncluded(Cursor cursor)
             {
-                return (cursor is TranslationUnitDecl) || (cursor is LinkageSpecDecl) || ((cursor is VarDecl) && (PreviousContext is MacroDefinitionRecord));
+                return (cursor is TranslationUnitDecl) || (cursor is LinkageSpecDecl) || ((cursor is VarDecl varDecl) && varDecl.Name.StartsWith("ClangSharpMacro_"));
             }
 
             bool IsExcludedByFile(Cursor cursor)
@@ -2203,10 +2237,6 @@ namespace ClangSharp
             else if (cursor is Decl decl)
             {
                 VisitDecl(decl);
-            }
-            else if (cursor is PreprocessedEntity preprocessedEntity)
-            {
-                VisitPreprocessedEntity(preprocessedEntity);
             }
             else if (cursor is Ref @ref)
             {

--- a/sources/ClangSharp/Cursors/Exprs/UnaryExprOrTypeTraitExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/UnaryExprOrTypeTraitExpr.cs
@@ -12,8 +12,26 @@ namespace ClangSharp
 
         internal UnaryExprOrTypeTraitExpr(CXCursor handle) : base(handle, CXCursorKind.CXCursor_UnaryExpr, CX_StmtClass.CX_StmtClass_UnaryExprOrTypeTraitExpr)
         {
-            _argumentExpr = new Lazy<Expr>(() => TranslationUnit.GetOrCreate<Expr>(Handle.SubExpr));
-            _argumentType = new Lazy<Type>(() => TranslationUnit.GetOrCreate<Type>(Handle.ArgumentType));
+            _argumentExpr = new Lazy<Expr>(() => {
+                try
+                {
+                    return TranslationUnit.GetOrCreate<Expr>(Handle.SubExpr);
+                }
+                catch
+                {
+                    return null;
+                }
+            });
+            _argumentType = new Lazy<Type>(() => {
+                try
+                {
+                    return TranslationUnit.GetOrCreate<Type>(Handle.ArgumentType);
+                }
+                catch
+                {
+                    return null;
+                }
+            });
         }
 
         public Expr ArgumentExpr => _argumentExpr.Value;

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
@@ -966,21 +966,25 @@ struct MyStruct2 : MyStruct1A, MyStruct1B
         }
 
         [Theory]
-        [InlineData("double", "double", 7, 5)]
-        [InlineData("short", "short", 7, 5)]
-        [InlineData("int", "int", 7, 5)]
-        [InlineData("float", "float", 7, 5)]
+        [InlineData("double", "double", 6, 5)]
+        [InlineData("short", "short", 6, 5)]
+        [InlineData("int", "int", 6, 5)]
+        [InlineData("float", "float", 6, 5)]
         public async Task NestedAnonymousTest(string nativeType, string expectedManagedType, int line, int column)
         {
             var inputContents = $@"struct MyStruct
 {{
-    {nativeType} r;
-    {nativeType} g;
-    {nativeType} b;
+    {nativeType} x;
+    {nativeType} y;
 
     struct
     {{
-        {nativeType} a;
+        {nativeType} z;
+
+        struct
+        {{
+            {nativeType} value;
+        }} w;
     }};
 }};
 ";
@@ -991,20 +995,28 @@ namespace ClangSharp.Test
 {{
     public partial struct MyStruct
     {{
-        public {expectedManagedType} r;
+        public {expectedManagedType} x;
 
-        public {expectedManagedType} g;
-
-        public {expectedManagedType} b;
+        public {expectedManagedType} y;
 
         [NativeTypeName(""MyStruct::(anonymous struct at ClangUnsavedFile.h:{line}:{column})"")]
         internal _Anonymous_e__Struct Anonymous;
 
-        public ref {expectedManagedType} a => MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.a, 1));
+        public ref {expectedManagedType} z => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.z, 1));
+
+        public ref _Anonymous_e__Struct._w_e__Struct w => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.w, 1));
 
         public partial struct _Anonymous_e__Struct
         {{
-            public {expectedManagedType} a;
+            public {expectedManagedType} z;
+
+            [NativeTypeName(""struct (anonymous struct at ClangUnsavedFile.h:10:9)"")]
+            public _w_e__Struct w;
+
+            public partial struct _w_e__Struct
+            {{
+                public {expectedManagedType} value;
+            }}
         }}
     }}
 }}
@@ -1048,9 +1060,9 @@ namespace ClangSharp.Test
         [NativeTypeName(""MyStruct::(anonymous struct at ClangUnsavedFile.h:6:5)"")]
         internal _Anonymous_e__Struct Anonymous;
 
-        public ref int z => MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.z, 1));
+        public ref int z => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.z, 1));
 
-        public ref int w => MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.w, 1));
+        public ref int w => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.w, 1));
 
         [NativeTypeName(""int : 16"")]
         public int o0_b0_16
@@ -1360,7 +1372,7 @@ namespace ClangSharp.Test
         [NativeTypeName(""MyStruct::(anonymous struct at ClangUnsavedFile.h:7:5)"")]
         internal _Anonymous_e__Struct Anonymous;
 
-        public ref double a => MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.a, 1));
+        public ref double a => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.a, 1));
 
         public partial struct _Anonymous_e__Struct
         {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/UnionDeclarationTest.cs
@@ -407,7 +407,7 @@ namespace ClangSharp.Test
         [NativeTypeName(""MyUnion::(anonymous union at ClangUnsavedFile.h:{line}:{column})"")]
         internal _Anonymous_e__Union Anonymous;
 
-        public ref {expectedManagedType} a => MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.a, 1));
+        public ref {expectedManagedType} a => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.a, 1));
 
         [StructLayout(LayoutKind.Explicit)]
         public partial struct _Anonymous_e__Union
@@ -626,7 +626,7 @@ namespace ClangSharp.Test
         [NativeTypeName(""MyUnion::(anonymous union at ClangUnsavedFile.h:7:5)"")]
         internal _Anonymous_e__Union Anonymous;
 
-        public ref double a => MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.a, 1));
+        public ref double a => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.a, 1));
 
         [StructLayout(LayoutKind.Explicit)]
         public partial struct _Anonymous_e__Union

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/VarDeclarationTest.cs
@@ -53,7 +53,6 @@ namespace ClangSharp.UnitTests
             await ValidateGeneratedBindings(inputContents, expectedOutputContents);
         }
 
-        // DEFINE_GUID(IID_IDXGIObject,0xaec22fb8,0x76f3,0x4639,0x9b,0xe0,0x28,0xeb,0x43,0xa6,0x7a,0x2e);
         [Fact]
         public async Task GuidMacroTest()
         {
@@ -174,6 +173,28 @@ namespace ClangSharp.Test
     {{
         [NativeTypeName(""#define MyMacro1 u\""Test\"""")]
         public const string MyMacro1 = ""Test"";
+    }}
+}}
+";
+
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task UncheckedConversionMacroTest()
+        {
+            var inputContents = $@"#define MyMacro1 (long)0x80000000L
+#define MyMacro2 (int)0x80000000";
+
+            var expectedOutputContents = $@"namespace ClangSharp.Test
+{{
+    public static partial class Methods
+    {{
+        [NativeTypeName(""#define MyMacro1 (long)0x80000000L"")]
+        public const int MyMacro1 = unchecked((int)0x80000000);
+
+        [NativeTypeName(""#define MyMacro2 (int)0x80000000"")]
+        public const int MyMacro2 = unchecked((int)0x80000000);
     }}
 }}
 ";


### PR DESCRIPTION
This massively improves the perf of MacroDefinitionRecord handling by ensuring we create at most one additional TranslationUnit.