### PR TITLE
Further improve codegen around UUID attributes and parentheses handling

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -902,6 +902,23 @@ namespace ClangSharp
                     _outputBuilder.WriteLine(']');
                 }
 
+                var uuid = recordDecl.Attrs.Where((attr) => attr.Kind == CX_AttrKind.CX_AttrKind_Uuid).SingleOrDefault();
+
+                if (uuid != null)
+                {
+                    var uuidText = GetSourceRangeContents(recordDecl.TranslationUnit.Handle, uuid.Extent).Split(new char[] { '"' }, StringSplitOptions.RemoveEmptyEntries)[1];
+
+                    _outputBuilder.AddUsingDirective("System.Runtime.InteropServices");
+                    _outputBuilder.WriteIndented('[');
+                    _outputBuilder.Write("Guid");
+                    _outputBuilder.Write('(');
+                    _outputBuilder.Write('"');
+                    _outputBuilder.Write(uuidText);
+                    _outputBuilder.Write('"');
+                    _outputBuilder.Write(')');
+                    _outputBuilder.WriteLine(']');
+                }
+
                 _outputBuilder.WriteIndented(GetAccessSpecifierName(recordDecl));
                 _outputBuilder.Write(' ');
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -458,25 +458,21 @@ namespace ClangSharp
                     _outputBuilder.Write(' ');
                 }
 
-                _outputBuilder.Write("EntryPoint");
-                _outputBuilder.Write(' ');
-                _outputBuilder.Write('=');
-                _outputBuilder.Write(' ');
-                _outputBuilder.Write('"');
+                var entryPoint = (cxxMethodDecl is null) ? GetCursorName(functionDecl) : cxxMethodDecl.Handle.Mangling.CString;
 
-                if (cxxMethodDecl is null)
+                if (entryPoint != name)
                 {
-                    var unmappedName = GetCursorName(functionDecl);
-                    _outputBuilder.Write(unmappedName);
-                }
-                else
-                {
-                    _outputBuilder.Write(cxxMethodDecl.Handle.Mangling);
+                    _outputBuilder.Write("EntryPoint");
+                    _outputBuilder.Write(' ');
+                    _outputBuilder.Write('=');
+                    _outputBuilder.Write(' ');
+                    _outputBuilder.Write('"');
+                    _outputBuilder.Write(entryPoint);
+                    _outputBuilder.Write('"');
+                    _outputBuilder.Write(',');
+                    _outputBuilder.Write(' ');
                 }
 
-                _outputBuilder.Write('"');
-                _outputBuilder.Write(',');
-                _outputBuilder.Write(' ');
                 _outputBuilder.Write("ExactSpelling");
                 _outputBuilder.Write(' ');
                 _outputBuilder.Write('=');

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -978,6 +978,34 @@ namespace ClangSharp
                     }
                 }
 
+                if ((cxxRecordDecl != null) && cxxRecordDecl.Bases.Any())
+                {
+                    var nativeTypeNameBuilder = new StringBuilder();
+
+                    nativeTypeNameBuilder.Append(recordDecl.IsUnion ? "union" : "struct");
+                    nativeTypeNameBuilder.Append(' ');
+
+                    nativeTypeNameBuilder.Append(GetCursorName(cxxRecordDecl));
+
+                    nativeTypeNameBuilder.Append(' ');
+                    nativeTypeNameBuilder.Append(':');
+                    nativeTypeNameBuilder.Append(' ');
+
+                    var baseName = GetCursorName(cxxRecordDecl.Bases[0].Referenced);
+                    nativeTypeNameBuilder.Append(baseName);
+
+                    for (int i = 1; i < cxxRecordDecl.Bases.Count; i++)
+                    {
+                        nativeTypeNameBuilder.Append(',');
+                        nativeTypeNameBuilder.Append(' ');
+
+                        baseName = GetCursorName(cxxRecordDecl.Bases[i].Referenced);
+                        nativeTypeNameBuilder.Append(baseName);
+                    }
+
+                    AddNativeTypeNameAttribute(nativeTypeNameBuilder.ToString());
+                }
+
                 _outputBuilder.WriteIndented(GetAccessSpecifierName(recordDecl));
                 _outputBuilder.Write(' ');
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -1881,9 +1881,9 @@ namespace ClangSharp
                     parmVarDecl1Type = referenceType1.PointeeType.CanonicalType;
                 }
 
-                if ((functionDecl.Parameters.Count == 1) && (parmVarDecl1Type.Kind == CXTypeKind.CXType_Enum))
+                if (functionDecl.Parameters.Count == 1)
                 {
-                    return true;
+                    return (parmVarDecl1Type.Kind == CXTypeKind.CXType_Enum);
                 }
 
                 var parmVarDecl2 = functionDecl.Parameters[1];

--- a/sources/ClangSharp/Interop.Extensions/CXEvalResult.cs
+++ b/sources/ClangSharp/Interop.Extensions/CXEvalResult.cs
@@ -11,11 +11,11 @@ namespace ClangSharp.Interop
             Handle = handle;
         }
 
-        public double AsDouble => clang.EvalResult_getAsDouble(this);
+        public double AsDouble => (Kind == CXEvalResultKind.CXEval_Float) ? clang.EvalResult_getAsDouble(this) : 0;
 
-        public int AsInt => clang.EvalResult_getAsInt(this);
+        public int AsInt => (Kind == CXEvalResultKind.CXEval_Int) ? clang.EvalResult_getAsInt(this) : 0;
 
-        public long AsLongLong => clang.EvalResult_getAsLongLong(this);
+        public long AsLongLong => (Kind == CXEvalResultKind.CXEval_Int) ? clang.EvalResult_getAsLongLong(this) : 0;
 
         public string AsStr
         {
@@ -33,11 +33,11 @@ namespace ClangSharp.Interop
             }
         }
 
-        public ulong AsUnsigned => clang.EvalResult_getAsUnsigned(this);
+        public ulong AsUnsigned => (Kind == CXEvalResultKind.CXEval_Int) ? clang.EvalResult_getAsUnsigned(this) : 0;
 
         public IntPtr Handle { get; set; }
 
-        public bool IsUnsignedInt => clang.EvalResult_isUnsignedInt(this) != 0;
+        public bool IsUnsignedInt => (Kind == CXEvalResultKind.CXEval_Int) && (clang.EvalResult_isUnsignedInt(this) != 0);
 
         public CXEvalResultKind Kind => clang.EvalResult_getKind(this);
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
@@ -712,7 +712,7 @@ namespace ClangSharp.Test
 
     public static partial class Methods
     {
-        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, EntryPoint = ""MyFunction"", ExactSpelling = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void MyFunction();
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
@@ -569,6 +569,7 @@ namespace ClangSharp.Test
         }}
     }}
 
+    [NativeTypeName(""struct MyStructB : MyStructA"")]
     public unsafe partial struct MyStructB
     {{
         public void** lpVtbl;

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationDllImportTest.cs
@@ -19,7 +19,7 @@ namespace ClangSharp.Test
 {
     public static partial class Methods
     {
-        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, EntryPoint = ""MyFunction"", ExactSpelling = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void MyFunction();
     }
 }
@@ -39,7 +39,7 @@ namespace ClangSharp.Test
 {
     public static unsafe partial class Methods
     {
-        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, EntryPoint = ""MyFunction"", ExactSpelling = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void MyFunction([NativeTypeName(""const float [4]"")] float* color);
     }
 }
@@ -59,7 +59,7 @@ namespace ClangSharp.Test
 {
     public static partial class Methods
     {
-        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, EntryPoint = ""MyFunction"", ExactSpelling = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void MyFunction([NativeTypeName(""void (*)()"")] IntPtr callback);
     }
 }
@@ -79,7 +79,7 @@ namespace ClangSharp.Test
 {
     public static partial class Methods
     {
-        [DllImport("""", CallingConvention = CallingConvention.Cdecl, EntryPoint = ""MyFunction"", ExactSpelling = true)]
+        [DllImport("""", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void MyFunction();
     }
 }
@@ -99,7 +99,7 @@ namespace ClangSharp.Test
 {
     public static partial class Methods
     {
-        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, EntryPoint = ""MyFunction"", ExactSpelling = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void MyFunction();
     }
 }
@@ -123,7 +123,7 @@ namespace ClangSharp.Test
 {
     public static partial class Methods
     {
-        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, EntryPoint = ""MyFunction"", ExactSpelling = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void MyFunction();
     }
 }
@@ -158,7 +158,7 @@ namespace ClangSharp.Test
 {{
     public static partial class Methods
     {{
-        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, EntryPoint = ""MyFunction"", ExactSpelling = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void MyFunction({expectedManagedParameters});
     }}
 }}
@@ -180,7 +180,7 @@ namespace ClangSharp.Test
 {{
     public static unsafe partial class Methods
     {{
-        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, EntryPoint = ""MyFunction"", ExactSpelling = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void MyFunction({expectedManagedParameters});
     }}
 }}
@@ -200,10 +200,10 @@ namespace ClangSharp.Test
 {
     public static partial class Methods
     {
-        [DllImport(""ClangSharpPInvokeGenerator"", EntryPoint = ""MyFunction1"", ExactSpelling = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", ExactSpelling = true)]
         public static extern void MyFunction1(int value);
 
-        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, EntryPoint = ""MyFunction2"", ExactSpelling = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void MyFunction2(int value);
     }
 }
@@ -226,10 +226,10 @@ namespace ClangSharp.Test
 {
     public static partial class Methods
     {
-        [DllImport(""ClangSharpPInvokeGenerator"", EntryPoint = ""MyFunction1"", ExactSpelling = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", ExactSpelling = true)]
         public static extern void MyFunction1(int value);
 
-        [DllImport(""ClangSharpPInvokeGenerator"", EntryPoint = ""MyFunction2"", ExactSpelling = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", ExactSpelling = true)]
         public static extern void MyFunction2(int value);
     }
 }
@@ -253,10 +253,10 @@ namespace ClangSharp.Test
 {
     public static partial class Methods
     {
-        [DllImport(""ClangSharpPInvokeGenerator"", EntryPoint = ""MyFunction1"", ExactSpelling = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", ExactSpelling = true)]
         public static extern void MyFunction1(int value);
 
-        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.StdCall, EntryPoint = ""MyFunction2"", ExactSpelling = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.StdCall, ExactSpelling = true)]
         public static extern void MyFunction2(int value);
     }
 }
@@ -281,10 +281,10 @@ namespace ClangSharp.Test
 {
     public static partial class Methods
     {
-        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, EntryPoint = ""MyFunction1"", ExactSpelling = true, SetLastError = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, SetLastError = true)]
         public static extern void MyFunction1(int value);
 
-        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, EntryPoint = ""MyFunction2"", ExactSpelling = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void MyFunction2(int value);
     }
 }
@@ -308,10 +308,10 @@ namespace ClangSharp.Test
 {
     public static partial class Methods
     {
-        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, EntryPoint = ""MyFunction1"", ExactSpelling = true, SetLastError = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, SetLastError = true)]
         public static extern void MyFunction1(int value);
 
-        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, EntryPoint = ""MyFunction2"", ExactSpelling = true, SetLastError = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, SetLastError = true)]
         public static extern void MyFunction2(int value);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
@@ -923,13 +923,14 @@ struct __declspec(uuid(""00000000-0000-0000-C000-000000000046"")) MyStruct1
     int x;
 }};
 
-struct DECLSPEC_UUID(""00000000-0000-0000-C000-000000000046"") MyStruct2
+struct DECLSPEC_UUID(""00000000-0000-0000-C000-000000000047"") MyStruct2
 {{
     int x;
 }};
 ";
 
-            var expectedOutputContents = $@"using System.Runtime.InteropServices;
+            var expectedOutputContents = $@"using System;
+using System.Runtime.InteropServices;
 
 namespace ClangSharp.Test
 {{
@@ -939,10 +940,17 @@ namespace ClangSharp.Test
         public int x;
     }}
 
-    [Guid(""00000000-0000-0000-C000-000000000046"")]
+    [Guid(""00000000-0000-0000-C000-000000000047"")]
     public partial struct MyStruct2
     {{
         public int x;
+    }}
+
+    public static partial class Methods
+    {{
+        public static readonly Guid IID_MyStruct1 = new Guid(0x00000000, 0x0000, 0x0000, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46);
+
+        public static readonly Guid IID_MyStruct2 = new Guid(0x00000000, 0x0000, 0x0000, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x47);
     }}
 }}
 ";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
@@ -914,6 +914,44 @@ namespace ClangSharp.Test
         }
 
         [Fact]
+        public async Task GuidTest()
+        {
+            var inputContents = $@"#define DECLSPEC_UUID(x) __declspec(uuid(x))
+
+struct __declspec(uuid(""00000000-0000-0000-C000-000000000046"")) MyStruct1
+{{
+    int x;
+}};
+
+struct DECLSPEC_UUID(""00000000-0000-0000-C000-000000000046"") MyStruct2
+{{
+    int x;
+}};
+";
+
+            var expectedOutputContents = $@"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    [Guid(""00000000-0000-0000-C000-000000000046"")]
+    public partial struct MyStruct1
+    {{
+        public int x;
+    }}
+
+    [Guid(""00000000-0000-0000-C000-000000000046"")]
+    public partial struct MyStruct2
+    {{
+        public int x;
+    }}
+}}
+";
+
+            var excludedNames = new string[] { "DECLSPEC_UUID" };
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents, excludedNames);
+        }
+
+        [Fact]
         public async Task InheritanceTest()
         {
             var inputContents = @"struct MyStruct1A

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
@@ -989,6 +989,7 @@ struct MyStruct2 : MyStruct1A, MyStruct1B
         public int y;
     }
 
+    [NativeTypeName(""struct MyStruct2 : MyStruct1A, MyStruct1B"")]
     public partial struct MyStruct2
     {
         public MyStruct1A __AnonymousBase_ClangUnsavedFile_L13_C20;
@@ -1609,6 +1610,7 @@ struct MyStruct1B : MyStruct1A
         }
     }
 
+    [NativeTypeName(""struct MyStruct1B : MyStruct1A"")]
     public partial struct MyStruct1B
     {
         public void MyMethod()

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/StructDeclarationTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -916,6 +917,12 @@ namespace ClangSharp.Test
         [Fact]
         public async Task GuidTest()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // Unix doesn't support __declspec(uuid(""))
+                return;
+            }
+
             var inputContents = $@"#define DECLSPEC_UUID(x) __declspec(uuid(x))
 
 struct __declspec(uuid(""00000000-0000-0000-C000-000000000046"")) MyStruct1

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/VarDeclarationTest.cs
@@ -201,5 +201,26 @@ namespace ClangSharp.Test
 
             await ValidateGeneratedBindings(inputContents, expectedOutputContents);
         }
+
+        [Fact]
+        public async Task UncheckedConversionMacroTest2()
+        {
+            var inputContents = $@"#define MyMacro1(x, y, z) ((int)(((unsigned long)(x)<<31) | ((unsigned long)(y)<<16) | ((unsigned long)(z))))
+#define MyMacro2(n) MyMacro1(1, 2, n)
+#define MyMacro3 MyMacro2(3)";
+
+            var expectedOutputContents = $@"namespace ClangSharp.Test
+{{
+    public static partial class Methods
+    {{
+        [NativeTypeName(""#define MyMacro3 MyMacro2(3)"")]
+        public const int MyMacro3 = unchecked((int)(((uint)(1) << 31) | ((uint)(2) << 16) | ((uint)(3))));
+    }}
+}}
+";
+
+            var excludedNames = new string[] { "MyMacro1", "MyMacro2" };
+            await ValidateGeneratedBindings(inputContents, expectedOutputContents, excludedNames);
+        }
     }
 }


### PR DESCRIPTION
This improves the handling of UUID attributes by making it largely automatic. It also improves the codegen for various declarations by:
* tracking struct inheritance
* ensuring we traverse namespace declarations
* not emitting the entry point property if the existing name matches
* performing better statement lookthrough around casts and parentheses