### PR TITLE
Fix remapping for union field names

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -1067,7 +1067,7 @@ namespace ClangSharp
                 return remappedName;
             }
 
-            if ((namedDecl is FieldDecl fieldDecl) && name.StartsWith("__AnonymousField_"))
+            if ((namedDecl is FieldDecl fieldDecl) && (name.StartsWith("__AnonymousField_") || name.StartsWith("__AnonymousFieldDecl_")))
             {
                 remappedName = "Anonymous";
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -1067,7 +1067,7 @@ namespace ClangSharp
                 return remappedName;
             }
 
-            if ((namedDecl is FieldDecl fieldDecl) && (name.StartsWith("__AnonymousField_") || name.StartsWith("__AnonymousFieldDecl_")))
+            if ((namedDecl is FieldDecl fieldDecl) && name.StartsWith("__AnonymousFieldDecl_"))
             {
                 remappedName = "Anonymous";
 


### PR DESCRIPTION
For code like:
```cpp
union MyUnion
{
    struct { int a; };
};
void MyFunction()
{
    MyUnion myUnion;  
    myUnion.a = 10;
}
```

`myUnion.a = 10;` was translated to C# using the mangled name, not the actual name of the field in C# (`Anonymous`).