### PR TITLE
Improve the generated code for a number of scenarios

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -1269,7 +1269,7 @@ namespace ClangSharp
 
                 foreach (var cxxMethodDecl in cxxRecordDecl.Methods)
                 {
-                    if (!cxxMethodDecl.IsVirtual)
+                    if (!cxxMethodDecl.IsVirtual || pinvokeGenerator.IsExcluded(cxxMethodDecl))
                     {
                         continue;
                     }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -113,6 +113,12 @@ namespace ClangSharp
             AddRange(_withUsings, withUsings);
         }
 
+        public bool ExcludeComProxies => _options.HasFlag(PInvokeGeneratorConfigurationOptions.ExcludeComProxies);
+
+        public bool ExcludeEmptyRecords => _options.HasFlag(PInvokeGeneratorConfigurationOptions.ExcludeEmptyRecords);
+
+        public bool ExcludeEnumOperators => _options.HasFlag(PInvokeGeneratorConfigurationOptions.ExcludeEnumOperators);
+
         public string[] ExcludedNames { get; }
 
         public bool GenerateCompatibleCode => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateCompatibleCode);

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
@@ -34,5 +34,11 @@ namespace ClangSharp
         GenerateTestsXUnit = 0x00000400,
 
         GenerateMacroBindings = 0x00000800,
+
+        ExcludeComProxies = 0x00001000,
+
+        ExcludeEmptyRecords = 0x00002000,
+
+        ExcludeEnumOperators = 0x00004000,
     }
 }

--- a/sources/ClangSharp/Interop.Extensions/CXEvalResult.cs
+++ b/sources/ClangSharp/Interop.Extensions/CXEvalResult.cs
@@ -21,7 +21,7 @@ namespace ClangSharp.Interop
         {
             get
             {
-                var pStr = clang.EvalResult_getAsStr(this);
+                var pStr = Kind == CXEvalResultKind.CXEval_StrLiteral ? clang.EvalResult_getAsStr(this) : null;
 
                 if (pStr is null)
                 {

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -122,6 +122,24 @@ namespace ClangSharp
                         break;
                     }
 
+                    case "exclude-com-proxies":
+                    {
+                        configOptions |= PInvokeGeneratorConfigurationOptions.ExcludeComProxies;
+                        break;
+                    }
+
+                    case "exclude-empty-records":
+                    {
+                        configOptions |= PInvokeGeneratorConfigurationOptions.ExcludeEmptyRecords;
+                        break;
+                    }
+
+                    case "exclude-enum-operators":
+                    {
+                        configOptions |= PInvokeGeneratorConfigurationOptions.ExcludeEnumOperators;
+                        break;
+                    }
+
                     case "explicit-vtbls":
                     {
                         configOptions |= PInvokeGeneratorConfigurationOptions.GenerateExplicitVtbls;

--- a/sources/ClangSharpPInvokeGenerator/Properties/launchSettings.json
+++ b/sources/ClangSharpPInvokeGenerator/Properties/launchSettings.json
@@ -12,11 +12,6 @@
     "GenerateLLVM": {
       "commandName": "Project",
       "commandLineArgs": "\"@$(MSBuildProjectDirectory)/Properties/GenerateLLVM.rsp\" --file-directory \"$(LLVMIncludePath)\" --include-directory \"$(LLVMIncludePath)\" --libraryPath $(LibLLVMName)"
-    },
-    "GenerateTerraFX": {
-      "commandName": "Project",
-      "commandLineArgs": "@generate.rsp",
-      "workingDirectory": "C:\\Repos\\terrafx.interop.windows\\generation\\shared\\dxgi"
     }
   }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/EnumDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/EnumDeclarationTest.cs
@@ -408,7 +408,7 @@ namespace ClangSharp.Test
     {
         MyEnum_Value0,
         MyEnum_Value1,
-        MyEnum_Value2 = unchecked((int)0x80000000),
+        MyEnum_Value2 = unchecked((int)(0x80000000)),
     }
 }
 ";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
@@ -387,7 +387,7 @@ namespace ClangSharp.Test
     {
         public static int MyFunction(MyEnum x)
         {
-            return x == MyEnum_Value0 || x == MyEnum_Value1 || x == MyEnum_Value2;
+            return (x == MyEnum_Value0 || x == MyEnum_Value1 || x == MyEnum_Value2) ? 1 : 0;
         }
     }
 }
@@ -469,7 +469,7 @@ namespace ClangSharp.Test
     {
         public static int MyFunction(float input)
         {
-            return (int)input;
+            return (int)(input);
         }
     }
 }
@@ -493,7 +493,7 @@ namespace ClangSharp.Test
     {
         public static int MyFunction(float input)
         {
-            return (int)input;
+            return (int)(input);
         }
     }
 }
@@ -587,7 +587,7 @@ namespace ClangSharp.Test
         [return: NativeTypeName(""MyStructB *"")]
         public static MyStructB* MyFunction([NativeTypeName(""MyStructA *"")] MyStructA* input)
         {{
-            return (MyStructB*)input;
+            return (MyStructB*)(input);
         }}
     }}
 }}
@@ -612,7 +612,7 @@ namespace ClangSharp.Test
         [return: NativeTypeName(""int *"")]
         public static int* MyFunction([NativeTypeName(""void *"")] void* input)
         {
-            return (int*)input;
+            return (int*)(input);
         }
     }
 }
@@ -637,7 +637,7 @@ namespace ClangSharp.Test
         [return: NativeTypeName(""int *"")]
         public static int* MyFunction([NativeTypeName(""void *"")] void* input)
         {
-            return (int*)input;
+            return (int*)(input);
         }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationDllImportTest.cs
@@ -37,7 +37,7 @@ namespace ClangSharp.Test
 
 namespace ClangSharp.Test
 {
-    public static partial class Methods
+    public static unsafe partial class Methods
     {
         [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, EntryPoint = ""MyFunction"", ExactSpelling = true)]
         public static extern void MyFunction([NativeTypeName(""const float [4]"")] float* color);
@@ -53,8 +53,7 @@ namespace ClangSharp.Test
         {
             var inputContents = @"void MyFunction(void (*callback)());";
 
-            var expectedOutputContents = @"using System;
-using System.Runtime.InteropServices;
+            var expectedOutputContents = @"using System.Runtime.InteropServices;
 
 namespace ClangSharp.Test
 {
@@ -148,7 +147,7 @@ namespace ClangSharp.Test
         [InlineData("unsigned short value = 7", @"[NativeTypeName(""unsigned short"")] ushort value = 7")]
         [InlineData("unsigned int value = 8", @"[NativeTypeName(""unsigned int"")] uint value = 8")]
         [InlineData("unsigned long long value = 9", @"[NativeTypeName(""unsigned long long"")] ulong value = 9")]
-        [InlineData("unsigned short value = 'A'", @"[NativeTypeName(""unsigned short"")] ushort value = (byte)'A'")]
+        [InlineData("unsigned short value = 'A'", @"[NativeTypeName(""unsigned short"")] ushort value = (byte)('A')")]
         public async Task OptionalParameterTest(string nativeParameters, string expectedManagedParameters)
         {
             var inputContents = $@"void MyFunction({nativeParameters});";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
@@ -71,7 +71,7 @@ struct MyStruct3
 {
     public partial struct MyStruct1
     {
-        internal uint _bitfield1;
+        public uint _bitfield1;
 
         [NativeTypeName(""unsigned int : 24"")]
         public uint o0_b0_24
@@ -87,7 +87,7 @@ struct MyStruct3
             }
         }
 
-        internal uint _bitfield2;
+        public uint _bitfield2;
 
         [NativeTypeName(""unsigned int : 16"")]
         public uint o4_b0_16
@@ -131,7 +131,7 @@ struct MyStruct3
             }
         }
 
-        internal byte _bitfield3;
+        public byte _bitfield3;
 
         [NativeTypeName(""unsigned char : 1"")]
         public byte o8_b0_1
@@ -147,7 +147,7 @@ struct MyStruct3
             }
         }
 
-        internal int _bitfield4;
+        public int _bitfield4;
 
         [NativeTypeName(""int : 1"")]
         public int o12_b0_1
@@ -180,7 +180,7 @@ struct MyStruct3
 
     public partial struct MyStruct2
     {
-        internal uint _bitfield1;
+        public uint _bitfield1;
 
         [NativeTypeName(""unsigned int : 1"")]
         public uint o0_b0_1
@@ -198,7 +198,7 @@ struct MyStruct3
 
         public int x;
 
-        internal uint _bitfield2;
+        public uint _bitfield2;
 
         [NativeTypeName(""unsigned int : 1"")]
         public uint o8_b0_1
@@ -217,7 +217,7 @@ struct MyStruct3
 
     public partial struct MyStruct3
     {
-        internal uint _bitfield;
+        public uint _bitfield;
 
         [NativeTypeName(""unsigned int : 1"")]
         public uint o0_b0_1
@@ -285,7 +285,7 @@ struct MyStruct3
 {
     public partial struct MyStruct1
     {
-        internal uint _bitfield1;
+        public uint _bitfield1;
 
         [NativeTypeName(""unsigned int : 24"")]
         public uint o0_b0_24
@@ -301,7 +301,7 @@ struct MyStruct3
             }
         }
 
-        internal uint _bitfield2;
+        public uint _bitfield2;
 
         [NativeTypeName(""unsigned int : 16"")]
         public uint o4_b0_16
@@ -390,7 +390,7 @@ struct MyStruct3
 
     public partial struct MyStruct2
     {
-        internal uint _bitfield1;
+        public uint _bitfield1;
 
         [NativeTypeName(""unsigned int : 1"")]
         public uint o0_b0_1
@@ -408,7 +408,7 @@ struct MyStruct3
 
         public int x;
 
-        internal uint _bitfield2;
+        public uint _bitfield2;
 
         [NativeTypeName(""unsigned int : 1"")]
         public uint o8_b0_1
@@ -427,7 +427,7 @@ struct MyStruct3
 
     public partial struct MyStruct3
     {
-        internal uint _bitfield;
+        public uint _bitfield;
 
         [NativeTypeName(""unsigned int : 1"")]
         public uint o0_b0_1
@@ -541,9 +541,9 @@ struct MyOtherStruct
 
         public partial struct _c_e__FixedBuffer
         {{
-            internal MyStruct e0;
-            internal MyStruct e1;
-            internal MyStruct e2;
+            public MyStruct e0;
+            public MyStruct e1;
+            public MyStruct e2;
 
             public unsafe ref MyStruct this[int index]
             {{
@@ -598,9 +598,9 @@ namespace ClangSharp.Test
 
         public partial struct _c_e__FixedBuffer
         {{
-            internal MyStruct e0;
-            internal MyStruct e1;
-            internal MyStruct e2;
+            public MyStruct e0;
+            public MyStruct e1;
+            public MyStruct e2;
 
             public ref MyStruct this[int index] => ref AsSpan()[index];
 
@@ -648,41 +648,41 @@ namespace ClangSharp.Test
 
         public partial struct _c_e__FixedBuffer
         {{
-            internal MyStruct e0_0_0_0;
-            internal MyStruct e1_0_0_0;
+            public MyStruct e0_0_0_0;
+            public MyStruct e1_0_0_0;
 
-            internal MyStruct e0_0_1_0;
-            internal MyStruct e1_0_1_0;
+            public MyStruct e0_0_1_0;
+            public MyStruct e1_0_1_0;
 
-            internal MyStruct e0_0_2_0;
-            internal MyStruct e1_0_2_0;
+            public MyStruct e0_0_2_0;
+            public MyStruct e1_0_2_0;
 
-            internal MyStruct e0_0_0_1;
-            internal MyStruct e1_0_0_1;
+            public MyStruct e0_0_0_1;
+            public MyStruct e1_0_0_1;
 
-            internal MyStruct e0_0_1_1;
-            internal MyStruct e1_0_1_1;
+            public MyStruct e0_0_1_1;
+            public MyStruct e1_0_1_1;
 
-            internal MyStruct e0_0_2_1;
-            internal MyStruct e1_0_2_1;
+            public MyStruct e0_0_2_1;
+            public MyStruct e1_0_2_1;
 
-            internal MyStruct e0_0_0_2;
-            internal MyStruct e1_0_0_2;
+            public MyStruct e0_0_0_2;
+            public MyStruct e1_0_0_2;
 
-            internal MyStruct e0_0_1_2;
-            internal MyStruct e1_0_1_2;
+            public MyStruct e0_0_1_2;
+            public MyStruct e1_0_1_2;
 
-            internal MyStruct e0_0_2_2;
-            internal MyStruct e1_0_2_2;
+            public MyStruct e0_0_2_2;
+            public MyStruct e1_0_2_2;
 
-            internal MyStruct e0_0_0_3;
-            internal MyStruct e1_0_0_3;
+            public MyStruct e0_0_0_3;
+            public MyStruct e1_0_0_3;
 
-            internal MyStruct e0_0_1_3;
-            internal MyStruct e1_0_1_3;
+            public MyStruct e0_0_1_3;
+            public MyStruct e1_0_1_3;
 
-            internal MyStruct e0_0_2_3;
-            internal MyStruct e1_0_2_3;
+            public MyStruct e0_0_2_3;
+            public MyStruct e1_0_2_3;
 
             public ref MyStruct this[int index] => ref AsSpan()[index];
 
@@ -730,9 +730,9 @@ struct MyOtherStruct
 
         public partial struct _c_e__FixedBuffer
         {{
-            internal MyStruct e0;
-            internal MyStruct e1;
-            internal MyStruct e2;
+            public MyStruct e0;
+            public MyStruct e1;
+            public MyStruct e2;
 
             public unsafe ref MyStruct this[int index]
             {{
@@ -790,9 +790,9 @@ namespace ClangSharp.Test
 
         public partial struct _c_e__FixedBuffer
         {{
-            internal MyStruct e0;
-            internal MyStruct e1;
-            internal MyStruct e2;
+            public MyStruct e0;
+            public MyStruct e1;
+            public MyStruct e2;
 
             public ref MyStruct this[int index] => ref AsSpan()[index];
 
@@ -806,10 +806,10 @@ namespace ClangSharp.Test
         }
 
         [Theory]
-        [InlineData("double *", "IntPtr")]
-        [InlineData("short *", "IntPtr")]
-        [InlineData("int *", "IntPtr")]
-        [InlineData("float *", "IntPtr")]
+        [InlineData("double *", "double*")]
+        [InlineData("short *", "short*")]
+        [InlineData("int *", "int*")]
+        [InlineData("float *", "float*")]
         public async Task FixedSizedBufferPointerTest(string nativeType, string expectedManagedType)
         {
             var inputContents = $@"struct MyStruct
@@ -818,31 +818,33 @@ namespace ClangSharp.Test
 }};
 ";
 
-            var expectedOutputContents = $@"using System;
-using System.Runtime.InteropServices;
-
-namespace ClangSharp.Test
+            var expectedOutputContents = $@"namespace ClangSharp.Test
 {{
     public partial struct MyStruct
     {{
         [NativeTypeName(""{nativeType}[3]"")]
         public _c_e__FixedBuffer c;
 
-        public partial struct _c_e__FixedBuffer
+        public unsafe partial struct _c_e__FixedBuffer
         {{
-            internal {expectedManagedType} e0;
-            internal {expectedManagedType} e1;
-            internal {expectedManagedType} e2;
+            public {expectedManagedType} e0;
+            public {expectedManagedType} e1;
+            public {expectedManagedType} e2;
 
-            public ref {expectedManagedType} this[int index] => ref AsSpan()[index];
-
-            public Span<{expectedManagedType}> AsSpan() => MemoryMarshal.CreateSpan(ref e0, 3);
+            public ref {expectedManagedType} this[int index]
+            {{
+                get
+                {{
+                    fixed ({expectedManagedType}* pThis = &e0)
+                    {{
+                        return ref pThis[index];
+                    }}
+                }}
+            }}
         }}
     }}
 }}
 ";
-
-            await ValidateGeneratedBindings(inputContents, expectedOutputContents);
 
             await ValidateGeneratedBindings(inputContents, expectedOutputContents);
         }
@@ -1000,7 +1002,7 @@ namespace ClangSharp.Test
         public {expectedManagedType} y;
 
         [NativeTypeName(""MyStruct::(anonymous struct at ClangUnsavedFile.h:{line}:{column})"")]
-        internal _Anonymous_e__Struct Anonymous;
+        public _Anonymous_e__Struct Anonymous;
 
         public ref {expectedManagedType} z => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.z, 1));
 
@@ -1058,37 +1060,35 @@ namespace ClangSharp.Test
         public int y;
 
         [NativeTypeName(""MyStruct::(anonymous struct at ClangUnsavedFile.h:6:5)"")]
-        internal _Anonymous_e__Struct Anonymous;
+        public _Anonymous_e__Struct Anonymous;
 
         public ref int z => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.z, 1));
 
         public ref int w => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.w, 1));
 
-        [NativeTypeName(""int : 16"")]
         public int o0_b0_16
         {
             get
             {
-                return Anonymous.Anonymous._bitfield & 0xFFFF;
+                return Anonymous.Anonymous.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous._bitfield = (Anonymous.Anonymous._bitfield & ~0xFFFF) | (value & 0xFFFF);
+                Anonymous.Anonymous.o0_b0_16 = value;
             }
         }
 
-        [NativeTypeName(""int : 4"")]
         public int o0_b16_4
         {
             get
             {
-                return (Anonymous.Anonymous._bitfield >> 16) & 0xF;
+                return Anonymous.Anonymous.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous._bitfield = (Anonymous.Anonymous._bitfield & ~(0xF << 16)) | ((value & 0xF) << 16);
+                Anonymous.Anonymous.o0_b16_4 = value;
             }
         }
 
@@ -1097,13 +1097,41 @@ namespace ClangSharp.Test
             public int z;
 
             [NativeTypeName(""MyStruct::(anonymous struct at ClangUnsavedFile.h:10:9)"")]
-            internal _Anonymous_e__Struct Anonymous;
+            public _Anonymous_e__Struct Anonymous;
 
             public partial struct _Anonymous_e__Struct
             {
                 public int w;
 
-                internal int _bitfield;
+                public int _bitfield;
+
+                [NativeTypeName(""int : 16"")]
+                public int o0_b0_16
+                {
+                    get
+                    {
+                        return _bitfield & 0xFFFF;
+                    }
+
+                    set
+                    {
+                        _bitfield = (_bitfield & ~0xFFFF) | (value & 0xFFFF);
+                    }
+                }
+
+                [NativeTypeName(""int : 4"")]
+                public int o0_b16_4
+                {
+                    get
+                    {
+                        return (_bitfield >> 16) & 0xF;
+                    }
+
+                    set
+                    {
+                        _bitfield = (_bitfield & ~(0xF << 16)) | ((value & 0xF) << 16);
+                    }
+                }
             }
         }
     }
@@ -1370,7 +1398,7 @@ namespace ClangSharp.Test
         public double b;
 
         [NativeTypeName(""MyStruct::(anonymous struct at ClangUnsavedFile.h:7:5)"")]
-        internal _Anonymous_e__Struct Anonymous;
+        public _Anonymous_e__Struct Anonymous;
 
         public ref double a => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.a, 1));
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/UnionDeclarationTest.cs
@@ -135,9 +135,9 @@ namespace ClangSharp.Test
 
         public partial struct _c_e__FixedBuffer
         {{
-            internal MyUnion e0;
-            internal MyUnion e1;
-            internal MyUnion e2;
+            public MyUnion e0;
+            public MyUnion e1;
+            public MyUnion e2;
 
             public unsafe ref MyUnion this[int index]
             {{
@@ -196,9 +196,9 @@ namespace ClangSharp.Test
 
         public partial struct _c_e__FixedBuffer
         {{
-            internal MyUnion e0;
-            internal MyUnion e1;
-            internal MyUnion e2;
+            public MyUnion e0;
+            public MyUnion e1;
+            public MyUnion e2;
 
             public ref MyUnion this[int index] => ref AsSpan()[index];
 
@@ -252,9 +252,9 @@ namespace ClangSharp.Test
 
         public partial struct _c_e__FixedBuffer
         {{
-            internal MyUnion e0;
-            internal MyUnion e1;
-            internal MyUnion e2;
+            public MyUnion e0;
+            public MyUnion e1;
+            public MyUnion e2;
 
             public unsafe ref MyUnion this[int index]
             {{
@@ -316,9 +316,9 @@ namespace ClangSharp.Test
 
         public partial struct _c_e__FixedBuffer
         {{
-            internal MyUnion e0;
-            internal MyUnion e1;
-            internal MyUnion e2;
+            public MyUnion e0;
+            public MyUnion e1;
+            public MyUnion e2;
 
             public ref MyUnion this[int index] => ref AsSpan()[index];
 
@@ -405,7 +405,7 @@ namespace ClangSharp.Test
 
         [FieldOffset(0)]
         [NativeTypeName(""MyUnion::(anonymous union at ClangUnsavedFile.h:{line}:{column})"")]
-        internal _Anonymous_e__Union Anonymous;
+        public _Anonymous_e__Union Anonymous;
 
         public ref {expectedManagedType} a => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.a, 1));
 
@@ -624,7 +624,7 @@ namespace ClangSharp.Test
 
         [FieldOffset(0)]
         [NativeTypeName(""MyUnion::(anonymous union at ClangUnsavedFile.h:7:5)"")]
-        internal _Anonymous_e__Union Anonymous;
+        public _Anonymous_e__Union Anonymous;
 
         public ref double a => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.a, 1));
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/VarDeclarationTest.cs
@@ -191,10 +191,10 @@ namespace ClangSharp.Test
     public static partial class Methods
     {{
         [NativeTypeName(""#define MyMacro1 (long)0x80000000L"")]
-        public const int MyMacro1 = unchecked((int)0x80000000);
+        public const int MyMacro1 = unchecked((int)(0x80000000));
 
         [NativeTypeName(""#define MyMacro2 (int)0x80000000"")]
-        public const int MyMacro2 = unchecked((int)0x80000000);
+        public const int MyMacro2 = unchecked((int)(0x80000000));
     }}
 }}
 ";


### PR DESCRIPTION
This fixes up a number of scenarios around renaming, inserting "unchecked" contexts, and automatically doing the right thing when generating bindings.

The biggest changes are:
* Addition of  `exclude-com-proxies, `exclude-empty-records`, and `exclude-enum-operators` switches
* Better traversal of implicit cast operations
* Better insertion of the `unchecked` keyword which improves correctness of macro definition record bindings
* Better automatic remapping of anonymous records/fields
* Better remapping of pointer and array types so additional remappings aren't required