### PR TITLE
Single quote must be escaped otherwise ''' is generated instead of '\''.

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -664,10 +664,11 @@ namespace ClangSharp
         internal static string EscapeCharacter(char value) => EscapeString(value.ToString());
 
         internal static string EscapeString(string value) => value.Replace("\\", "\\\\")
-                                                                 .Replace("\r", "\\r")
-                                                                 .Replace("\n", "\\n")
-                                                                 .Replace("\t", "\\t")
-                                                                 .Replace("\"", "\\\"");
+                                                                  .Replace("\r", "\\r")
+                                                                  .Replace("\n", "\\n")
+                                                                  .Replace("\t", "\\t")
+                                                                  .Replace("\"", "\\\"")
+                                                                  .Replace("\'", "\\'");
 
         private AccessSpecifier GetAccessSpecifier(NamedDecl namedDecl)
         {


### PR DESCRIPTION
Single quote must be escaped otherwise ''' is generated instead of '\\'' which results in a compiler error (e.g.: CS1011, C1012, etc.).

For example, the current version generates the following code for SDL_keycode.h:
<pre>
public enum SDL_KeyCode
{
    SDLK_QUOTE = (byte)(''')
}
</pre>
instead of 
<pre>
public enum SDL_KeyCode
{
    SDLK_QUOTE = (byte)('\'')
}
</pre>
