### PR TITLE
Fix unchecked generation for pointers

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -2759,6 +2759,7 @@ namespace ClangSharp
                     case "ulong":
                     case "UInt64":
                     case "ushort":
+                    case var _ when typeName.EndsWith('*'):
                     {
                         return true;
                     }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -2759,7 +2759,7 @@ namespace ClangSharp
                     case "ulong":
                     case "UInt64":
                     case "ushort":
-                    case var _ when typeName.EndsWith('*'):
+                    case var _ when typeName.EndsWith("*"):
                     {
                         return true;
                     }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/VarDeclarationTest.cs
@@ -222,5 +222,24 @@ namespace ClangSharp.Test
             var excludedNames = new string[] { "MyMacro1", "MyMacro2" };
             await ValidateGeneratedBindingsAsync(inputContents, expectedOutputContents, excludedNames: excludedNames);
         }
+
+        [Fact]
+        public async Task UncheckedPointerMacroTest()
+        {
+            var inputContents = $@"#define Macro1 ((int*) -1)";
+
+            var expectedOutputContents = $@"namespace ClangSharp.Test
+{{
+    public static unsafe partial class Methods
+    {{
+        [NativeTypeName(""#define Macro1 ((int*) -1)"")]
+        public static readonly int* Macro1 = unchecked((int*)(-1));
+    }}
+}}
+";
+
+            await ValidateGeneratedBindingsAsync(inputContents, expectedOutputContents);
+        }
+
     }
 }


### PR DESCRIPTION
A macro definition like `#define Macro ((int*) -1)` does not generate the corresponding expression in C# using `unchecked`. The code will compile, but when in a checked context, will raise an OverflowException at runtime. This patch changes the generator to consider pointers an 'unsigned' type, so that the expression is generated inside of an unchecked context.