### PR TITLE
Add support for templates in type signatures

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -1027,6 +1027,10 @@ namespace ClangSharp
                 {
                     baseType = elaboratedType.CanonicalType;
                 }
+                else if (baseType is TemplateSpecializationType templateSpecializationType)
+                {
+                    baseType = templateSpecializationType.CanonicalType;
+                }
                 else if (baseType is TypedefType typedefType)
                 {
                     baseType = typedefType.Decl.UnderlyingType;
@@ -1139,12 +1143,6 @@ namespace ClangSharp
         {
             var name = GetTypeName(cursor, context, type, out nativeTypeName);
             name = GetRemappedName(name, cursor, tryRemapOperatorName: false);
-
-            if (name.Contains("::"))
-            {
-                name = name.Split(new string[] { "::" }, StringSplitOptions.RemoveEmptyEntries).Last();
-                name = GetRemappedName(name, cursor, tryRemapOperatorName: false);
-            }
 
             var canonicalType = type.CanonicalType;
 
@@ -1389,19 +1387,59 @@ namespace ClangSharp
             {
                 name = GetTypeNameForPointeeType(cursor, context, referenceType.PointeeType, out var nativePointeeTypeName);
             }
+            else if (type is TemplateSpecializationType templateSpecializationType)
+            {
+                var nameBuilder = new StringBuilder();
+
+                var templateTypeDecl = ((RecordType)templateSpecializationType.CanonicalType).Decl;
+                nameBuilder.Append(GetRemappedName(templateTypeDecl.Name, templateTypeDecl, tryRemapOperatorName: false));
+
+                nameBuilder.Append('<');
+
+                bool shouldWritePrecedingComma = false;
+
+                foreach (var arg in templateSpecializationType.Args)
+                {
+                    if (shouldWritePrecedingComma)
+                    {
+                        nameBuilder.Append(',');
+                        nameBuilder.Append(' ');
+
+                    }
+
+                    var typeName = GetRemappedTypeName(cursor, context: null, arg.AsType, out _);
+
+                    if (typeName == "bool")
+                    {
+                        // bool is not blittable, so we shouldn't use it for P/Invoke signatures
+                        typeName = "byte";
+                    }
+
+                    if (typeName.EndsWith("*"))
+                    {
+                        // Pointers are not yet supported as generic arguments; remap to UIntPtr
+                        typeName = "UIntPtr";
+                        _outputBuilder.AddUsingDirective("System");
+                    }    
+
+                    nameBuilder.Append(typeName);
+
+                    shouldWritePrecedingComma = true;
+                }
+
+                nameBuilder.Append('>');
+
+                name = nameBuilder.ToString();
+            }
             else if (type is TagType tagType)
             {
-                if (tagType.Decl.Handle.IsAnonymous)
-                {
-                    name = GetAnonymousName(tagType.Decl, tagType.KindSpelling);
-                }
-                else if (tagType.Handle.IsConstQualified)
+                if (tagType.Handle.IsConstQualified)
                 {
                     name = GetTypeName(cursor, context, tagType.Decl.TypeForDecl, out var nativeDeclTypeName);
                 }
                 else
                 {
-                    // The default name should be correct
+                    name = GetCursorName(tagType.Decl);
                 }
             }
             else if (type is TypedefType typedefType)

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -1403,7 +1403,6 @@ namespace ClangSharp
                     {
                         nameBuilder.Append(',');
                         nameBuilder.Append(' ');
-
                     }
 
                     var typeName = GetRemappedTypeName(cursor, context: null, arg.AsType, out _);
@@ -1588,7 +1587,7 @@ namespace ClangSharp
                 }
                 else
                 {
-                    name = "IntPtr";
+                    name = "UIntPtr";
                 }
             }
             else

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -1415,8 +1415,8 @@ namespace ClangSharp
 
                     if (typeName.EndsWith("*"))
                     {
-                        // Pointers are not yet supported as generic arguments; remap to UIntPtr
-                        typeName = "UIntPtr";
+                        // Pointers are not yet supported as generic arguments; remap to IntPtr
+                        typeName = "IntPtr";
                         _outputBuilder.AddUsingDirective("System");
                     }    
 
@@ -1587,7 +1587,7 @@ namespace ClangSharp
                 }
                 else
                 {
-                    name = "UIntPtr";
+                    name = "IntPtr";
                 }
             }
             else

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -818,7 +818,6 @@ namespace ClangSharp
                     else
                     {
                         name = GetTypeName(namedDecl, context: null, typeDecl.TypeForDecl, out var nativeTypeName);
-                        Debug.Assert(string.IsNullOrWhiteSpace(nativeTypeName));
                     }
                 }
                 else if (namedDecl is ParmVarDecl)
@@ -1433,13 +1432,23 @@ namespace ClangSharp
             }
             else if (type is TagType tagType)
             {
-                if (tagType.Handle.IsConstQualified)
+                if (tagType.Decl.Handle.IsAnonymous)
+                {
+                    name = GetAnonymousName(tagType.Decl, tagType.KindSpelling);
+                }
+                else if (tagType.Handle.IsConstQualified)
                 {
                     name = GetTypeName(cursor, context, tagType.Decl.TypeForDecl, out var nativeDeclTypeName);
                 }
                 else
                 {
-                    name = GetCursorName(tagType.Decl);
+                    // The default name should be correct	
+                }
+
+                if (name.Contains("::"))
+                {
+                    name = name.Split(new string[] { "::" }, StringSplitOptions.RemoveEmptyEntries).Last();
+                    name = GetRemappedName(name, cursor, tryRemapOperatorName: false);
                 }
             }
             else if (type is TypedefType typedefType)

--- a/sources/ClangSharp/TemplateArgument.cs
+++ b/sources/ClangSharp/TemplateArgument.cs
@@ -31,11 +31,11 @@ namespace ClangSharp
         {
             _parentType = parentType;
             _index = index;
-            _asDecl = new Lazy<ValueDecl>(() => _parentDecl.TranslationUnit.GetOrCreate<ValueDecl>(_parentType.Handle.GetTemplateArgumentAsDecl(_index)));
-            _asExpr = new Lazy<Expr>(() => _parentDecl.TranslationUnit.GetOrCreate<Expr>(_parentType.Handle.GetTemplateArgumentAsExpr(_index)));
-            _asType = new Lazy<Type>(() => _parentDecl.TranslationUnit.GetOrCreate<Type>(_parentType.Handle.GetTemplateArgumentAsType(_index)));
-            _integralType = new Lazy<Type>(() => _parentDecl.TranslationUnit.GetOrCreate<Type>(_parentType.Handle.GetTemplateArgumentIntegralType(_index)));
-            _nullPtrType = new Lazy<Type>(() => _parentDecl.TranslationUnit.GetOrCreate<Type>(_parentType.Handle.GetTemplateArgumentNullPtrType(_index)));
+            _asDecl = new Lazy<ValueDecl>(() => _parentType.TranslationUnit.GetOrCreate<ValueDecl>(_parentType.Handle.GetTemplateArgumentAsDecl(_index)));
+            _asExpr = new Lazy<Expr>(() => _parentType.TranslationUnit.GetOrCreate<Expr>(_parentType.Handle.GetTemplateArgumentAsExpr(_index)));
+            _asType = new Lazy<Type>(() => _parentType.TranslationUnit.GetOrCreate<Type>(_parentType.Handle.GetTemplateArgumentAsType(_index)));
+            _integralType = new Lazy<Type>(() => _parentType.TranslationUnit.GetOrCreate<Type>(_parentType.Handle.GetTemplateArgumentIntegralType(_index)));
+            _nullPtrType = new Lazy<Type>(() => _parentType.TranslationUnit.GetOrCreate<Type>(_parentType.Handle.GetTemplateArgumentNullPtrType(_index)));
         }
 
         public ValueDecl AsDecl => _asDecl.Value;

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionDeclarationDllImportTest.cs
@@ -72,8 +72,8 @@ namespace ClangSharp.Test
         [Theory]
         [InlineData("MyTemplate<int>", @"MyTemplate<int>", "")]
         [InlineData("MyTemplate<bool>", @"[NativeTypeName(""MyTemplate<bool>"")] MyTemplate<byte>", "")]
-        [InlineData("MyTemplate<float*>", @"[NativeTypeName(""MyTemplate<float *>"")] MyTemplate<UIntPtr>", "using System;\n")]
-        [InlineData("MyTemplate<void(*)(int)>", @"[NativeTypeName(""MyTemplate<void (*)(int)>"")] MyTemplate<UIntPtr>", "using System;\n")]
+        [InlineData("MyTemplate<float*>", @"[NativeTypeName(""MyTemplate<float *>"")] MyTemplate<IntPtr>", "using System;\n")]
+        [InlineData("MyTemplate<void(*)(int)>", @"[NativeTypeName(""MyTemplate<void (*)(int)>"")] MyTemplate<IntPtr>", "using System;\n")]
         public async Task TemplateParameterTest(string nativeParameter, string expectedManagedParameter, string expectedUsingStatement)
         {
             var inputContents = @$"template <typename T> struct MyTemplate;
@@ -116,7 +116,7 @@ namespace ClangSharp.Test
     public partial struct MyStruct
     {{
         [NativeTypeName(""MyTemplate<float *>"")]
-        public MyTemplate<UIntPtr> a;
+        public MyTemplate<IntPtr> a;
     }}
 }}
 ";


### PR DESCRIPTION
Very rudimentary template support is present. This doesn't add support for template type declarations, only the ability to translate elements like `MyStruct<int>` in type signatures. Unfortunately, since pointers in generics aren't yet allowed in .NET, any pointer types in template arguments get erased uniformly as `UIntPtr` when translating to C#. 