### PR TITLE
Check if CXXRecordDecl is lambda before calling getLambdaContextDecl().

### DIFF
--- a/sources/libClangSharp/ClangSharp.cpp
+++ b/sources/libClangSharp/ClangSharp.cpp
@@ -1692,7 +1692,8 @@ CXCursor clangsharp_Cursor_getLambdaContextDecl(CXCursor C) {
         const Decl* D = getCursorDecl(C);
 
         if (const CXXRecordDecl* CRD = dyn_cast<CXXRecordDecl>(D)) {
-            return MakeCXCursor(CRD->getLambdaContextDecl(), getCursorTU(C));
+            if( CRD->isLambda() )
+                return MakeCXCursor(CRD->getLambdaContextDecl(), getCursorTU(C));
         }
     }
 


### PR DESCRIPTION
Failing to check if the CXCursors represents a lambda before trying to get the LambdaContextDecl can cause an assert in clang/llvm which cause an `AccessViolationException` to be raised in C#.
see issue #184