### PR TITLE
Insert cast to enum underlying type when casting to enum type in enum initializer

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -454,6 +454,15 @@ namespace ClangSharp
 
         private void VisitExplicitCastExpr(ExplicitCastExpr explicitCastExpr)
         {
+            if (IsPrevContextDecl<EnumConstantDecl>(out var _) && explicitCastExpr.Type is EnumType)
+            {
+                // In C#, explicitly casting to an enum type in an enum initializer usually results in compile errors.
+                // Remove all explicit casts to an enum type; the evaluation of the constant value will still happen correctly.
+
+                Visit(explicitCastExpr.SubExprAsWritten);
+                return;
+            }
+
             var type = explicitCastExpr.Type;
             var typeName = GetRemappedTypeName(explicitCastExpr, context: null, type, out var nativeTypeName);
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -454,16 +454,16 @@ namespace ClangSharp
 
         private void VisitExplicitCastExpr(ExplicitCastExpr explicitCastExpr)
         {
-            if (IsPrevContextDecl<EnumConstantDecl>(out var _) && explicitCastExpr.Type is EnumType)
+            if (IsPrevContextDecl<EnumConstantDecl>(out var _) && explicitCastExpr.Type is EnumType enumType)
             {
-                // In C#, explicitly casting to an enum type in an enum initializer usually results in compile errors.
-                // Remove all explicit casts to an enum type; the evaluation of the constant value will still happen correctly.
-
-                Visit(explicitCastExpr.SubExprAsWritten);
-                return;
+                _outputBuilder.Write('(');
+                var enumUnderlyingTypeName = GetRemappedTypeName(explicitCastExpr, context: null, enumType.Decl.IntegerType, out _);
+                _outputBuilder.Write(enumUnderlyingTypeName);
+                _outputBuilder.Write(')');
             }
 
             var type = explicitCastExpr.Type;
+
             var typeName = GetRemappedTypeName(explicitCastExpr, context: null, type, out var nativeTypeName);
 
             _outputBuilder.Write('(');

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/EnumDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/EnumDeclarationTest.cs
@@ -394,7 +394,7 @@ namespace ClangSharp.Test
         [Fact]
         public async Task WithCastToEnumType()
         {
-            var inputContents = @"enum MyEnum
+            var inputContents = @"enum MyEnum : int
 {
     MyEnum_Value0 = (MyEnum) 10,
     MyEnum_Value1 = (MyEnum) MyEnum_Value0,
@@ -420,12 +420,12 @@ namespace ClangSharp.Test
         [Fact]
         public async Task WithMultipleEnumsTest()
         {
-            var inputContents = @"enum MyEnum1
+            var inputContents = @"enum MyEnum1 : int
 {
     MyEnum1_Value0 = 10,
 };
 
-enum MyEnum2
+enum MyEnum2 : int
 {
     MyEnum2_Value0 = MyEnum1_Value0,
     MyEnum2_Value1 = MyEnum1_Value0 + (MyEnum1) 10,

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/EnumDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/EnumDeclarationTest.cs
@@ -392,6 +392,67 @@ namespace ClangSharp.Test
         }
 
         [Fact]
+        public async Task WithCastToEnumType()
+        {
+            var inputContents = @"enum MyEnum
+{
+    MyEnum_Value0 = (MyEnum) 10,
+    MyEnum_Value1 = (MyEnum) MyEnum_Value0,
+    MyEnum_Value2 = ((MyEnum) 10) + MyEnum_Value1,
+};
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public enum MyEnum
+    {
+        MyEnum_Value0 = 10,
+        MyEnum_Value1 = MyEnum_Value0,
+        MyEnum_Value2 = (10) + MyEnum_Value1,
+    }
+}
+";
+
+            await ValidateGeneratedBindingsAsync(inputContents, expectedOutputContents);
+        }
+
+
+        [Fact]
+        public async Task WithMultipleEnumsTest()
+        {
+            var inputContents = @"enum MyEnum1
+{
+    MyEnum1_Value0 = 10,
+};
+
+enum MyEnum2
+{
+    MyEnum2_Value0 = MyEnum1_Value0,
+    MyEnum2_Value1 = MyEnum1_Value0 + (MyEnum1) 10,
+};
+";
+
+            var expectedOutputContents = @"using static ClangSharp.Test.MyEnum1;
+
+namespace ClangSharp.Test
+{
+    public enum MyEnum1
+    {
+        MyEnum1_Value0 = 10,
+    }
+
+    public enum MyEnum2
+    {
+        MyEnum2_Value0 = MyEnum1_Value0,
+        MyEnum2_Value1 = MyEnum1_Value0 + 10,
+    }
+}
+";
+
+            await ValidateGeneratedBindingsAsync(inputContents, expectedOutputContents);
+        }
+
+        [Fact]
         public async Task WithImplicitConversionTest()
         {
             var inputContents = @"enum MyEnum : int

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/EnumDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/EnumDeclarationTest.cs
@@ -406,9 +406,9 @@ namespace ClangSharp.Test
 {
     public enum MyEnum
     {
-        MyEnum_Value0 = 10,
-        MyEnum_Value1 = MyEnum_Value0,
-        MyEnum_Value2 = (10) + MyEnum_Value1,
+        MyEnum_Value0 = (int)(MyEnum)(10),
+        MyEnum_Value1 = (int)(MyEnum)(MyEnum_Value0),
+        MyEnum_Value2 = ((int)(MyEnum)(10)) + MyEnum_Value1,
     }
 }
 ";
@@ -444,7 +444,7 @@ namespace ClangSharp.Test
     public enum MyEnum2
     {
         MyEnum2_Value0 = MyEnum1_Value0,
-        MyEnum2_Value1 = MyEnum1_Value0 + 10,
+        MyEnum2_Value1 = MyEnum1_Value0 + (int)(MyEnum1)(10),
     }
 }
 ";


### PR DESCRIPTION
In C#, generally, casts to enum types inside of enum initializers cause things to stop working. For example:
```cs
public enum E1
{
    F = 3
}

public enum E2
{
    M = E1.F + E1.F, // Compiles fine
    E = (E1) E1.F + E1.F // Does not work!
}
```

Removing all casts to enum types when inside an enum initializer avoids these issues. 
