### PR TITLE
Be explicit on which symbols are exported

### DIFF
--- a/sources/libClangSharp/CMakeLists.txt
+++ b/sources/libClangSharp/CMakeLists.txt
@@ -1,3 +1,9 @@
+include(GenerateExportHeader)
+
+set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
+set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
 set(SOURCES
   CIndexDiagnostic.cpp
   ClangSharp.cpp
@@ -40,10 +46,20 @@ else()
 endif()
 
 target_include_directories(ClangSharp PRIVATE ${CLANG_INCLUDE_DIRS})
+
 set_target_properties(ClangSharp PROPERTIES
     PREFIX lib
     VERSION ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION}
+)
+
+generate_export_header(ClangSharp
+    EXPORT_MACRO_NAME "CLANGSHARP_LINKAGE"
+    EXPORT_FILE_NAME ClangSharp_export.h
+)
+
+set_property(TARGET ClangSharp APPEND PROPERTY
+    PUBLIC_HEADER ClangSharp.h "${CMAKE_CURRENT_BINARY_DIR}/ClangSharp_export.h"
 )
 
 include(GNUInstallDirs)
@@ -52,4 +68,5 @@ install(TARGETS ClangSharp
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT development
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT runtime
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT development
 )

--- a/sources/libClangSharp/ClangSharp.h
+++ b/sources/libClangSharp/ClangSharp.h
@@ -17,24 +17,12 @@
 #include <clang/AST/StmtObjC.h>
 #include <clang/AST/VTableBuilder.h>
 #include <clang/Basic/Specifiers.h>
+#include <clang-c/ExternC.h>
 #include <clang-c/Index.h>
 
 #pragma warning(pop)
 
-#ifdef __cplusplus
-#define EXTERN_C extern "C"
-#else
-#define EXTERN_C
-#endif
-
-#ifdef _MSC_VER
-// We always export functions on Windows as this library
-// isn't meant to be consumed by other native code
-#define CLANGSHARP_LINKAGE EXTERN_C __declspec(dllexport)
-#else
-// Not necessary outside MSVC
-#define CLANGSHARP_LINKAGE EXTERN_C
-#endif
+#include "ClangSharp_export.h"
 
 enum CX_AtomicOperatorKind {
     CX_AO_Invalid,
@@ -220,6 +208,7 @@ struct CX_TemplateName {
     CXTranslationUnit tu;
 };
 
+LLVM_CLANG_C_EXTERN_C_BEGIN
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getArgument(CXCursor C, unsigned i);
 
 CLANGSHARP_LINKAGE CXType clangsharp_Cursor_getArgumentType(CXCursor C);
@@ -839,5 +828,6 @@ CLANGSHARP_LINKAGE CX_TypeClass clangsharp_Type_getTypeClass(CXType CT);
 CLANGSHARP_LINKAGE CXCursor clangsharp_Type_getUnderlyingExpr(CXType CT);
 
 CLANGSHARP_LINKAGE CXType clangsharp_Type_getUnderlyingType(CXType CT);
+LLVM_CLANG_C_EXTERN_C_END
 
 #endif


### PR DESCRIPTION
Instead of exporting every symbol from non-MSVC builds, use CMake
to generate export macro and hide everything by default. Also install
the header files.