### PR TITLE
Adding new config options for ClangSharp

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -345,7 +345,7 @@ namespace ClangSharp
 
             var type = fieldDecl.Type;
             var typeName = GetRemappedTypeName(fieldDecl, context: null, type, out var nativeTypeName);
-            
+
             if (fieldDecl.Parent.IsUnion)
             {
                 _outputBuilder.WriteIndentedLine("[FieldOffset(0)]");
@@ -1134,10 +1134,6 @@ namespace ClangSharp
                 {
                     OutputMethods(cxxRecordDecl, cxxRecordDecl);
                     excludedCursors = excludedCursors.Concat(cxxRecordDecl.Methods);
-                }
-
-                if (recordDecl.Spelling == "WhitePoint")
-                {
                 }
 
                 Visit(recordDecl.Decls, excludedCursors);

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -431,13 +431,11 @@ namespace ClangSharp
                 type = attributedType.ModifiedType;
                 callConv = attributedType.Handle.FunctionTypeCallingConv;
             }
+            var functionType = (FunctionType)type;
 
-            if (type is FunctionType functionType)
+            if (callConv == CXCallingConv.CXCallingConv_Invalid)
             {
-                if (callConv == CXCallingConv.CXCallingConv_Invalid)
-                {
-                    callConv = functionType.CallConv;
-                }
+                callConv = functionType.CallConv;
             }
 
             var cxxMethodDecl = functionDecl as CXXMethodDecl;

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -431,11 +431,13 @@ namespace ClangSharp
                 type = attributedType.ModifiedType;
                 callConv = attributedType.Handle.FunctionTypeCallingConv;
             }
-            var functionType = (FunctionType)type;
 
-            if (callConv == CXCallingConv.CXCallingConv_Invalid)
+            if (type is FunctionType functionType)
             {
-                callConv = functionType.CallConv;
+                if (callConv == CXCallingConv.CXCallingConv_Invalid)
+                {
+                    callConv = functionType.CallConv;
+                }
             }
 
             var cxxMethodDecl = functionDecl as CXXMethodDecl;
@@ -740,6 +742,7 @@ namespace ClangSharp
                 }
 
                 AddNativeTypeNameAttribute(nativeTypeName, prefix: "", postfix: " ");
+                AddCppAttributes(parmVarDecl, prefix: "", postfix: " ");
 
                 _outputBuilder.Write(typeName);
                 _outputBuilder.Write(' ');
@@ -776,13 +779,15 @@ namespace ClangSharp
                 var typeName = GetRemappedTypeName(parmVarDecl, context: null, type, out var nativeTypeName);
                 AddNativeTypeNameAttribute(nativeTypeName, prefix: "", postfix: " ");
 
+                var parameters = typedefDecl.CursorChildren.OfType<ParmVarDecl>().ToList();
+                AddCppAttributes(parmVarDecl, prefix: "", postfix: " ");
+
                 _outputBuilder.Write(typeName);
                 _outputBuilder.Write(' ');
 
                 var name = GetRemappedCursorName(parmVarDecl);
                 _outputBuilder.Write(EscapeName(name));
 
-                var parameters = typedefDecl.CursorChildren.OfType<ParmVarDecl>().ToList();
                 var index = parameters.IndexOf(parmVarDecl);
                 var lastIndex = parameters.Count - 1;
 
@@ -934,6 +939,7 @@ namespace ClangSharp
                     }
 
                     AddNativeTypeNameAttribute(nativeTypeNameBuilder.ToString());
+                    AddNativeInheritanceAttribute(GetCursorName(cxxRecordDecl.Bases.Last().Referenced));
                 }
 
                 _outputBuilder.WriteIndented(GetAccessSpecifierName(recordDecl));
@@ -1590,6 +1596,11 @@ namespace ClangSharp
 
             void VisitAnonymousRecordDeclFields(RecordDecl rootRecordDecl, RecordDecl anonymousRecordDecl, string contextType, string contextName)
             {
+                if (_config.ExcludeAnonymousFieldHelpers)
+                {
+                    return;
+                }
+
                 foreach (var declaration in anonymousRecordDecl.Decls)
                 {
                     if (declaration is FieldDecl fieldDecl)
@@ -2489,9 +2500,26 @@ namespace ClangSharp
                 {
                     ForPointeeType(typedefDecl, parentType: null, referenceType.PointeeType);
                 }
-                else if (underlyingType is TagType)
+                else if (underlyingType is TagType underlyingTagType)
                 {
-                    // Nothing to do for tag types
+                    // See if there's a potential typedef remapping we want to log
+                    if (_config.LogPotentialTypedefRemappings)
+                    {
+                        var typedefName = typedefDecl.UnderlyingDecl.Name;
+                        var possibleNamesToRemap = new string[] { "_" + typedefName, "_tag" + typedefName, "tag" + typedefName };
+                        var underlyingName = underlyingTagType.AsString;
+
+                        foreach (var possibleNameToRemap in possibleNamesToRemap)
+                        {
+                            if (!_config.RemappedNames.ContainsKey(possibleNameToRemap))
+                            {
+                                if (possibleNameToRemap == underlyingName)
+                                {
+                                    AddDiagnostic(DiagnosticLevel.Info, $"Potential remap: {possibleNameToRemap}={typedefName}");
+                                }
+                            }
+                        }
+                    }
                 }
                 else if (underlyingType is TypedefType typedefType)
                 {

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -345,7 +345,7 @@ namespace ClangSharp
 
             var type = fieldDecl.Type;
             var typeName = GetRemappedTypeName(fieldDecl, context: null, type, out var nativeTypeName);
-
+            
             if (fieldDecl.Parent.IsUnion)
             {
                 _outputBuilder.WriteIndentedLine("[FieldOffset(0)]");
@@ -778,8 +778,6 @@ namespace ClangSharp
                 var type = parmVarDecl.Type;
                 var typeName = GetRemappedTypeName(parmVarDecl, context: null, type, out var nativeTypeName);
                 AddNativeTypeNameAttribute(nativeTypeName, prefix: "", postfix: " ");
-
-                var parameters = typedefDecl.CursorChildren.OfType<ParmVarDecl>().ToList();
                 AddCppAttributes(parmVarDecl, prefix: "", postfix: " ");
 
                 _outputBuilder.Write(typeName);
@@ -788,6 +786,7 @@ namespace ClangSharp
                 var name = GetRemappedCursorName(parmVarDecl);
                 _outputBuilder.Write(EscapeName(name));
 
+                var parameters = typedefDecl.CursorChildren.OfType<ParmVarDecl>().ToList();
                 var index = parameters.IndexOf(parmVarDecl);
                 var lastIndex = parameters.Count - 1;
 
@@ -1135,6 +1134,10 @@ namespace ClangSharp
                 {
                     OutputMethods(cxxRecordDecl, cxxRecordDecl);
                     excludedCursors = excludedCursors.Concat(cxxRecordDecl.Methods);
+                }
+
+                if (recordDecl.Spelling == "WhitePoint")
+                {
                 }
 
                 Visit(recordDecl.Decls, excludedCursors);

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -431,11 +431,13 @@ namespace ClangSharp
                 type = attributedType.ModifiedType;
                 callConv = attributedType.Handle.FunctionTypeCallingConv;
             }
-            var functionType = (FunctionType)type;
 
-            if (callConv == CXCallingConv.CXCallingConv_Invalid)
+            if (type is FunctionType functionType)
             {
-                callConv = functionType.CallConv;
+                if (callConv == CXCallingConv.CXCallingConv_Invalid)
+                {
+                    callConv = functionType.CallConv;
+                }
             }
 
             var cxxMethodDecl = functionDecl as CXXMethodDecl;

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -319,15 +319,13 @@ namespace ClangSharp
 
             _outputBuilder.Write($"[CppAttributeList(\"");
 
-            for (int i = 0; i < parmVarDecl.Attrs.Count; i++)
+            _outputBuilder.Write(EscapeString(parmVarDecl.Attrs[0].Spelling));
+            for (int i = 1; i < parmVarDecl.Attrs.Count; i++)
             {
-                var attr = EscapeString(parmVarDecl.Attrs[i].Spelling);
-                if (i != 0)
-                {
-                    _outputBuilder.Write('^');
-                }
+                // Separator char between attributes
+                _outputBuilder.Write('^');
 
-                _outputBuilder.Write(attr);
+                _outputBuilder.Write(EscapeString(parmVarDecl.Attrs[i].Spelling));
             }
 
             _outputBuilder.Write($"\")]");
@@ -1076,10 +1074,10 @@ namespace ClangSharp
             }
             else if ((namedDecl is RecordDecl recordDecl) && name.StartsWith("__AnonymousRecord_"))
             {
-                remappedName = "_Anonymous";
-
                 if (recordDecl.Parent is RecordDecl parentRecordDecl)
                 {
+                    remappedName = "_Anonymous";
+
                     var matchingField = parentRecordDecl.Fields.Where((fieldDecl) => fieldDecl.Type.CanonicalType == recordDecl.TypeForDecl.CanonicalType).FirstOrDefault();
 
                     if (matchingField != null)
@@ -1092,8 +1090,9 @@ namespace ClangSharp
                         var index = parentRecordDecl.AnonymousDecls.IndexOf(recordDecl) + 1;
                         remappedName += index.ToString();
                     }
+
+                    remappedName += $"_e__{(recordDecl.IsUnion ? "Union" : "Struct")}";
                 }
-                remappedName += $"_e__{(recordDecl.IsUnion ? "Union" : "Struct")}";
             }
 
             return remappedName;

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -1176,6 +1176,10 @@ namespace ClangSharp
 
                 name += $"_e__{(recordDecl.IsUnion ? "Union" : "Struct")}";
             }
+            else if ((canonicalType is EnumType enumType) && name.StartsWith("__AnonymousEnum_"))
+            {
+                name = GetRemappedTypeName(enumType.Decl, context: null, enumType.Decl.IntegerType, out _);
+            }
             else if (cursor is EnumDecl enumDecl)
             {
                 var enumDeclName = GetRemappedCursorName(enumDecl);

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -342,6 +342,11 @@ namespace ClangSharp
 
         private void AddNativeInheritanceAttribute(string inheritedFromName, string prefix = null, string postfix = null, string attributePrefix = null)
         {
+            if (!_config.GenerateNativeInheritanceAttribute)
+            {
+                return;
+            }
+
             if (prefix is null)
             {
                 _outputBuilder.WriteIndentation();

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -2182,6 +2182,9 @@ namespace ClangSharp
 
             bool IsIncludedFileOrLocation(Cursor cursor, CXFile file, CXSourceLocation location)
             {
+                // Use case insensitive comparison on Windows
+                var equalityComparer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
                 // Normalize paths to be '/' for comparison
                 var fileName = file.Name.ToString().Replace('\\', '/');
 
@@ -2190,8 +2193,6 @@ namespace ClangSharp
                     AddDiagnostic(DiagnosticLevel.Info, $"Visiting {fileName}");
                 }
 
-                // Use case insensitive comparison on Windows
-                var equalityComparer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
                 if (_config.TraversalNames.Contains(fileName, equalityComparer))
                 {
                     return true;

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -26,7 +26,6 @@ namespace ClangSharp
         private readonly Dictionary<string, Guid> _uuidsToGenerate;
         private readonly HashSet<string> _generatedUuids;
         private readonly PInvokeGeneratorConfiguration _config;
-        private readonly Dictionary<string, bool> _fileIncluded = new Dictionary<string, bool>(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
 
         private string _filePath;
         private string[] _clangCommandLineArgs;
@@ -2181,11 +2180,6 @@ namespace ClangSharp
             {
                 // Normalize paths to be '/' for comparison
                 var fileName = file.Name.ToString().Replace('\\', '/');
-                bool ret;
-                if (_fileIncluded.TryGetValue(fileName, out ret))
-                {
-                    return ret;
-                }
 
                 if (_visitedFiles.Add(fileName) && _config.LogVisitedFiles)
                 {
@@ -2196,16 +2190,14 @@ namespace ClangSharp
                 var equalityComparer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
                 if (_config.TraversalNames.Contains(fileName, equalityComparer))
                 {
-                    ret = true;
+                    return true;
                 }
                 else if ((_config.TraversalNames.Length == 0) && location.IsFromMainFile)
                 {
-                    ret = true;
+                    return true;
                 }
 
-                _fileIncluded[fileName] = ret;
-
-                return ret;
+                return false;
             }
 
             bool IsComProxy(FunctionDecl functionDecl, string name)

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -157,6 +157,8 @@ namespace ClangSharp
 
         public bool GenerateCppAttributes => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateCppAttributes);
 
+        public bool GenerateNativeInheritanceAttribute => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateNativeInheritanceAttribute);
+
         public string MethodClassName { get; }
 
         public string MethodPrefixToStrip { get;}

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -149,6 +149,14 @@ namespace ClangSharp
 
         public bool LogVisitedFiles => _options.HasFlag(PInvokeGeneratorConfigurationOptions.LogVisitedFiles);
 
+        public bool ExcludeFunctionsWithBody => _options.HasFlag(PInvokeGeneratorConfigurationOptions.ExcludeFunctionsWithBody);
+
+        public bool ExcludeAnonymousFieldHelpers => _options.HasFlag(PInvokeGeneratorConfigurationOptions.ExcludeAnonymousFieldHelpers);
+
+        public bool LogPotentialTypedefRemappings => _options.HasFlag(PInvokeGeneratorConfigurationOptions.LogPotentialTypedefRemappings);
+
+        public bool GenerateCppAttributes => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateCppAttributes);
+
         public string MethodClassName { get; }
 
         public string MethodPrefixToStrip { get;}

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
@@ -42,5 +42,13 @@ namespace ClangSharp
         ExcludeEnumOperators = 0x00004000,
 
         GenerateAggressiveInlining = 0x00008000,
+
+        ExcludeFunctionsWithBody = 0x00010000,
+
+        ExcludeAnonymousFieldHelpers = 0x00020000,
+
+        LogPotentialTypedefRemappings = 0x00040000,
+
+        GenerateCppAttributes = 0x00080000,
     }
 }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
@@ -50,5 +50,7 @@ namespace ClangSharp
         LogPotentialTypedefRemappings = 0x00040000,
 
         GenerateCppAttributes = 0x00080000,
+
+        GenerateNativeInheritanceAttribute = 0x00100000,
     }
 }

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+#define CatchAndDisplayRootCommandExceptions
 
 using System;
 using System.Collections.Generic;
@@ -49,7 +50,24 @@ namespace ClangSharp
             AddWithTypeOption(s_rootCommand);
             AddWithUsingOption(s_rootCommand);
 
+#if !CatchAndDisplayRootCommandExceptions
             return await s_rootCommand.InvokeAsync(args);
+#else
+            try
+            {
+                var ret = await s_rootCommand.InvokeAsync(args);
+                return ret;
+            }
+            catch (Exception e)
+            {
+                for (; e != null; e = e.InnerException)
+                {
+                    Console.WriteLine("Exception encountered: " + e.Message);
+                }
+
+                return -1;
+            }
+#endif
         }
 
         public static int Run(InvocationContext context)
@@ -261,6 +279,30 @@ namespace ClangSharp
                     case "windows-types":
                     {
                         configOptions &= ~PInvokeGeneratorConfigurationOptions.GenerateUnixTypes;
+                        break;
+                    }
+
+                    case "exclude-funcs-with-body":
+                    {
+                        configOptions |= PInvokeGeneratorConfigurationOptions.ExcludeFunctionsWithBody;
+                        break;
+                    }
+
+                    case "log-potential-typedef-remappings":
+                    {
+                        configOptions |= PInvokeGeneratorConfigurationOptions.LogPotentialTypedefRemappings;
+                        break;
+                    }
+
+                    case "exclude-anonymous-field-helpers":
+                    {
+                        configOptions |= PInvokeGeneratorConfigurationOptions.ExcludeAnonymousFieldHelpers;
+                        break;
+                    }
+
+                    case "generate-cpp-attributes":
+                    {
+                        configOptions |= PInvokeGeneratorConfigurationOptions.GenerateCppAttributes;
                         break;
                     }
 

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -288,6 +288,12 @@ namespace ClangSharp
                         break;
                     }
 
+                    case "generate-native-inheritance-attribute":
+                    {
+                        configOptions |= PInvokeGeneratorConfigurationOptions.GenerateNativeInheritanceAttribute;
+                        break;
+                    }
+
                     default:
                     {
                         errorList.Add($"Error: Unrecognized config switch: {configSwitch}.");

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -1,5 +1,4 @@
 // Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
-#define CatchAndDisplayRootCommandExceptions
 
 using System;
 using System.Collections.Generic;
@@ -50,24 +49,7 @@ namespace ClangSharp
             AddWithTypeOption(s_rootCommand);
             AddWithUsingOption(s_rootCommand);
 
-#if !CatchAndDisplayRootCommandExceptions
             return await s_rootCommand.InvokeAsync(args);
-#else
-            try
-            {
-                var ret = await s_rootCommand.InvokeAsync(args);
-                return ret;
-            }
-            catch (Exception e)
-            {
-                for (; e != null; e = e.InnerException)
-                {
-                    Console.WriteLine("Exception encountered: " + e.Message);
-                }
-
-                return -1;
-            }
-#endif
         }
 
         public static int Run(InvocationContext context)


### PR DESCRIPTION
Some changes required for a project where we use ClangSharp to against Win32 headers so that they can be projected into other languages.

- Adds 5 new config options:

1. ExcludeFunctionsWithBody: exclude functions that have a body (code). For projecting to other languages, we want to avoid any functions that include code. We only want DLL import functions.
2. ExcludeAnonymousFieldHelpers: exclude helper code for anonymous fields.
3. LogPotentialTypedefRemappings: adds diagnostics to suggest remappings (e.g. tagMyStruct to MyStruct).
4. GenerateCppAttributes: adds a CppAttributeList attribute for parameters that have C++ attributes on them. We are using this for SAL attributes which help us figure out, for example, if a pointer to a struct is just a single struct or an array.
5. GenerateNativeInheritanceAttribute: adds an attribute that shows the last base type the struct derived from. We use this to help figure out COM interface inheritance.

- Fixed a few issues we ran into:

1. An anonymous struct that wasn't a nested type was getting named "_Anonymous_e__Struct" but then was referenced in a function as the header/location name (e.g. __AnonymousRecord_myheader_L275_C9), so it wouldn't compile. Make sure to only rename to "_Anonymous_e__Struct" if it's a nested type.
2. This wasn't safe to cast in one case we saw: var functionType = (FunctionType)type; So instead use "is" to make sure it really is of type FunctionType.
3. When getting the type for an anonymous enum, get its integer type instead of its anonymous type name, since anonymous enum values are emitted as constants and not as constants in an enum type.