### PR TITLE
Fix translation for constant string literals

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -2607,6 +2607,7 @@ namespace ClangSharp
                 _outputBuilder.Write(' ');
 
                 var isProperty = false;
+                var isStringLiteral = false;
 
                 if (IsStmtAsWritten<StringLiteral>(varDecl.Init, out var stringLiteral, removeParens: true))
                 {
@@ -2620,6 +2621,7 @@ namespace ClangSharp
 
                             typeName = "ReadOnlySpan<byte>";
                             isProperty = true;
+                            isStringLiteral = true;
                             break;
                         }
 
@@ -2638,6 +2640,7 @@ namespace ClangSharp
                             _outputBuilder.Write("const ");
 
                             typeName = "string";
+                            isStringLiteral = true;
                             break;
                         }
 
@@ -2664,7 +2667,7 @@ namespace ClangSharp
 
                 _outputBuilder.Write(typeName);
 
-                if (type is ArrayType)
+                if (!isStringLiteral && type is ArrayType)
                 {
                     _outputBuilder.Write("[]");
                 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/VarDeclarationTest.cs
@@ -181,6 +181,44 @@ namespace ClangSharp.Test
         }
 
         [Fact]
+        public async Task WideStringLiteralConstTest()
+        {
+            var inputContents = $@"const wchar_t MyConst1[] = L""Test"";";
+
+            var expectedOutputContents = $@"namespace ClangSharp.Test
+{{
+    public static partial class Methods
+    {{
+        [NativeTypeName(""const wchar_t [5]"")]
+        public const string MyConst1 = ""Test"";
+    }}
+}}
+";
+
+            await ValidateGeneratedBindingsAsync(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
+        public async Task StringLiteralConstTest()
+        {
+            var inputContents = $@"const char MyConst1[] = ""Test"";";
+
+            var expectedOutputContents = $@"using System;
+
+namespace ClangSharp.Test
+{{
+    public static partial class Methods
+    {{
+        [NativeTypeName(""const char [5]"")]
+        public static ReadOnlySpan<byte> MyConst1 => new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+    }}
+}}
+";
+
+            await ValidateGeneratedBindingsAsync(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
         public async Task UncheckedConversionMacroTest()
         {
             var inputContents = $@"#define MyMacro1 (long)0x80000000L


### PR DESCRIPTION
Constant string literal declarations like
```cpp
const wchar_t MyConst[] = "Test";
```
are incorrectly translated to C# as
```cs
public const string[] MyConst = "Test";
```
This patch removes the erroneous array type specifier.