### PR TITLE
Fix translation for implicit move constructor invocation

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -252,9 +252,9 @@ namespace ClangSharp
 
         private void VisitCXXConstructExpr(CXXConstructExpr cxxConstructExpr)
         {
-            var isCopyConstructor = cxxConstructExpr.Constructor.IsCopyConstructor;
+            var isCopyOrMoveConstructor = cxxConstructExpr.Constructor is { IsCopyConstructor: true } or { IsMoveConstructor: true };
 
-            if (!isCopyConstructor)
+            if (!isCopyOrMoveConstructor)
             {
                 _outputBuilder.Write("new ");
 
@@ -277,7 +277,7 @@ namespace ClangSharp
                 }
             }
 
-            if (!isCopyConstructor)
+            if (!isCopyOrMoveConstructor)
             {
                 _outputBuilder.Write(')');
             }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationBodyImportTest.cs
@@ -1509,6 +1509,49 @@ bool MyFunction(const MyStruct& lhs, const MyStruct& rhs)
         }
 
         [Fact]
+        public async Task ReturnStructTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    double r;
+    double g;
+    double b;
+};
+
+MyStruct MyFunction()
+{
+    MyStruct myStruct;
+    return myStruct;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        public double r;
+
+        public double g;
+
+        public double b;
+    }
+
+    public static partial class Methods
+    {
+        public static MyStruct MyFunction()
+        {
+            MyStruct myStruct = new MyStruct();
+
+            return myStruct;
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindingsAsync(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
         public async Task SwitchTest()
         {
             var inputContents = @"int MyFunction(int value)


### PR DESCRIPTION
Move constructors need the same special handling as copy constructors do. 

One scenario that this fixes is functions which return structs. Previously, for C++ code like this: 
```cpp
struct MyStruct
{
    double r;
    double g;
    double b;
};

MyStruct MyFunction()
{
    MyStruct myStruct;
    return myStruct;
}
```
the `MyFunction` function would be translated as such: 
```cs
public static MyStruct MyFunction()
{
    MyStruct myStruct = new MyStruct();
    return new MyStruct(myStruct);
}
```
This patch removes the explicit constructor invocation.