### PR TITLE
Introduce EnumDesc, add ability to output source location attribute

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/Abstractions/ConstantDesc.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Abstractions/ConstantDesc.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
 
+using ClangSharp.Interop;
+
 namespace ClangSharp.Abstractions
 {
     internal struct ConstantDesc
@@ -9,5 +11,6 @@ namespace ClangSharp.Abstractions
         public string EscapedName { get; set; }
         public string NativeTypeName { get; set; }
         public ConstantKind Kind { get; set; }
+        public CXSourceLocation? Location { get; set; }
     }
 }

--- a/sources/ClangSharp.PInvokeGenerator/Abstractions/EnumDesc.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Abstractions/EnumDesc.cs
@@ -1,0 +1,13 @@
+using ClangSharp.Interop;
+
+namespace ClangSharp.Abstractions
+{
+    public struct EnumDesc
+    {
+        public AccessSpecifier AccessSpecifier { get; set; }
+        public string TypeName { get; set; }
+        public string EscapedName { get; set; }
+        public string NativeType { get; set; }
+        public CXSourceLocation? Location { get; set; }
+    }
+}

--- a/sources/ClangSharp.PInvokeGenerator/Abstractions/FieldDesc.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Abstractions/FieldDesc.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
 
+using ClangSharp.Interop;
+
 namespace ClangSharp.Abstractions
 {
     internal struct FieldDesc
@@ -10,5 +12,6 @@ namespace ClangSharp.Abstractions
         public int? Offset { get; set; }
         public bool NeedsNewKeyword { get; set; }
         public string InheritedFrom { get; set; }
+        public CXSourceLocation? Location { get; set; }
     }
 }

--- a/sources/ClangSharp.PInvokeGenerator/Abstractions/FunctionOrDelegateDesc.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Abstractions/FunctionOrDelegateDesc.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using ClangSharp.Interop;
 
 namespace ClangSharp.Abstractions
 {
@@ -15,6 +16,7 @@ namespace ClangSharp.Abstractions
         public CallingConvention CallingConvention { get; set; }
         public FunctionOrDelegateFlags Flags { get; set; }
         public long? VtblIndex { get; set; }
+        public CXSourceLocation? Location { get; set; }
 
         public bool IsVirtual
         {

--- a/sources/ClangSharp.PInvokeGenerator/Abstractions/IOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Abstractions/IOutputBuilder.VisitDecl.cs
@@ -21,7 +21,7 @@ namespace ClangSharp.Abstractions
         void EndConstantValue();
         void EndConstant(bool isConstant);
 
-        void BeginEnum(AccessSpecifier accessSpecifier, string typeName, string escapedName, string nativeTypeName);
+        void BeginEnum(in EnumDesc desc);
         void EndEnum();
 
         void BeginField(in FieldDesc desc);

--- a/sources/ClangSharp.PInvokeGenerator/Abstractions/ParameterDesc.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Abstractions/ParameterDesc.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using ClangSharp.Interop;
 
 namespace ClangSharp.Abstractions
 {
@@ -13,5 +14,6 @@ namespace ClangSharp.Abstractions
         public IEnumerable<string> CppAttributes { get; set; }
         public Action<TCustomAttrGeneratorData> WriteCustomAttrs { get; set; }
         public TCustomAttrGeneratorData CustomAttrGeneratorData { get; set; }
+        public CXSourceLocation? Location { get; set; }
     }
 }

--- a/sources/ClangSharp.PInvokeGenerator/Abstractions/StructDesc.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Abstractions/StructDesc.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using ClangSharp.Interop;
 
 namespace ClangSharp.Abstractions
 {
@@ -14,6 +15,7 @@ namespace ClangSharp.Abstractions
         public StructLayoutAttribute Layout { get; set; }
         public Guid? Uuid { get; set; }
         public StructFlags Flags { get; set; }
+        public CXSourceLocation? Location { get; set; }
 
         public bool IsUnsafe
         {

--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
@@ -300,6 +300,8 @@ namespace ClangSharp.CSharp
 
             if (!inline)
                 WriteNewline();
+            else
+                Write(' ');
         }
 
         public void WriteReturnType(string typeString)

--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.cs
@@ -20,8 +20,11 @@ namespace ClangSharp.CSharp
 
         private int _indentationLevel;
         private readonly MarkerMode _markerMode;
+        private readonly bool _writeSourceLocation;
 
-        public CSharpOutputBuilder(string name, string indentationString = DefaultIndentationString, bool isTestOutput = false, MarkerMode markerMode = MarkerMode.None)
+        public CSharpOutputBuilder(string name, string indentationString = DefaultIndentationString,
+                                   bool isTestOutput = false, MarkerMode markerMode = MarkerMode.None,
+                                   bool writeSourceLocation = false)
         {
             _name = name;
             _contents = new List<string>();
@@ -31,6 +34,7 @@ namespace ClangSharp.CSharp
             _indentationString = indentationString;
             _isTestOutput = isTestOutput;
             _markerMode = markerMode;
+            _writeSourceLocation = writeSourceLocation;
         }
 
         public IEnumerable<string> Contents => _contents;

--- a/sources/ClangSharp.PInvokeGenerator/OutputBuilderFactory.cs
+++ b/sources/ClangSharp.PInvokeGenerator/OutputBuilderFactory.cs
@@ -11,11 +11,13 @@ namespace ClangSharp
     internal sealed class OutputBuilderFactory
     {
         private readonly PInvokeGeneratorOutputMode _mode;
+        private readonly bool _writeSourceLocation;
         private readonly Dictionary<string, IOutputBuilder> _outputBuilders;
 
-        public OutputBuilderFactory(PInvokeGeneratorOutputMode mode)
+        public OutputBuilderFactory(PInvokeGeneratorConfiguration mode)
         {
-            _mode = mode;
+            _mode = mode.OutputMode;
+            _writeSourceLocation = mode.GenerateSourceLocationAttribute;
             _outputBuilders = new Dictionary<string, IOutputBuilder>();
         }
 
@@ -32,7 +34,7 @@ namespace ClangSharp
 
             var outputBuilder = _mode switch
             {
-                PInvokeGeneratorOutputMode.CSharp => (IOutputBuilder) new CSharpOutputBuilder(name),
+                PInvokeGeneratorOutputMode.CSharp => (IOutputBuilder) new CSharpOutputBuilder(name, writeSourceLocation: _writeSourceLocation),
                 PInvokeGeneratorOutputMode.Xml => new XmlOutputBuilder(name),
                 _ => throw new InvalidOperationException()
             };
@@ -48,7 +50,7 @@ namespace ClangSharp
                 throw new ArgumentNullException(nameof(name));
             }
 
-            var outputBuilder = new CSharpOutputBuilder(name, isTestOutput: true);
+            var outputBuilder = new CSharpOutputBuilder(name, isTestOutput: true, writeSourceLocation: _writeSourceLocation);
 
             _outputBuilders.Add(name, outputBuilder);
             return outputBuilder;

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -276,7 +276,8 @@ namespace ClangSharp
                 TypeName = typeName,
                 EscapedName = escapedName,
                 NativeTypeName = null,
-                Kind = isAnonymousEnum ? ConstantKind.PrimitiveConstant : ConstantKind.Enumerator
+                Kind = isAnonymousEnum ? ConstantKind.PrimitiveConstant : ConstantKind.Enumerator,
+                Location = enumConstantDecl.Location
             };
 
             _outputBuilder.BeginConstant(in desc);
@@ -322,8 +323,19 @@ namespace ClangSharp
             {
                 if (!isAnonymousEnum)
                 {
-                    var typeName = GetRemappedTypeName(enumDecl, context: null, enumDecl.IntegerType, out var nativeTypeName);
-                    _outputBuilder.BeginEnum(accessSpecifier, typeName, escapedName, nativeTypeName);
+                    var typeName = GetRemappedTypeName(enumDecl, context: null, enumDecl.IntegerType,
+                        out var nativeTypeName);
+
+                    EnumDesc desc = new()
+                    {
+                        AccessSpecifier = accessSpecifier,
+                        TypeName = typeName,
+                        EscapedName = escapedName,
+                        NativeType = nativeTypeName,
+                        Location = enumDecl.Location
+                    };
+
+                    _outputBuilder.BeginEnum(in desc);
                 }
 
                 Visit(enumDecl.Enumerators);
@@ -363,7 +375,8 @@ namespace ClangSharp
                 NativeTypeName = nativeTypeName,
                 EscapedName = escapedName,
                 Offset = offset,
-                NeedsNewKeyword = NeedsNewKeyword(name)
+                NeedsNewKeyword = NeedsNewKeyword(name),
+                Location = fieldDecl.Location
             };
 
             _outputBuilder.BeginField(in desc);
@@ -482,7 +495,8 @@ namespace ClangSharp
                     x.This.WithUsings("*");
                     x.This.WithUsings(x.Name);
                 },
-                CustomAttrGeneratorData = (name, this)
+                CustomAttrGeneratorData = (name, this),
+                Location = functionDecl.Location
             };
 
             _outputBuilder.BeginFunctionOrDelegate(in desc, ref _isMethodClassUnsafe);
@@ -700,7 +714,8 @@ namespace ClangSharp
                 NativeTypeName = null,
                 EscapedName = escapedName,
                 Offset = null,
-                NeedsNewKeyword = false
+                NeedsNewKeyword = false,
+                Location = fieldDecl.Location
             };
 
             _outputBuilder.WriteDivider(true);
@@ -937,7 +952,8 @@ namespace ClangSharp
                         ? parmVarDecl.Attrs.Select(x => EscapeString(x.Spelling))
                         : null,
                     CustomAttrGeneratorData = (name, this),
-                    WriteCustomAttrs = static _ => { }
+                    WriteCustomAttrs = static _ => { },
+                    Location = parmVarDecl.Location
                 };
 
                 _outputBuilder.BeginParameter(in desc);
@@ -983,7 +999,8 @@ namespace ClangSharp
                         ? parmVarDecl.Attrs.Select(x => EscapeString(x.Spelling))
                         : null,
                     CustomAttrGeneratorData = (name, this),
-                    WriteCustomAttrs = static _ => { }
+                    WriteCustomAttrs = static _ => { },
+                    Location = parmVarDecl.Location
                 };
 
                 _outputBuilder.BeginParameter(in desc);
@@ -1144,7 +1161,8 @@ namespace ClangSharp
                     CustomAttrGeneratorData = (name, this),
                     WriteCustomAttrs = static _ => { },
                     NativeType = nativeNameWithExtras,
-                    NativeInheritance = _config.GenerateNativeInheritanceAttribute ? nativeInheritance : null
+                    NativeInheritance = _config.GenerateNativeInheritanceAttribute ? nativeInheritance : null,
+                    Location = recordDecl.Location
                 };
                 _outputBuilder.BeginStruct(in desc);
 
@@ -1192,7 +1210,8 @@ namespace ClangSharp
                                 EscapedName = baseFieldName,
                                 Offset = null,
                                 NeedsNewKeyword = false,
-                                InheritedFrom = parent
+                                InheritedFrom = parent,
+                                Location = cxxBaseSpecifier.Location
                             };
 
                             _outputBuilder.BeginField(in fieldDesc);
@@ -1508,7 +1527,8 @@ namespace ClangSharp
                     NativeTypeName = nativeTypeName,
                     EscapedName = escapedName,
                     Offset = null,
-                    NeedsNewKeyword = NeedsNewKeyword(remappedName)
+                    NeedsNewKeyword = NeedsNewKeyword(remappedName),
+                    Location = cxxMethodDecl.Location
                 };
 
                 _outputBuilder.BeginField(in desc);
@@ -1553,6 +1573,7 @@ namespace ClangSharp
                     IsCxxRecordCtxUnsafe = IsUnsafe(cxxRecordDecl),
                     IsUnsafe = true,
                     VtblIndex = _config.GenerateVtblIndexAttribute ? cxxMethodDecl.VtblIndex : -1,
+                    Location = cxxMethodDecl.Location
                 };
 
                 _outputBuilder.BeginFunctionOrDelegate(in desc, ref _isMethodClassUnsafe);
@@ -1774,7 +1795,8 @@ namespace ClangSharp
                             NativeTypeName = null,
                             EscapedName = bitfieldName,
                             Offset = fieldDecl.Parent.IsUnion ? 0 : null,
-                            NeedsNewKeyword = false
+                            NeedsNewKeyword = false,
+                            Location = fieldDecl.Location
                         };
                         _outputBuilder.BeginField(in fieldDesc);
                         _outputBuilder.WriteRegularField(typeNameBacking, bitfieldName);
@@ -1945,7 +1967,8 @@ namespace ClangSharp
                     NativeTypeName = nativeTypeName,
                     EscapedName = escapedName,
                     Offset = null,
-                    NeedsNewKeyword = false
+                    NeedsNewKeyword = false,
+                    Location = fieldDecl.Location
                 };
 
                 _outputBuilder.WriteDivider();
@@ -2164,7 +2187,8 @@ namespace ClangSharp
                     EscapedName = escapedName,
                     IsUnsafe = isUnsafeElementType,
                     Layout = layout,
-                    WriteCustomAttrs = static _ => {}
+                    WriteCustomAttrs = static _ => {},
+                    Location = constantArray.Location
                 };
 
                 _outputBuilder.BeginStruct(in desc);
@@ -2221,7 +2245,8 @@ namespace ClangSharp
                         NativeTypeName = null,
                         EscapedName = fieldName,
                         Offset = null,
-                        NeedsNewKeyword = false
+                        NeedsNewKeyword = false,
+                        Location = constantArray.Location
                     };
 
                     _outputBuilder.BeginField(in fieldDesc);
@@ -2317,7 +2342,8 @@ namespace ClangSharp
                         CustomAttrGeneratorData = (name, this),
                         WriteCustomAttrs = static _ => {},
                         IsStatic = false,
-                        IsMemberFunction = true
+                        IsMemberFunction = true,
+                        Location = constantArray.Location
                     };
 
                     _outputBuilder.BeginFunctionOrDelegate(in function, ref _isMethodClassUnsafe);
@@ -2406,7 +2432,8 @@ namespace ClangSharp
                         IsVirtual = true, // such that it outputs as a delegate
                         IsUnsafe = IsUnsafe(typedefDecl, functionProtoType),
                         NativeTypeName = nativeTypeName,
-                        WriteCustomAttrs = static _ => {}
+                        WriteCustomAttrs = static _ => {},
+                        Location = typedefDecl.Location
                     };
 
                     _outputBuilder.BeginFunctionOrDelegate(in desc, ref _isMethodClassUnsafe);
@@ -2702,7 +2729,8 @@ namespace ClangSharp
                     TypeName = typeName,
                     EscapedName = escapedName,
                     NativeTypeName = nativeTypeName,
-                    Kind = kind
+                    Kind = kind,
+                    Location = varDecl.Location
                 };
 
                 _outputBuilder.BeginConstant(in desc);

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -50,7 +50,7 @@ namespace ClangSharp
             }
 
             _index = CXIndex.Create();
-            _outputBuilderFactory = new OutputBuilderFactory(config.OutputMode);
+            _outputBuilderFactory = new OutputBuilderFactory(config);
             _outputStreamFactory = outputStreamFactory ?? ((path) => {
                 var directoryPath = Path.GetDirectoryName(path);
                 _ = Directory.CreateDirectory(directoryPath);

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -181,6 +181,8 @@ namespace ClangSharp
 
         public bool GenerateVtblIndexAttribute => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateVtblIndexAttribute);
 
+        public bool GenerateSourceLocationAttribute => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+
         public string MethodClassName { get; }
 
         public string MethodPrefixToStrip { get;}

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
@@ -7,57 +7,57 @@ namespace ClangSharp
     [Flags]
     public enum PInvokeGeneratorConfigurationOptions
     {
-        None = 0x00000000,
+        None = 0,
 
-        GenerateMultipleFiles = 0x00000001,
+        GenerateMultipleFiles = 1 << 0,
 
-        GenerateUnixTypes = 0x00000002,
+        GenerateUnixTypes = 1 << 1,
 
-        NoDefaultRemappings = 0x00000004,
+        NoDefaultRemappings = 1 << 2,
 
-        GenerateCompatibleCode = 0x00000008,
+        GenerateCompatibleCode = 1 << 3,
 
-        ExcludeNIntCodegen = 0x00000010,
+        ExcludeNIntCodegen = 1 << 4,
 
-        ExcludeFnptrCodegen = 0x00000020,
+        ExcludeFnptrCodegen = 1 << 5,
 
-        LogExclusions = 0x00000040,
+        LogExclusions = 1 << 6,
 
-        LogVisitedFiles = 0x00000080,
+        LogVisitedFiles = 1 << 7,
 
-        GenerateExplicitVtbls = 0x00000100,
+        GenerateExplicitVtbls = 1 << 8,
 
-        GenerateTestsNUnit = 0x00000200,
+        GenerateTestsNUnit = 1 << 9,
 
-        GenerateTestsXUnit = 0x00000400,
+        GenerateTestsXUnit = 1 << 10,
 
-        GenerateMacroBindings = 0x00000800,
+        GenerateMacroBindings = 1 << 11,
 
-        ExcludeComProxies = 0x00001000,
+        ExcludeComProxies = 1 << 12,
 
-        ExcludeEmptyRecords = 0x00002000,
+        ExcludeEmptyRecords = 1 << 13,
 
-        ExcludeEnumOperators = 0x00004000,
+        ExcludeEnumOperators = 1 << 14,
 
-        GenerateAggressiveInlining = 0x00008000,
+        GenerateAggressiveInlining = 1 << 15,
 
-        ExcludeFunctionsWithBody = 0x00010000,
+        ExcludeFunctionsWithBody = 1 << 16,
 
-        ExcludeAnonymousFieldHelpers = 0x00020000,
+        ExcludeAnonymousFieldHelpers = 1 << 17,
 
-        LogPotentialTypedefRemappings = 0x00040000,
+        LogPotentialTypedefRemappings = 1 << 18,
 
-        GenerateCppAttributes = 0x00080000,
+        GenerateCppAttributes = 1 << 19,
 
-        GenerateNativeInheritanceAttribute = 0x00100000,
+        GenerateNativeInheritanceAttribute = 1 << 20,
 
-        DontUseUsingStaticsForEnums = 0x00200000,
+        DontUseUsingStaticsForEnums = 1 << 21,
 
-        GenerateVtblIndexAttribute = 0x00400000,
+        GenerateVtblIndexAttribute = 1 << 22,
 
-        GeneratePreviewCode = 0x00800000,
+        GeneratePreviewCode = 1 << 23,
 
-        GenerateTemplateBindings = 0x01000000,
+        GenerateTemplateBindings = 1 << 24,
 
         GenerateSourceLocationAttribute = 1 << 25,
     }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
@@ -58,5 +58,7 @@ namespace ClangSharp
         GeneratePreviewCode = 0x00800000,
 
         GenerateTemplateBindings = 0x01000000,
+
+        GenerateSourceLocationAttribute = 1 << 25,
     }
 }

--- a/sources/ClangSharp.PInvokeGenerator/XML/XmlOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/XmlOutputBuilder.VisitDecl.cs
@@ -37,10 +37,10 @@ namespace ClangSharp.XML
         public void EndConstantValue() => _sb.Append("</value>");
         public void EndConstant(bool isConstant) => _sb.Append(isConstant ? "</constant>" : "</enumerator>");
 
-        public void BeginEnum(AccessSpecifier accessSpecifier, string typeName, string escapedName, string nativeTypeName)
+        public void BeginEnum(in EnumDesc desc)
         {
-            _ = _sb.Append($"<enumeration name=\"{escapedName}\" access=\"{accessSpecifier.AsString()}\">");
-            _ = _sb.Append($"<type>{typeName}</type>");
+            _ = _sb.Append($"<enumeration name=\"{desc.EscapedName}\" access=\"{desc.AccessSpecifier.AsString()}\">");
+            _ = _sb.Append($"<type>{desc.TypeName}</type>");
         }
 
         public void EndEnum() => _sb.Append("</enumeration>");

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/FunctionDeclarationDllImportTest.cs
@@ -69,5 +69,8 @@ namespace ClangSharp.UnitTests
 
         [Fact]
         public abstract Task WithSetLastErrorStarTest();
+
+        [Fact]
+        public abstract Task SourceLocationTest();
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/StructDeclarationTest.cs
@@ -199,5 +199,8 @@ namespace ClangSharp.UnitTests
 
         [Fact]
         public abstract Task UsingDeclarationTest();
+
+        [Fact]
+        public abstract Task SourceLocationAttributeTest();
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/FunctionDeclarationDllImportTest.cs
@@ -345,5 +345,25 @@ namespace ClangSharp.Test
             };
             return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents, withSetLastErrors: withSetLastErrors);
         }
+
+        public override Task SourceLocationTest()
+        {
+            const string InputContents = @"void MyFunction(float value);";
+
+            const string ExpectedOutputContents = @"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [SourceLocation(""ClangUnsavedFile.h"", 1, 6)]
+        public static extern void MyFunction([SourceLocation(""ClangUnsavedFile.h"", 1, 23)] float value);
+    }
+}
+";
+
+            return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/StructDeclarationTest.cs
@@ -1556,5 +1556,35 @@ struct MyStruct1B : MyStruct1A
 
             return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
         }
+
+        public override Task SourceLocationAttributeTest()
+        {
+            const string InputContents = @"struct MyStruct
+{
+    int r;
+    int g;
+    int b;
+};
+";
+
+            const string ExpectedOutputContents = @"namespace ClangSharp.Test
+{
+    [SourceLocation(""ClangUnsavedFile.h"", 1, 8)]
+    public partial struct MyStruct
+    {
+        [SourceLocation(""ClangUnsavedFile.h"", 3, 9)]
+        public int r;
+
+        [SourceLocation(""ClangUnsavedFile.h"", 4, 9)]
+        public int g;
+
+        [SourceLocation(""ClangUnsavedFile.h"", 5, 9)]
+        public int b;
+    }
+}
+";
+
+            return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/FunctionDeclarationDllImportTest.cs
@@ -345,5 +345,25 @@ namespace ClangSharp.Test
             };
             return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents, withSetLastErrors: withSetLastErrors);
         }
+
+        public override Task SourceLocationTest()
+        {
+            const string InputContents = @"void MyFunction(float value);";
+
+            const string ExpectedOutputContents = @"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [SourceLocation(""ClangUnsavedFile.h"", 1, 6)]
+        public static extern void MyFunction([SourceLocation(""ClangUnsavedFile.h"", 1, 23)] float value);
+    }
+}
+";
+
+            return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/StructDeclarationTest.cs
@@ -1560,5 +1560,35 @@ struct MyStruct1B : MyStruct1A
 
             return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
         }
+
+        public override Task SourceLocationAttributeTest()
+        {
+            const string InputContents = @"struct MyStruct
+{
+    int r;
+    int g;
+    int b;
+};
+";
+
+            const string ExpectedOutputContents = @"namespace ClangSharp.Test
+{
+    [SourceLocation(""ClangUnsavedFile.h"", 1, 8)]
+    public partial struct MyStruct
+    {
+        [SourceLocation(""ClangUnsavedFile.h"", 3, 9)]
+        public int r;
+
+        [SourceLocation(""ClangUnsavedFile.h"", 4, 9)]
+        public int g;
+
+        [SourceLocation(""ClangUnsavedFile.h"", 5, 9)]
+        public int b;
+    }
+}
+";
+
+            return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/FunctionDeclarationDllImportTest.cs
@@ -344,5 +344,25 @@ namespace ClangSharp.Test
             };
             return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents, withSetLastErrors: withSetLastErrors);
         }
+
+        public override Task SourceLocationTest()
+        {
+            const string InputContents = @"void MyFunction(float value);";
+
+            const string ExpectedOutputContents = @"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [SourceLocation(""ClangUnsavedFile.h"", 1, 6)]
+        public static extern void MyFunction([SourceLocation(""ClangUnsavedFile.h"", 1, 23)] float value);
+    }
+}
+";
+
+            return ValidateGeneratedCSharpLatestUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/StructDeclarationTest.cs
@@ -1535,5 +1535,35 @@ struct MyStruct1B : MyStruct1A
 
             return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents);
         }
+
+        public override Task SourceLocationAttributeTest()
+        {
+            const string InputContents = @"struct MyStruct
+{
+    int r;
+    int g;
+    int b;
+};
+";
+
+            const string ExpectedOutputContents = @"namespace ClangSharp.Test
+{
+    [SourceLocation(""ClangUnsavedFile.h"", 1, 8)]
+    public partial struct MyStruct
+    {
+        [SourceLocation(""ClangUnsavedFile.h"", 3, 9)]
+        public int r;
+
+        [SourceLocation(""ClangUnsavedFile.h"", 4, 9)]
+        public int g;
+
+        [SourceLocation(""ClangUnsavedFile.h"", 5, 9)]
+        public int b;
+    }
+}
+";
+
+            return ValidateGeneratedCSharpLatestUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/FunctionDeclarationDllImportTest.cs
@@ -344,5 +344,25 @@ namespace ClangSharp.Test
             };
             return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, withSetLastErrors: withSetLastErrors);
         }
+
+        public override Task SourceLocationTest()
+        {
+            const string InputContents = @"void MyFunction(float value);";
+
+            const string ExpectedOutputContents = @"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [SourceLocation(""ClangUnsavedFile.h"", 1, 6)]
+        public static extern void MyFunction([SourceLocation(""ClangUnsavedFile.h"", 1, 23)] float value);
+    }
+}
+";
+
+            return ValidateGeneratedCSharpLatestWindowsBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/StructDeclarationTest.cs
@@ -1539,5 +1539,35 @@ struct MyStruct1B : MyStruct1A
 
             return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
         }
+
+        public override Task SourceLocationAttributeTest()
+        {
+            const string InputContents = @"struct MyStruct
+{
+    int r;
+    int g;
+    int b;
+};
+";
+
+            const string ExpectedOutputContents = @"namespace ClangSharp.Test
+{
+    [SourceLocation(""ClangUnsavedFile.h"", 1, 8)]
+    public partial struct MyStruct
+    {
+        [SourceLocation(""ClangUnsavedFile.h"", 3, 9)]
+        public int r;
+
+        [SourceLocation(""ClangUnsavedFile.h"", 4, 9)]
+        public int g;
+
+        [SourceLocation(""ClangUnsavedFile.h"", 5, 9)]
+        public int b;
+    }
+}
+";
+
+            return ValidateGeneratedCSharpLatestWindowsBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/FunctionDeclarationDllImportTest.cs
@@ -395,5 +395,27 @@ struct MyStruct
             };
             return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents, withSetLastErrors: withSetLastErrors);
         }
+
+        public override Task SourceLocationTest()
+        {
+            const string InputContents = @"void MyFunction(float value);";
+
+            const string ExpectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"">
+      <function name=""MyFunction"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""Cdecl"" static=""true"">
+        <type>void</type>
+        <param name=""value"">
+          <type>float</type>
+        </param>
+      </function>
+    </class>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlCompatibleUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/StructDeclarationTest.cs
@@ -1555,5 +1555,36 @@ struct MyStruct1B : MyStruct1A
 
             return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
         }
+
+        public override Task SourceLocationAttributeTest()
+        {
+            const string InputContents = @"struct MyStruct
+{
+    int r;
+    int g;
+    int b;
+};
+";
+
+            const string ExpectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"">
+      <field name=""r"" access=""public"">
+        <type>int</type>
+      </field>
+      <field name=""g"" access=""public"">
+        <type>int</type>
+      </field>
+      <field name=""b"" access=""public"">
+        <type>int</type>
+      </field>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlCompatibleUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/FunctionDeclarationDllImportTest.cs
@@ -395,5 +395,27 @@ struct MyStruct
             };
             return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents, withSetLastErrors: withSetLastErrors);
         }
+
+        public override Task SourceLocationTest()
+        {
+            const string InputContents = @"void MyFunction(float value);";
+
+            const string ExpectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"">
+      <function name=""MyFunction"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""Cdecl"" static=""true"">
+        <type>void</type>
+        <param name=""value"">
+          <type>float</type>
+        </param>
+      </function>
+    </class>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/StructDeclarationTest.cs
@@ -1561,5 +1561,36 @@ struct MyStruct1B : MyStruct1A
 
             return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
         }
+
+        public override Task SourceLocationAttributeTest()
+        {
+            const string InputContents = @"struct MyStruct
+{
+    int r;
+    int g;
+    int b;
+};
+";
+
+            const string ExpectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"">
+      <field name=""r"" access=""public"">
+        <type>int</type>
+      </field>
+      <field name=""g"" access=""public"">
+        <type>int</type>
+      </field>
+      <field name=""b"" access=""public"">
+        <type>int</type>
+      </field>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/FunctionDeclarationDllImportTest.cs
@@ -395,5 +395,27 @@ struct MyStruct
             };
             return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents, withSetLastErrors: withSetLastErrors);
         }
+
+        public override Task SourceLocationTest()
+        {
+            const string InputContents = @"void MyFunction(float value);";
+
+            const string ExpectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"">
+      <function name=""MyFunction"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""Cdecl"" static=""true"">
+        <type>void</type>
+        <param name=""value"">
+          <type>float</type>
+        </param>
+      </function>
+    </class>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlLatestUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/StructDeclarationTest.cs
@@ -1536,5 +1536,36 @@ struct MyStruct1B : MyStruct1A
 
             return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents);
         }
+
+        public override Task SourceLocationAttributeTest()
+        {
+            const string InputContents = @"struct MyStruct
+{
+    int r;
+    int g;
+    int b;
+};
+";
+
+            const string ExpectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"">
+      <field name=""r"" access=""public"">
+        <type>int</type>
+      </field>
+      <field name=""g"" access=""public"">
+        <type>int</type>
+      </field>
+      <field name=""b"" access=""public"">
+        <type>int</type>
+      </field>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlLatestUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/FunctionDeclarationDllImportTest.cs
@@ -395,5 +395,27 @@ struct MyStruct
             };
             return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents, withSetLastErrors: withSetLastErrors);
         }
+
+        public override Task SourceLocationTest()
+        {
+            const string InputContents = @"void MyFunction(float value);";
+
+            const string ExpectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"">
+      <function name=""MyFunction"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""Cdecl"" static=""true"">
+        <type>void</type>
+        <param name=""value"">
+          <type>float</type>
+        </param>
+      </function>
+    </class>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlLatestWindowsBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/StructDeclarationTest.cs
@@ -1542,5 +1542,36 @@ struct MyStruct1B : MyStruct1A
 
             return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
         }
+
+        public override Task SourceLocationAttributeTest()
+        {
+            const string InputContents = @"struct MyStruct
+{
+    int r;
+    int g;
+    int b;
+};
+";
+
+            const string ExpectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"">
+      <field name=""r"" access=""public"">
+        <type>int</type>
+      </field>
+      <field name=""g"" access=""public"">
+        <type>int</type>
+      </field>
+      <field name=""b"" access=""public"">
+        <type>int</type>
+      </field>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlLatestWindowsBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+        }
     }
 }


### PR DESCRIPTION
Not currently exposed, but can easily be plumbed as opt-in command line option. Note, that not all Desc items have Location attribute set, since for some it doesn't make any sense.