### PR TITLE
Ensure that the record packing and calling convention are correct regardless of -m32 or -m64

### DIFF
--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -61,17 +61,3 @@ jobs:
     configuration: Release
     architecture: x64
     OVERRIDE_RUNTIME_IDENTIFIER: ubuntu.18.04-x64
-
-- template: azure-unix.yml
-  parameters:
-    name: macos_debug_x64
-    pool: macOS-latest
-    configuration: Debug
-    architecture: x64
-
-- template: azure-unix.yml
-  parameters:
-    name: macos_release_x64
-    pool: macOS-latest
-    configuration: Release
-    architecture: x64

--- a/sources/ClangSharp.PInvokeGenerator/Abstractions/StructDesc.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Abstractions/StructDesc.cs
@@ -63,9 +63,9 @@ namespace ClangSharp.Abstractions
                 {
                     Debug.Assert(layout.Kind == LayoutKind.Explicit);
 
-                    StructLayoutAttribute attribute = new(layout.Kind);
+                    var attribute = new StructLayoutAttribute(layout.Kind);
 
-                    if (layout.Pack < layout.MaxFieldAlignment)
+                    if (layout.Pack != 0)
                     {
                         attribute.Pack = (int)layout.Pack;
                     }
@@ -73,9 +73,11 @@ namespace ClangSharp.Abstractions
                     return attribute;
                 }
 
-                if (layout.Pack < layout.MaxFieldAlignment)
+                if (layout.Pack != 0)
                 {
-                    return new StructLayoutAttribute(layout.Kind) {Pack = (int)layout.Pack};
+                    return new StructLayoutAttribute(layout.Kind) {
+                        Pack = (int)layout.Pack
+                    };
                 }
 
                 return null;

--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
@@ -433,15 +433,16 @@ namespace ClangSharp.CSharp
 
         public void BeginStruct<TCustomAttrGeneratorData>(in StructDesc<TCustomAttrGeneratorData> info)
         {
-            if (info.LayoutAttribute is { } attribute)
+            if (info.LayoutAttribute is not null)
             {
                 AddUsingDirective("System.Runtime.InteropServices");
                 WriteIndented("[StructLayout(LayoutKind.");
-                Write(attribute.Value);
-                if (attribute.Pack != default)
+                Write(info.LayoutAttribute.Value);
+
+                if (info.LayoutAttribute.Pack != 0)
                 {
                     Write(", Pack = ");
-                    Write(attribute.Pack);
+                    Write(info.LayoutAttribute.Pack);
                 }
 
                 WriteLine(")]");

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -455,11 +455,11 @@ namespace ClangSharp
             var callingConventionName = GetCallingConvention(functionDecl, cxxRecordDecl, type);
 
             var isDllImport = body is null && !isVirtual;
-            var entryPoint = isDllImport ? functionDecl.Handle.Mangling.CString : null;
+            var entryPoint = "";
 
-            if (entryPoint == $"_{functionDecl.Name}")
+            if (isDllImport)
             {
-                entryPoint = functionDecl.Name;
+                entryPoint = functionDecl.IsExternC ? GetCursorName(functionDecl) : functionDecl.Handle.Mangling.CString;
             }
 
             var needsReturnFixup = isVirtual && NeedsReturnFixup(cxxMethodDecl);
@@ -1151,7 +1151,7 @@ namespace ClangSharp
                         Alignment64 = alignment64,
                         Size32 = size32,
                         Size64 = size64,
-                        Pack = alignment,
+                        Pack = recordDecl.HasAttrs && recordDecl.Attrs.Any((attr) => attr.Kind == CX_AttrKind.CX_AttrKind_MaxFieldAlignment) && ((alignment != alignment32) || (alignment != alignment64)) ? alignment : 0,
                         MaxFieldAlignment = maxAlignm,
                         Kind = layoutKind
                     },
@@ -2201,7 +2201,7 @@ namespace ClangSharp
                         Alignment64 = alignment64,
                         Size32 = size32,
                         Size64 = size64,
-                        Pack = alignment,
+                        Pack = recordDecl.HasAttrs && recordDecl.Attrs.Any((attr) => attr.Kind == CX_AttrKind.CX_AttrKind_MaxFieldAlignment) && ((alignment != alignment32) || (alignment != alignment64)) ? alignment : 0,
                         MaxFieldAlignment = maxAlignm,
                         Kind = LayoutKind.Sequential
                     },

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -877,6 +877,10 @@ namespace ClangSharp
                 {
                     case CXCallingConv.CXCallingConv_C:
                     {
+                        if ((cursor is CXXMethodDecl cxxMethodDecl) && cxxMethodDecl.IsInstance)
+                        {
+                            return CallingConvention.ThisCall;
+                        }
                         return CallingConvention.Cdecl;
                     }
 

--- a/sources/ClangSharp.PInvokeGenerator/XML/XmlOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/XmlOutputBuilder.VisitDecl.cs
@@ -248,15 +248,16 @@ namespace ClangSharp.XML
                 _ = _sb.Append(" unsafe=\"true\"");
             }
 
-            if (info.LayoutAttribute is { } attribute)
+            if (info.LayoutAttribute is not null)
             {
                 _ = _sb.Append(" layout=\"");
-                _ = _sb.Append(attribute.Value);
+                _ = _sb.Append(info.LayoutAttribute.Value);
                 _ = _sb.Append('"');
-                if (attribute.Pack != default)
+
+                if (info.LayoutAttribute.Pack != 0)
                 {
                     _ = _sb.Append(" pack=\"");
-                    _ = _sb.Append(attribute.Pack);
+                    _ = _sb.Append(info.LayoutAttribute.Pack);
                     _ = _sb.Append('"');
                 }
             }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/StructDeclarationTest.cs
@@ -154,6 +154,9 @@ namespace ClangSharp.UnitTests
         public abstract Task NoDefinitionTest();
 
         [Fact]
+        public abstract Task PackTest();
+
+        [Fact]
         public abstract Task PointerToSelfTest();
 
         [Fact]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -164,14 +164,12 @@ namespace ClangSharp.UnitTests
     }
 };
 ";
-            var callConv = "Cdecl";
             var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "__ZN8MyStruct12MyVoidMethodEv" : "_ZN8MyStruct12MyVoidMethodEv";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 if (!Environment.Is64BitProcess)
                 {
-                    callConv = "ThisCall";
                     entryPoint = "?MyVoidMethod@MyStruct@@QAEXXZ";
                 }
                 else
@@ -186,7 +184,7 @@ namespace ClangSharp.Test
 {{
     public partial struct MyStruct
     {{
-        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.{callConv}, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
         public static extern void MyVoidMethod();
 
         public int MyInt32Method()
@@ -417,13 +415,6 @@ int MyFunctionB(MyStruct* x)
     virtual int GetType(int objA, int objB) = 0;
 };";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "ThisCall";
-            }
-
             var expectedOutputContents = $@"using System;
 using System.Runtime.InteropServices;
 
@@ -433,13 +424,13 @@ namespace ClangSharp.Test
     {{
         public void** lpVtbl;
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate int _GetType(MyStruct* pThis, int obj);
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate int _GetType1(MyStruct* pThis);
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate int _GetType2(MyStruct* pThis, int objA, int objB);
 
         public int GetType(int obj)
@@ -481,12 +472,10 @@ namespace ClangSharp.Test
     virtual int GetType(int objA, int objB) = 0;
 };";
 
-            var callConv = "Cdecl";
             var nativeCallConv = "";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
             {
-                callConv = "ThisCall";
                 nativeCallConv = " __attribute__((thiscall))";
             }
 
@@ -499,13 +488,13 @@ namespace ClangSharp.Test
     {{
         public Vtbl* lpVtbl;
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate int _GetType(MyStruct* pThis, int obj);
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate int _GetType1(MyStruct* pThis);
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate int _GetType2(MyStruct* pThis, int objA, int objB);
 
         public int GetType(int obj)
@@ -806,13 +795,6 @@ namespace ClangSharp.Test
 };
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "ThisCall";
-            }
-
             var expectedOutputContents = $@"using System;
 using System.Runtime.InteropServices;
 
@@ -822,17 +804,17 @@ namespace ClangSharp.Test
     {{
         public void** lpVtbl;
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate void _MyVoidMethod(MyStruct* pThis);
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         [return: NativeTypeName(""char"")]
         public delegate sbyte _MyInt8Method(MyStruct* pThis);
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate int _MyInt32Method(MyStruct* pThis);
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate void* _MyVoidStarMethod(MyStruct* pThis);
 
         public void MyVoidMethod()
@@ -891,13 +873,6 @@ namespace ClangSharp.Test
 };
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "ThisCall";
-            }
-
             var expectedOutputContents = $@"using System;
 using System.Runtime.InteropServices;
 
@@ -907,17 +882,17 @@ namespace ClangSharp.Test
     {{
         public void** lpVtbl;
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate void _MyVoidMethod(MyStruct* pThis);
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         [return: NativeTypeName(""char"")]
         public delegate sbyte _MyInt8Method(MyStruct* pThis);
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate int _MyInt32Method(MyStruct* pThis);
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate void* _MyVoidStarMethod(MyStruct* pThis);
 
         [VtblIndex(0)]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/FunctionDeclarationBodyImportTest.cs
@@ -495,13 +495,6 @@ MyStructB* MyFunction(MyStructA* input)
 }
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "ThisCall";
-            }
-
             var expectedOutputContents = $@"using System;
 using System.Runtime.InteropServices;
 
@@ -511,7 +504,7 @@ namespace ClangSharp.Test
     {{
         public void** lpVtbl;
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate void _MyMethod(MyStructA* pThis);
 
         public void MyMethod()
@@ -528,7 +521,7 @@ namespace ClangSharp.Test
     {{
         public void** lpVtbl;
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate void _MyMethod(MyStructB* pThis);
 
         public void MyMethod()

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/StructDeclarationTest.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace ClangSharp.UnitTests
 {
@@ -1299,6 +1300,59 @@ namespace ClangSharp.Test
 }}
 ";
             return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
+
+        public override Task PackTest()
+        {
+            const string InputContents = @"struct MyStruct1 {
+    unsigned Field1;
+
+    void* Field2;
+
+    unsigned Field3;
+};
+
+#pragma pack(4)
+
+struct MyStruct2 {
+    unsigned Field1;
+
+    void* Field2;
+
+    unsigned Field3;
+};
+";
+
+            const string ExpectedOutputContents = @"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct MyStruct1
+    {
+        [NativeTypeName(""unsigned int"")]
+        public uint Field1;
+
+        public void* Field2;
+
+        [NativeTypeName(""unsigned int"")]
+        public uint Field3;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public unsafe partial struct MyStruct2
+    {
+        [NativeTypeName(""unsigned int"")]
+        public uint Field1;
+
+        public void* Field2;
+
+        [NativeTypeName(""unsigned int"")]
+        public uint Field3;
+    }
+}
+";
+
+            return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(InputContents, ExpectedOutputContents);
         }
 
         public override Task PointerToSelfTest()

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/UnionDeclarationTest.cs
@@ -133,13 +133,12 @@ union MyUnion3
     unsigned int o0_b1_1 : 1;
 };
 ";
-            var expectedPack = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ", Pack = 1" : "";
 
             var expectedOutputContents = $@"using System.Runtime.InteropServices;
 
 namespace ClangSharp.Test
 {{
-    [StructLayout(LayoutKind.Explicit{expectedPack})]
+    [StructLayout(LayoutKind.Explicit)]
     public partial struct MyUnion1
     {{
         [FieldOffset(0)]
@@ -288,7 +287,7 @@ namespace ClangSharp.Test
         }}
     }}
 
-    [StructLayout(LayoutKind.Explicit{expectedPack})]
+    [StructLayout(LayoutKind.Explicit)]
     public partial struct MyUnion3
     {{
         [FieldOffset(0)]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -164,14 +164,12 @@ namespace ClangSharp.UnitTests
     }
 };
 ";
-            var callConv = "Cdecl";
             var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "__ZN8MyStruct12MyVoidMethodEv" : "_ZN8MyStruct12MyVoidMethodEv";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 if (!Environment.Is64BitProcess)
                 {
-                    callConv = "ThisCall";
                     entryPoint = "?MyVoidMethod@MyStruct@@QAEXXZ";
                 }
                 else
@@ -186,7 +184,7 @@ namespace ClangSharp.Test
 {{
     public partial struct MyStruct
     {{
-        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.{callConv}, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
         public static extern void MyVoidMethod();
 
         public int MyInt32Method()
@@ -417,13 +415,6 @@ int MyFunctionB(MyStruct* x)
     virtual int GetType(int objA, int objB) = 0;
 };";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "ThisCall";
-            }
-
             var expectedOutputContents = $@"using System;
 using System.Runtime.InteropServices;
 
@@ -433,13 +424,13 @@ namespace ClangSharp.Test
     {{
         public void** lpVtbl;
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate int _GetType(MyStruct* pThis, int obj);
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate int _GetType1(MyStruct* pThis);
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate int _GetType2(MyStruct* pThis, int objA, int objB);
 
         public int GetType(int obj)
@@ -481,12 +472,10 @@ namespace ClangSharp.Test
     virtual int GetType(int objA, int objB) = 0;
 };";
 
-            var callConv = "Cdecl";
             var nativeCallConv = "";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
             {
-                callConv = "ThisCall";
                 nativeCallConv = " __attribute__((thiscall))";
             }
 
@@ -499,13 +488,13 @@ namespace ClangSharp.Test
     {{
         public Vtbl* lpVtbl;
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate int _GetType(MyStruct* pThis, int obj);
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate int _GetType1(MyStruct* pThis);
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate int _GetType2(MyStruct* pThis, int objA, int objB);
 
         public int GetType(int obj)
@@ -806,13 +795,6 @@ namespace ClangSharp.Test
 };
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "ThisCall";
-            }
-
             var expectedOutputContents = $@"using System;
 using System.Runtime.InteropServices;
 
@@ -822,17 +804,17 @@ namespace ClangSharp.Test
     {{
         public void** lpVtbl;
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate void _MyVoidMethod(MyStruct* pThis);
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         [return: NativeTypeName(""char"")]
         public delegate sbyte _MyInt8Method(MyStruct* pThis);
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate int _MyInt32Method(MyStruct* pThis);
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate void* _MyVoidStarMethod(MyStruct* pThis);
 
         public void MyVoidMethod()
@@ -891,13 +873,6 @@ namespace ClangSharp.Test
 };
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "ThisCall";
-            }
-
             var expectedOutputContents = $@"using System;
 using System.Runtime.InteropServices;
 
@@ -907,17 +882,17 @@ namespace ClangSharp.Test
     {{
         public void** lpVtbl;
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate void _MyVoidMethod(MyStruct* pThis);
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         [return: NativeTypeName(""char"")]
         public delegate sbyte _MyInt8Method(MyStruct* pThis);
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate int _MyInt32Method(MyStruct* pThis);
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate void* _MyVoidStarMethod(MyStruct* pThis);
 
         [VtblIndex(0)]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/FunctionDeclarationBodyImportTest.cs
@@ -495,13 +495,6 @@ MyStructB* MyFunction(MyStructA* input)
 }
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "ThisCall";
-            }
-
             var expectedOutputContents = $@"using System;
 using System.Runtime.InteropServices;
 
@@ -511,7 +504,7 @@ namespace ClangSharp.Test
     {{
         public void** lpVtbl;
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate void _MyMethod(MyStructA* pThis);
 
         public void MyMethod()
@@ -528,7 +521,7 @@ namespace ClangSharp.Test
     {{
         public void** lpVtbl;
 
-        [UnmanagedFunctionPointer(CallingConvention.{callConv})]
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         public delegate void _MyMethod(MyStructB* pThis);
 
         public void MyMethod()

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/StructDeclarationTest.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace ClangSharp.UnitTests
 {
@@ -1303,6 +1304,59 @@ namespace ClangSharp.Test
 }}
 ";
             return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
+
+        public override Task PackTest()
+        {
+            const string InputContents = @"struct MyStruct1 {
+    unsigned Field1;
+
+    void* Field2;
+
+    unsigned Field3;
+};
+
+#pragma pack(4)
+
+struct MyStruct2 {
+    unsigned Field1;
+
+    void* Field2;
+
+    unsigned Field3;
+};
+";
+
+            const string ExpectedOutputContents = @"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct MyStruct1
+    {
+        [NativeTypeName(""unsigned int"")]
+        public uint Field1;
+
+        public void* Field2;
+
+        [NativeTypeName(""unsigned int"")]
+        public uint Field3;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public unsafe partial struct MyStruct2
+    {
+        [NativeTypeName(""unsigned int"")]
+        public uint Field1;
+
+        public void* Field2;
+
+        [NativeTypeName(""unsigned int"")]
+        public uint Field3;
+    }
+}
+";
+
+            return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(InputContents, ExpectedOutputContents);
         }
 
         public override Task PointerToSelfTest()

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/UnionDeclarationTest.cs
@@ -134,13 +134,11 @@ union MyUnion3
 };
 ";
 
-            var expectedPack = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ", Pack = 1" : "";
-
             var expectedOutputContents = $@"using System.Runtime.InteropServices;
 
 namespace ClangSharp.Test
 {{
-    [StructLayout(LayoutKind.Explicit{expectedPack})]
+    [StructLayout(LayoutKind.Explicit)]
     public partial struct MyUnion1
     {{
         [FieldOffset(0)]
@@ -295,7 +293,7 @@ namespace ClangSharp.Test
         }}
     }}
 
-    [StructLayout(LayoutKind.Explicit{expectedPack})]
+    [StructLayout(LayoutKind.Explicit)]
     public partial struct MyUnion3
     {{
         [FieldOffset(0)]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
@@ -164,14 +164,12 @@ namespace ClangSharp.UnitTests
     }
 };
 ";
-            var callConv = "Cdecl";
             var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "__ZN8MyStruct12MyVoidMethodEv" : "_ZN8MyStruct12MyVoidMethodEv";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 if (!Environment.Is64BitProcess)
                 {
-                    callConv = "ThisCall";
                     entryPoint = "?MyVoidMethod@MyStruct@@QAEXXZ";
                 }
                 else
@@ -186,7 +184,7 @@ namespace ClangSharp.Test
 {{
     public partial struct MyStruct
     {{
-        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.{callConv}, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
         public static extern void MyVoidMethod();
 
         public int MyInt32Method()
@@ -417,13 +415,6 @@ int MyFunctionB(MyStruct* x)
     virtual int GetType(int objA, int objB) = 0;
 };";
 
-            var callConv = "Cdecl";
-            
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "Thiscall";
-            }
-
             var expectedOutputContents = $@"using System.Runtime.CompilerServices;
 
 namespace ClangSharp.Test
@@ -434,17 +425,17 @@ namespace ClangSharp.Test
 
         public int GetType(int obj)
         {{
-            return ((delegate* unmanaged[{callConv}]<MyStruct*, int, int>)(lpVtbl[{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 2 : 0)}]))((MyStruct*)Unsafe.AsPointer(ref this), obj);
+            return ((delegate* unmanaged[Thiscall]<MyStruct*, int, int>)(lpVtbl[{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 2 : 0)}]))((MyStruct*)Unsafe.AsPointer(ref this), obj);
         }}
 
         public new int GetType()
         {{
-            return ((delegate* unmanaged[{callConv}]<MyStruct*, int>)(lpVtbl[1]))((MyStruct*)Unsafe.AsPointer(ref this));
+            return ((delegate* unmanaged[Thiscall]<MyStruct*, int>)(lpVtbl[1]))((MyStruct*)Unsafe.AsPointer(ref this));
         }}
 
         public int GetType(int objA, int objB)
         {{
-            return ((delegate* unmanaged[{callConv}]<MyStruct*, int, int, int>)(lpVtbl[{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 0 : 2)}]))((MyStruct*)Unsafe.AsPointer(ref this), objA, objB);
+            return ((delegate* unmanaged[Thiscall]<MyStruct*, int, int, int>)(lpVtbl[{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 0 : 2)}]))((MyStruct*)Unsafe.AsPointer(ref this), objA, objB);
         }}
     }}
 }}
@@ -462,12 +453,10 @@ namespace ClangSharp.Test
     virtual int GetType(int objA, int objB) = 0;
 };";
 
-            var callConv = "Cdecl";
             var nativeCallConv = "";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
             {
-                callConv = "Thiscall";
                 nativeCallConv = " __attribute__((thiscall))";
             }
 
@@ -497,13 +486,13 @@ namespace ClangSharp.Test
         public partial struct Vtbl
         {{
             [NativeTypeName(""{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "int (int, int)" : "int (int)")}{nativeCallConv}"")]
-            public {(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : "new ")}delegate* unmanaged[{callConv}]<MyStruct*, int, int{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ", int" : "")}> GetType{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "2" : "")};
+            public {(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : "new ")}delegate* unmanaged[Thiscall]<MyStruct*, int, int{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ", int" : "")}> GetType{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "2" : "")};
 
             [NativeTypeName(""int (){nativeCallConv}"")]
-            public delegate* unmanaged[{callConv}]<MyStruct*, int> GetType1;
+            public delegate* unmanaged[Thiscall]<MyStruct*, int> GetType1;
 
             [NativeTypeName(""{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "int (int)" : "int (int, int)")}{nativeCallConv}"")]
-            public {(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "new " : "")}delegate* unmanaged[{callConv}]<MyStruct*, int, int{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : ", int")}> GetType{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : "2")};
+            public {(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "new " : "")}delegate* unmanaged[Thiscall]<MyStruct*, int, int{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : ", int")}> GetType{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : "2")};
         }}
     }}
 }}
@@ -768,13 +757,6 @@ namespace ClangSharp.Test
 };
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "Thiscall";
-            }
-
             var expectedOutputContents = $@"using System.Runtime.CompilerServices;
 
 namespace ClangSharp.Test
@@ -785,23 +767,23 @@ namespace ClangSharp.Test
 
         public void MyVoidMethod()
         {{
-            ((delegate* unmanaged[{callConv}]<MyStruct*, void>)(lpVtbl[0]))((MyStruct*)Unsafe.AsPointer(ref this));
+            ((delegate* unmanaged[Thiscall]<MyStruct*, void>)(lpVtbl[0]))((MyStruct*)Unsafe.AsPointer(ref this));
         }}
 
         [return: NativeTypeName(""char"")]
         public sbyte MyInt8Method()
         {{
-            return ((delegate* unmanaged[{callConv}]<MyStruct*, sbyte>)(lpVtbl[1]))((MyStruct*)Unsafe.AsPointer(ref this));
+            return ((delegate* unmanaged[Thiscall]<MyStruct*, sbyte>)(lpVtbl[1]))((MyStruct*)Unsafe.AsPointer(ref this));
         }}
 
         public int MyInt32Method()
         {{
-            return ((delegate* unmanaged[{callConv}]<MyStruct*, int>)(lpVtbl[2]))((MyStruct*)Unsafe.AsPointer(ref this));
+            return ((delegate* unmanaged[Thiscall]<MyStruct*, int>)(lpVtbl[2]))((MyStruct*)Unsafe.AsPointer(ref this));
         }}
 
         public void* MyVoidStarMethod()
         {{
-            return ((delegate* unmanaged[{callConv}]<MyStruct*, void*>)(lpVtbl[3]))((MyStruct*)Unsafe.AsPointer(ref this));
+            return ((delegate* unmanaged[Thiscall]<MyStruct*, void*>)(lpVtbl[3]))((MyStruct*)Unsafe.AsPointer(ref this));
         }}
     }}
 }}
@@ -827,13 +809,6 @@ namespace ClangSharp.Test
 };
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "Thiscall";
-            }
-
             var expectedOutputContents = $@"using System.Runtime.CompilerServices;
 
 namespace ClangSharp.Test
@@ -845,26 +820,26 @@ namespace ClangSharp.Test
         [VtblIndex(0)]
         public void MyVoidMethod()
         {{
-            ((delegate* unmanaged[{callConv}]<MyStruct*, void>)(lpVtbl[0]))((MyStruct*)Unsafe.AsPointer(ref this));
+            ((delegate* unmanaged[Thiscall]<MyStruct*, void>)(lpVtbl[0]))((MyStruct*)Unsafe.AsPointer(ref this));
         }}
 
         [VtblIndex(1)]
         [return: NativeTypeName(""char"")]
         public sbyte MyInt8Method()
         {{
-            return ((delegate* unmanaged[{callConv}]<MyStruct*, sbyte>)(lpVtbl[1]))((MyStruct*)Unsafe.AsPointer(ref this));
+            return ((delegate* unmanaged[Thiscall]<MyStruct*, sbyte>)(lpVtbl[1]))((MyStruct*)Unsafe.AsPointer(ref this));
         }}
 
         [VtblIndex(2)]
         public int MyInt32Method()
         {{
-            return ((delegate* unmanaged[{callConv}]<MyStruct*, int>)(lpVtbl[2]))((MyStruct*)Unsafe.AsPointer(ref this));
+            return ((delegate* unmanaged[Thiscall]<MyStruct*, int>)(lpVtbl[2]))((MyStruct*)Unsafe.AsPointer(ref this));
         }}
 
         [VtblIndex(3)]
         public void* MyVoidStarMethod()
         {{
-            return ((delegate* unmanaged[{callConv}]<MyStruct*, void*>)(lpVtbl[3]))((MyStruct*)Unsafe.AsPointer(ref this));
+            return ((delegate* unmanaged[Thiscall]<MyStruct*, void*>)(lpVtbl[3]))((MyStruct*)Unsafe.AsPointer(ref this));
         }}
     }}
 }}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/FunctionDeclarationBodyImportTest.cs
@@ -495,13 +495,6 @@ MyStructB* MyFunction(MyStructA* input)
 }
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "Thiscall";
-            }
-
             var expectedOutputContents = $@"using System.Runtime.CompilerServices;
 
 namespace ClangSharp.Test
@@ -512,7 +505,7 @@ namespace ClangSharp.Test
 
         public void MyMethod()
         {{
-            ((delegate* unmanaged[{callConv}]<MyStructA*, void>)(lpVtbl[0]))((MyStructA*)Unsafe.AsPointer(ref this));
+            ((delegate* unmanaged[Thiscall]<MyStructA*, void>)(lpVtbl[0]))((MyStructA*)Unsafe.AsPointer(ref this));
         }}
     }}
 
@@ -523,7 +516,7 @@ namespace ClangSharp.Test
 
         public void MyMethod()
         {{
-            ((delegate* unmanaged[{callConv}]<MyStructB*, void>)(lpVtbl[0]))((MyStructB*)Unsafe.AsPointer(ref this));
+            ((delegate* unmanaged[Thiscall]<MyStructB*, void>)(lpVtbl[0]))((MyStructB*)Unsafe.AsPointer(ref this));
         }}
     }}
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/StructDeclarationTest.cs
@@ -1281,6 +1281,59 @@ namespace ClangSharp.Test
             return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task PackTest()
+        {
+            const string InputContents = @"struct MyStruct1 {
+    unsigned Field1;
+
+    void* Field2;
+
+    unsigned Field3;
+};
+
+#pragma pack(4)
+
+struct MyStruct2 {
+    unsigned Field1;
+
+    void* Field2;
+
+    unsigned Field3;
+};
+";
+
+            const string ExpectedOutputContents = @"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct MyStruct1
+    {
+        [NativeTypeName(""unsigned int"")]
+        public uint Field1;
+
+        public void* Field2;
+
+        [NativeTypeName(""unsigned int"")]
+        public uint Field3;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public unsafe partial struct MyStruct2
+    {
+        [NativeTypeName(""unsigned int"")]
+        public uint Field1;
+
+        public void* Field2;
+
+        [NativeTypeName(""unsigned int"")]
+        public uint Field3;
+    }
+}
+";
+
+            return ValidateGeneratedCSharpLatestUnixBindingsAsync(InputContents, ExpectedOutputContents);
+        }
+
         public override Task PointerToSelfTest()
         {
             var inputContents = @"struct example_s {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/UnionDeclarationTest.cs
@@ -134,13 +134,11 @@ union MyUnion3
 };
 ";
 
-            var expectedPack = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ", Pack = 1" : "";
-
             var expectedOutputContents = $@"using System.Runtime.InteropServices;
 
 namespace ClangSharp.Test
 {{
-    [StructLayout(LayoutKind.Explicit{expectedPack})]
+    [StructLayout(LayoutKind.Explicit)]
     public partial struct MyUnion1
     {{
         [FieldOffset(0)]
@@ -289,7 +287,7 @@ namespace ClangSharp.Test
         }}
     }}
 
-    [StructLayout(LayoutKind.Explicit{expectedPack})]
+    [StructLayout(LayoutKind.Explicit)]
     public partial struct MyUnion3
     {{
         [FieldOffset(0)]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
@@ -164,14 +164,12 @@ namespace ClangSharp.UnitTests
     }
 };
 ";
-            var callConv = "Cdecl";
             var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "__ZN8MyStruct12MyVoidMethodEv" : "_ZN8MyStruct12MyVoidMethodEv";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 if (!Environment.Is64BitProcess)
                 {
-                    callConv = "ThisCall";
                     entryPoint = "?MyVoidMethod@MyStruct@@QAEXXZ";
                 }
                 else
@@ -186,7 +184,7 @@ namespace ClangSharp.Test
 {{
     public partial struct MyStruct
     {{
-        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.{callConv}, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
         public static extern void MyVoidMethod();
 
         public int MyInt32Method()
@@ -417,13 +415,6 @@ int MyFunctionB(MyStruct* x)
     virtual int GetType(int objA, int objB) = 0;
 };";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "Thiscall";
-            }
-
             var expectedOutputContents = $@"using System.Runtime.CompilerServices;
 
 namespace ClangSharp.Test
@@ -434,17 +425,17 @@ namespace ClangSharp.Test
 
         public int GetType(int obj)
         {{
-            return ((delegate* unmanaged[{callConv}]<MyStruct*, int, int>)(lpVtbl[{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 2 : 0)}]))((MyStruct*)Unsafe.AsPointer(ref this), obj);
+            return ((delegate* unmanaged[Thiscall]<MyStruct*, int, int>)(lpVtbl[{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 2 : 0)}]))((MyStruct*)Unsafe.AsPointer(ref this), obj);
         }}
 
         public new int GetType()
         {{
-            return ((delegate* unmanaged[{callConv}]<MyStruct*, int>)(lpVtbl[1]))((MyStruct*)Unsafe.AsPointer(ref this));
+            return ((delegate* unmanaged[Thiscall]<MyStruct*, int>)(lpVtbl[1]))((MyStruct*)Unsafe.AsPointer(ref this));
         }}
 
         public int GetType(int objA, int objB)
         {{
-            return ((delegate* unmanaged[{callConv}]<MyStruct*, int, int, int>)(lpVtbl[{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 0 : 2)}]))((MyStruct*)Unsafe.AsPointer(ref this), objA, objB);
+            return ((delegate* unmanaged[Thiscall]<MyStruct*, int, int, int>)(lpVtbl[{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 0 : 2)}]))((MyStruct*)Unsafe.AsPointer(ref this), objA, objB);
         }}
     }}
 }}
@@ -462,12 +453,10 @@ namespace ClangSharp.Test
     virtual int GetType(int objA, int objB) = 0;
 };";
 
-            var callConv = "Cdecl";
             var nativeCallConv = "";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
             {
-                callConv = "Thiscall";
                 nativeCallConv = " __attribute__((thiscall))";
             }
 
@@ -497,13 +486,13 @@ namespace ClangSharp.Test
         public partial struct Vtbl
         {{
             [NativeTypeName(""{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "int (int, int)" : "int (int)")}{nativeCallConv}"")]
-            public {(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : "new ")}delegate* unmanaged[{callConv}]<MyStruct*, int, int{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ", int" : "")}> GetType{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "2" : "")};
+            public {(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : "new ")}delegate* unmanaged[Thiscall]<MyStruct*, int, int{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ", int" : "")}> GetType{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "2" : "")};
 
             [NativeTypeName(""int (){nativeCallConv}"")]
-            public delegate* unmanaged[{callConv}]<MyStruct*, int> GetType1;
+            public delegate* unmanaged[Thiscall]<MyStruct*, int> GetType1;
 
             [NativeTypeName(""{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "int (int)" : "int (int, int)")}{nativeCallConv}"")]
-            public {(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "new " : "")}delegate* unmanaged[{callConv}]<MyStruct*, int, int{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : ", int")}> GetType{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : "2")};
+            public {(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "new " : "")}delegate* unmanaged[Thiscall]<MyStruct*, int, int{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : ", int")}> GetType{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : "2")};
         }}
     }}
 }}
@@ -768,13 +757,6 @@ namespace ClangSharp.Test
 };
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "Thiscall";
-            }
-
             var expectedOutputContents = $@"using System.Runtime.CompilerServices;
 
 namespace ClangSharp.Test
@@ -785,23 +767,23 @@ namespace ClangSharp.Test
 
         public void MyVoidMethod()
         {{
-            ((delegate* unmanaged[{callConv}]<MyStruct*, void>)(lpVtbl[0]))((MyStruct*)Unsafe.AsPointer(ref this));
+            ((delegate* unmanaged[Thiscall]<MyStruct*, void>)(lpVtbl[0]))((MyStruct*)Unsafe.AsPointer(ref this));
         }}
 
         [return: NativeTypeName(""char"")]
         public sbyte MyInt8Method()
         {{
-            return ((delegate* unmanaged[{callConv}]<MyStruct*, sbyte>)(lpVtbl[1]))((MyStruct*)Unsafe.AsPointer(ref this));
+            return ((delegate* unmanaged[Thiscall]<MyStruct*, sbyte>)(lpVtbl[1]))((MyStruct*)Unsafe.AsPointer(ref this));
         }}
 
         public int MyInt32Method()
         {{
-            return ((delegate* unmanaged[{callConv}]<MyStruct*, int>)(lpVtbl[2]))((MyStruct*)Unsafe.AsPointer(ref this));
+            return ((delegate* unmanaged[Thiscall]<MyStruct*, int>)(lpVtbl[2]))((MyStruct*)Unsafe.AsPointer(ref this));
         }}
 
         public void* MyVoidStarMethod()
         {{
-            return ((delegate* unmanaged[{callConv}]<MyStruct*, void*>)(lpVtbl[3]))((MyStruct*)Unsafe.AsPointer(ref this));
+            return ((delegate* unmanaged[Thiscall]<MyStruct*, void*>)(lpVtbl[3]))((MyStruct*)Unsafe.AsPointer(ref this));
         }}
     }}
 }}
@@ -827,13 +809,6 @@ namespace ClangSharp.Test
 };
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "Thiscall";
-            }
-
             var expectedOutputContents = $@"using System.Runtime.CompilerServices;
 
 namespace ClangSharp.Test
@@ -845,26 +820,26 @@ namespace ClangSharp.Test
         [VtblIndex(0)]
         public void MyVoidMethod()
         {{
-            ((delegate* unmanaged[{callConv}]<MyStruct*, void>)(lpVtbl[0]))((MyStruct*)Unsafe.AsPointer(ref this));
+            ((delegate* unmanaged[Thiscall]<MyStruct*, void>)(lpVtbl[0]))((MyStruct*)Unsafe.AsPointer(ref this));
         }}
 
         [VtblIndex(1)]
         [return: NativeTypeName(""char"")]
         public sbyte MyInt8Method()
         {{
-            return ((delegate* unmanaged[{callConv}]<MyStruct*, sbyte>)(lpVtbl[1]))((MyStruct*)Unsafe.AsPointer(ref this));
+            return ((delegate* unmanaged[Thiscall]<MyStruct*, sbyte>)(lpVtbl[1]))((MyStruct*)Unsafe.AsPointer(ref this));
         }}
 
         [VtblIndex(2)]
         public int MyInt32Method()
         {{
-            return ((delegate* unmanaged[{callConv}]<MyStruct*, int>)(lpVtbl[2]))((MyStruct*)Unsafe.AsPointer(ref this));
+            return ((delegate* unmanaged[Thiscall]<MyStruct*, int>)(lpVtbl[2]))((MyStruct*)Unsafe.AsPointer(ref this));
         }}
 
         [VtblIndex(3)]
         public void* MyVoidStarMethod()
         {{
-            return ((delegate* unmanaged[{callConv}]<MyStruct*, void*>)(lpVtbl[3]))((MyStruct*)Unsafe.AsPointer(ref this));
+            return ((delegate* unmanaged[Thiscall]<MyStruct*, void*>)(lpVtbl[3]))((MyStruct*)Unsafe.AsPointer(ref this));
         }}
     }}
 }}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/FunctionDeclarationBodyImportTest.cs
@@ -495,13 +495,6 @@ MyStructB* MyFunction(MyStructA* input)
 }
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "Thiscall";
-            }
-
             var expectedOutputContents = $@"using System.Runtime.CompilerServices;
 
 namespace ClangSharp.Test
@@ -512,7 +505,7 @@ namespace ClangSharp.Test
 
         public void MyMethod()
         {{
-            ((delegate* unmanaged[{callConv}]<MyStructA*, void>)(lpVtbl[0]))((MyStructA*)Unsafe.AsPointer(ref this));
+            ((delegate* unmanaged[Thiscall]<MyStructA*, void>)(lpVtbl[0]))((MyStructA*)Unsafe.AsPointer(ref this));
         }}
     }}
 
@@ -523,7 +516,7 @@ namespace ClangSharp.Test
 
         public void MyMethod()
         {{
-            ((delegate* unmanaged[{callConv}]<MyStructB*, void>)(lpVtbl[0]))((MyStructB*)Unsafe.AsPointer(ref this));
+            ((delegate* unmanaged[Thiscall]<MyStructB*, void>)(lpVtbl[0]))((MyStructB*)Unsafe.AsPointer(ref this));
         }}
     }}
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/StructDeclarationTest.cs
@@ -1285,6 +1285,59 @@ namespace ClangSharp.Test
             return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task PackTest()
+        {
+            const string InputContents = @"struct MyStruct1 {
+    unsigned Field1;
+
+    void* Field2;
+
+    unsigned Field3;
+};
+
+#pragma pack(4)
+
+struct MyStruct2 {
+    unsigned Field1;
+
+    void* Field2;
+
+    unsigned Field3;
+};
+";
+
+            const string ExpectedOutputContents = @"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct MyStruct1
+    {
+        [NativeTypeName(""unsigned int"")]
+        public uint Field1;
+
+        public void* Field2;
+
+        [NativeTypeName(""unsigned int"")]
+        public uint Field3;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public unsafe partial struct MyStruct2
+    {
+        [NativeTypeName(""unsigned int"")]
+        public uint Field1;
+
+        public void* Field2;
+
+        [NativeTypeName(""unsigned int"")]
+        public uint Field3;
+    }
+}
+";
+
+            return ValidateGeneratedCSharpLatestWindowsBindingsAsync(InputContents, ExpectedOutputContents);
+        }
+
         public override Task PointerToSelfTest()
         {
             var inputContents = @"struct example_s {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/UnionDeclarationTest.cs
@@ -134,13 +134,11 @@ union MyUnion3
 };
 ";
 
-            var expectedPack = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ", Pack = 1" : "";
-
             var expectedOutputContents = $@"using System.Runtime.InteropServices;
 
 namespace ClangSharp.Test
 {{
-    [StructLayout(LayoutKind.Explicit{expectedPack})]
+    [StructLayout(LayoutKind.Explicit)]
     public partial struct MyUnion1
     {{
         [FieldOffset(0)]
@@ -295,7 +293,7 @@ namespace ClangSharp.Test
         }}
     }}
 
-    [StructLayout(LayoutKind.Explicit{expectedPack})]
+    [StructLayout(LayoutKind.Explicit)]
     public partial struct MyUnion3
     {{
         [FieldOffset(0)]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -206,14 +206,12 @@ namespace ClangSharp.UnitTests
     }
 };
 ";
-            var callConv = "Cdecl";
             var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "__ZN8MyStruct12MyVoidMethodEv" : "_ZN8MyStruct12MyVoidMethodEv";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 if (!Environment.Is64BitProcess)
                 {
-                    callConv = "ThisCall";
                     entryPoint = "?MyVoidMethod@MyStruct@@QAEXXZ";
                 }
                 else
@@ -226,7 +224,7 @@ namespace ClangSharp.UnitTests
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""MyStruct"" access=""public"">
-      <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""{callConv}"" entrypoint=""{entryPoint}"" static=""true"">
+      <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
         <type>void</type>
       </function>
       <function name=""MyInt32Method"" access=""public"">
@@ -471,13 +469,6 @@ int MyFunctionB(MyStruct* x)
     virtual int GetType(int objA, int objB) = 0;
 };";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "ThisCall";
-            }
-
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
@@ -485,7 +476,7 @@ int MyFunctionB(MyStruct* x)
       <field name=""lpVtbl"" access=""public"">
         <type>void**</type>
       </field>
-      <delegate name=""_GetType"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_GetType"" access=""public"" convention=""ThisCall"">
         <type>int</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
@@ -494,13 +485,13 @@ int MyFunctionB(MyStruct* x)
           <type>int</type>
         </param>
       </delegate>
-      <delegate name=""_GetType1"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_GetType1"" access=""public"" convention=""ThisCall"">
         <type>int</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
         </param>
       </delegate>
-      <delegate name=""_GetType2"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_GetType2"" access=""public"" convention=""ThisCall"">
         <type>int</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
@@ -565,12 +556,10 @@ int MyFunctionB(MyStruct* x)
     virtual int GetType(int objA, int objB) = 0;
 };";
 
-            var callConv = "Cdecl";
             var nativeCallConv = "";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
             {
-                callConv = "ThisCall";
                 nativeCallConv = " __attribute__((thiscall))";
             }
 
@@ -581,7 +570,7 @@ int MyFunctionB(MyStruct* x)
       <field name=""lpVtbl"" access=""public"">
         <type>Vtbl*</type>
       </field>
-      <delegate name=""_GetType"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_GetType"" access=""public"" convention=""ThisCall"">
         <type>int</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
@@ -590,13 +579,13 @@ int MyFunctionB(MyStruct* x)
           <type>int</type>
         </param>
       </delegate>
-      <delegate name=""_GetType1"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_GetType1"" access=""public"" convention=""ThisCall"">
         <type>int</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
         </param>
       </delegate>
-      <delegate name=""_GetType2"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_GetType2"" access=""public"" convention=""ThisCall"">
         <type>int</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
@@ -955,13 +944,6 @@ extern ""C"" void MyFunction();";
 };
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "ThisCall";
-            }
-
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
@@ -969,25 +951,25 @@ extern ""C"" void MyFunction();";
       <field name=""lpVtbl"" access=""public"">
         <type>void**</type>
       </field>
-      <delegate name=""_MyVoidMethod"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_MyVoidMethod"" access=""public"" convention=""ThisCall"">
         <type>void</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
         </param>
       </delegate>
-      <delegate name=""_MyInt8Method"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_MyInt8Method"" access=""public"" convention=""ThisCall"">
         <type native=""char"">sbyte</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
         </param>
       </delegate>
-      <delegate name=""_MyInt32Method"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_MyInt32Method"" access=""public"" convention=""ThisCall"">
         <type>int</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
         </param>
       </delegate>
-      <delegate name=""_MyVoidStarMethod"" access=""public"" convention=""{callConv}"" unsafe=""true"">
+      <delegate name=""_MyVoidStarMethod"" access=""public"" convention=""ThisCall"" unsafe=""true"">
         <type>void*</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
@@ -1054,13 +1036,6 @@ extern ""C"" void MyFunction();";
 };
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "ThisCall";
-            }
-
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
@@ -1068,25 +1043,25 @@ extern ""C"" void MyFunction();";
       <field name=""lpVtbl"" access=""public"">
         <type>void**</type>
       </field>
-      <delegate name=""_MyVoidMethod"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_MyVoidMethod"" access=""public"" convention=""ThisCall"">
         <type>void</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
         </param>
       </delegate>
-      <delegate name=""_MyInt8Method"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_MyInt8Method"" access=""public"" convention=""ThisCall"">
         <type native=""char"">sbyte</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
         </param>
       </delegate>
-      <delegate name=""_MyInt32Method"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_MyInt32Method"" access=""public"" convention=""ThisCall"">
         <type>int</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
         </param>
       </delegate>
-      <delegate name=""_MyVoidStarMethod"" access=""public"" convention=""{callConv}"" unsafe=""true"">
+      <delegate name=""_MyVoidStarMethod"" access=""public"" convention=""ThisCall"" unsafe=""true"">
         <type>void*</type>
         <param name=""pThis"">
           <type>MyStruct*</type>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/FunctionDeclarationBodyImportTest.cs
@@ -578,13 +578,6 @@ MyStructB* MyFunction(MyStructA* input)
 }
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "ThisCall";
-            }
-
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
@@ -592,7 +585,7 @@ MyStructB* MyFunction(MyStructA* input)
       <field name=""lpVtbl"" access=""public"">
         <type>void**</type>
       </field>
-      <delegate name=""_MyMethod"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_MyMethod"" access=""public"" convention=""ThisCall"">
         <type>void</type>
         <param name=""pThis"">
           <type>MyStructA*</type>
@@ -612,7 +605,7 @@ MyStructB* MyFunction(MyStructA* input)
       <field name=""lpVtbl"" access=""public"">
         <type>void**</type>
       </field>
-      <delegate name=""_MyMethod"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_MyMethod"" access=""public"" convention=""ThisCall"">
         <type>void</type>
         <param name=""pThis"">
           <type>MyStructB*</type>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/StructDeclarationTest.cs
@@ -1281,6 +1281,59 @@ struct MyStruct
             return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task PackTest()
+        {
+            const string InputContents = @"struct MyStruct1 {
+    unsigned Field1;
+
+    void* Field2;
+
+    unsigned Field3;
+};
+
+#pragma pack(4)
+
+struct MyStruct2 {
+    unsigned Field1;
+
+    void* Field2;
+
+    unsigned Field3;
+};
+";
+
+            const string ExpectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct1"" access=""public"" unsafe=""true"">
+      <field name=""Field1"" access=""public"">
+        <type native=""unsigned int"">uint</type>
+      </field>
+      <field name=""Field2"" access=""public"">
+        <type>void*</type>
+      </field>
+      <field name=""Field3"" access=""public"">
+        <type native=""unsigned int"">uint</type>
+      </field>
+    </struct>
+    <struct name=""MyStruct2"" access=""public"" unsafe=""true"" layout=""Sequential"" pack=""4"">
+      <field name=""Field1"" access=""public"">
+        <type native=""unsigned int"">uint</type>
+      </field>
+      <field name=""Field2"" access=""public"">
+        <type>void*</type>
+      </field>
+      <field name=""Field3"" access=""public"">
+        <type native=""unsigned int"">uint</type>
+      </field>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlCompatibleUnixBindingsAsync(InputContents, ExpectedOutputContents);
+        }
+
         public override Task PointerToSelfTest()
         {
             var inputContents = @"struct example_s {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/UnionDeclarationTest.cs
@@ -128,12 +128,10 @@ union MyUnion3
 };
 ";
 
-            var expectedPack = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @" pack=""1""" : "";
-
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
-    <struct name=""MyUnion1"" access=""public"" layout=""Explicit""{expectedPack}>
+    <struct name=""MyUnion1"" access=""public"" layout=""Explicit"">
       <field name=""_bitfield1"" access=""public"" offset=""0"">
         <type>uint</type>
       </field>
@@ -242,7 +240,7 @@ union MyUnion3
         </set>
       </field>
     </struct>
-    <struct name=""MyUnion3"" access=""public"" layout=""Explicit""{expectedPack}>
+    <struct name=""MyUnion3"" access=""public"" layout=""Explicit"">
       <field name=""_bitfield"" access=""public"" offset=""0"">
         <type>uint</type>
       </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -206,14 +206,12 @@ namespace ClangSharp.UnitTests
     }
 };
 ";
-            var callConv = "Cdecl";
             var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "__ZN8MyStruct12MyVoidMethodEv" : "_ZN8MyStruct12MyVoidMethodEv";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 if (!Environment.Is64BitProcess)
                 {
-                    callConv = "ThisCall";
                     entryPoint = "?MyVoidMethod@MyStruct@@QAEXXZ";
                 }
                 else
@@ -226,7 +224,7 @@ namespace ClangSharp.UnitTests
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""MyStruct"" access=""public"">
-      <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""{callConv}"" entrypoint=""{entryPoint}"" static=""true"">
+      <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
         <type>void</type>
       </function>
       <function name=""MyInt32Method"" access=""public"">
@@ -471,13 +469,6 @@ int MyFunctionB(MyStruct* x)
     virtual int GetType(int objA, int objB) = 0;
 };";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "ThisCall";
-            }
-
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
@@ -485,7 +476,7 @@ int MyFunctionB(MyStruct* x)
       <field name=""lpVtbl"" access=""public"">
         <type>void**</type>
       </field>
-      <delegate name=""_GetType"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_GetType"" access=""public"" convention=""ThisCall"">
         <type>int</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
@@ -494,13 +485,13 @@ int MyFunctionB(MyStruct* x)
           <type>int</type>
         </param>
       </delegate>
-      <delegate name=""_GetType1"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_GetType1"" access=""public"" convention=""ThisCall"">
         <type>int</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
         </param>
       </delegate>
-      <delegate name=""_GetType2"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_GetType2"" access=""public"" convention=""ThisCall"">
         <type>int</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
@@ -565,12 +556,10 @@ int MyFunctionB(MyStruct* x)
     virtual int GetType(int objA, int objB) = 0;
 };";
 
-            var callConv = "Cdecl";
             var nativeCallConv = "";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
             {
-                callConv = "ThisCall";
                 nativeCallConv = " __attribute__((thiscall))";
             }
 
@@ -581,7 +570,7 @@ int MyFunctionB(MyStruct* x)
       <field name=""lpVtbl"" access=""public"">
         <type>Vtbl*</type>
       </field>
-      <delegate name=""_GetType"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_GetType"" access=""public"" convention=""ThisCall"">
         <type>int</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
@@ -590,13 +579,13 @@ int MyFunctionB(MyStruct* x)
           <type>int</type>
         </param>
       </delegate>
-      <delegate name=""_GetType1"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_GetType1"" access=""public"" convention=""ThisCall"">
         <type>int</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
         </param>
       </delegate>
-      <delegate name=""_GetType2"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_GetType2"" access=""public"" convention=""ThisCall"">
         <type>int</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
@@ -955,13 +944,6 @@ extern ""C"" void MyFunction();";
 };
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "ThisCall";
-            }
-
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
@@ -969,25 +951,25 @@ extern ""C"" void MyFunction();";
       <field name=""lpVtbl"" access=""public"">
         <type>void**</type>
       </field>
-      <delegate name=""_MyVoidMethod"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_MyVoidMethod"" access=""public"" convention=""ThisCall"">
         <type>void</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
         </param>
       </delegate>
-      <delegate name=""_MyInt8Method"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_MyInt8Method"" access=""public"" convention=""ThisCall"">
         <type native=""char"">sbyte</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
         </param>
       </delegate>
-      <delegate name=""_MyInt32Method"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_MyInt32Method"" access=""public"" convention=""ThisCall"">
         <type>int</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
         </param>
       </delegate>
-      <delegate name=""_MyVoidStarMethod"" access=""public"" convention=""{callConv}"" unsafe=""true"">
+      <delegate name=""_MyVoidStarMethod"" access=""public"" convention=""ThisCall"" unsafe=""true"">
         <type>void*</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
@@ -1054,13 +1036,6 @@ extern ""C"" void MyFunction();";
 };
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "ThisCall";
-            }
-
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
@@ -1068,25 +1043,25 @@ extern ""C"" void MyFunction();";
       <field name=""lpVtbl"" access=""public"">
         <type>void**</type>
       </field>
-      <delegate name=""_MyVoidMethod"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_MyVoidMethod"" access=""public"" convention=""ThisCall"">
         <type>void</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
         </param>
       </delegate>
-      <delegate name=""_MyInt8Method"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_MyInt8Method"" access=""public"" convention=""ThisCall"">
         <type native=""char"">sbyte</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
         </param>
       </delegate>
-      <delegate name=""_MyInt32Method"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_MyInt32Method"" access=""public"" convention=""ThisCall"">
         <type>int</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
         </param>
       </delegate>
-      <delegate name=""_MyVoidStarMethod"" access=""public"" convention=""{callConv}"" unsafe=""true"">
+      <delegate name=""_MyVoidStarMethod"" access=""public"" convention=""ThisCall"" unsafe=""true"">
         <type>void*</type>
         <param name=""pThis"">
           <type>MyStruct*</type>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/FunctionDeclarationBodyImportTest.cs
@@ -578,13 +578,6 @@ MyStructB* MyFunction(MyStructA* input)
 }
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "ThisCall";
-            }
-
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
@@ -592,7 +585,7 @@ MyStructB* MyFunction(MyStructA* input)
       <field name=""lpVtbl"" access=""public"">
         <type>void**</type>
       </field>
-      <delegate name=""_MyMethod"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_MyMethod"" access=""public"" convention=""ThisCall"">
         <type>void</type>
         <param name=""pThis"">
           <type>MyStructA*</type>
@@ -612,7 +605,7 @@ MyStructB* MyFunction(MyStructA* input)
       <field name=""lpVtbl"" access=""public"">
         <type>void**</type>
       </field>
-      <delegate name=""_MyMethod"" access=""public"" convention=""{callConv}"">
+      <delegate name=""_MyMethod"" access=""public"" convention=""ThisCall"">
         <type>void</type>
         <param name=""pThis"">
           <type>MyStructB*</type>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/StructDeclarationTest.cs
@@ -1286,6 +1286,58 @@ struct MyStruct
 ";
             return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
         }
+        public override Task PackTest()
+        {
+            const string InputContents = @"struct MyStruct1 {
+    unsigned Field1;
+
+    void* Field2;
+
+    unsigned Field3;
+};
+
+#pragma pack(4)
+
+struct MyStruct2 {
+    unsigned Field1;
+
+    void* Field2;
+
+    unsigned Field3;
+};
+";
+
+            const string ExpectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct1"" access=""public"" unsafe=""true"">
+      <field name=""Field1"" access=""public"">
+        <type native=""unsigned int"">uint</type>
+      </field>
+      <field name=""Field2"" access=""public"">
+        <type>void*</type>
+      </field>
+      <field name=""Field3"" access=""public"">
+        <type native=""unsigned int"">uint</type>
+      </field>
+    </struct>
+    <struct name=""MyStruct2"" access=""public"" unsafe=""true"" layout=""Sequential"" pack=""4"">
+      <field name=""Field1"" access=""public"">
+        <type native=""unsigned int"">uint</type>
+      </field>
+      <field name=""Field2"" access=""public"">
+        <type>void*</type>
+      </field>
+      <field name=""Field3"" access=""public"">
+        <type native=""unsigned int"">uint</type>
+      </field>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(InputContents, ExpectedOutputContents);
+        }
 
         public override Task PointerToSelfTest()
         {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/UnionDeclarationTest.cs
@@ -128,12 +128,10 @@ union MyUnion3
 };
 ";
 
-            var expectedPack = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @" pack=""1""" : "";
-
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
-    <struct name=""MyUnion1"" access=""public"" layout=""Explicit""{expectedPack}>
+    <struct name=""MyUnion1"" access=""public"" layout=""Explicit"">
       <field name=""_bitfield1"" access=""public"" offset=""0"">
         <type>uint</type>
       </field>
@@ -248,7 +246,7 @@ union MyUnion3
         </set>
       </field>
     </struct>
-    <struct name=""MyUnion3"" access=""public"" layout=""Explicit""{expectedPack}>
+    <struct name=""MyUnion3"" access=""public"" layout=""Explicit"">
       <field name=""_bitfield"" access=""public"" offset=""0"">
         <type>uint</type>
       </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
@@ -206,14 +206,12 @@ namespace ClangSharp.UnitTests
     }
 };
 ";
-            var callConv = "Cdecl";
             var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "__ZN8MyStruct12MyVoidMethodEv" : "_ZN8MyStruct12MyVoidMethodEv";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 if (!Environment.Is64BitProcess)
                 {
-                    callConv = "ThisCall";
                     entryPoint = "?MyVoidMethod@MyStruct@@QAEXXZ";
                 }
                 else
@@ -226,7 +224,7 @@ namespace ClangSharp.UnitTests
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""MyStruct"" access=""public"">
-      <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""{callConv}"" entrypoint=""{entryPoint}"" static=""true"">
+      <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
         <type>void</type>
       </function>
       <function name=""MyInt32Method"" access=""public"">
@@ -471,13 +469,6 @@ int MyFunctionB(MyStruct* x)
     virtual int GetType(int objA, int objB) = 0;
 };";
 
-            var callConv = "Cdecl";
-            
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "Thiscall";
-            }
-
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
@@ -491,13 +482,13 @@ int MyFunctionB(MyStruct* x)
           <type>int</type>
         </param>
         <body>
-          <code>return ((delegate* unmanaged[{callConv}]&lt;MyStruct*, int, int&gt;)(lpVtbl[<vtbl explicit=""False"">{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 2 : 0)}</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>, <param name=""obj"">obj</param>);</code>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;MyStruct*, int, int&gt;)(lpVtbl[<vtbl explicit=""False"">{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 2 : 0)}</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>, <param name=""obj"">obj</param>);</code>
         </body>
       </function>
       <function name=""GetType"" access=""public"" unsafe=""true"">
         <type>int</type>
         <body>
-          <code>return ((delegate* unmanaged[{callConv}]&lt;MyStruct*, int&gt;)(lpVtbl[<vtbl explicit=""False"">1</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;MyStruct*, int&gt;)(lpVtbl[<vtbl explicit=""False"">1</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
       <function name=""GetType"" access=""public"" unsafe=""true"">
@@ -509,7 +500,7 @@ int MyFunctionB(MyStruct* x)
           <type>int</type>
         </param>
         <body>
-          <code>return ((delegate* unmanaged[{callConv}]&lt;MyStruct*, int, int, int&gt;)(lpVtbl[<vtbl explicit=""False"">{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 0 : 2)}</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>, <param name=""objA"">objA</param>, <param name=""objB"">objB</param>);</code>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;MyStruct*, int, int, int&gt;)(lpVtbl[<vtbl explicit=""False"">{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 0 : 2)}</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>, <param name=""objA"">objA</param>, <param name=""objB"">objB</param>);</code>
         </body>
       </function>
     </struct>
@@ -529,12 +520,10 @@ int MyFunctionB(MyStruct* x)
     virtual int GetType(int objA, int objB) = 0;
 };";
 
-            var callConv = "Cdecl";
             var nativeCallConv = "";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
             {
-                callConv = "Thiscall";
                 nativeCallConv = " __attribute__((thiscall))";
             }
 
@@ -574,13 +563,13 @@ int MyFunctionB(MyStruct* x)
       </function>
       <vtbl>
         <field name=""GetType{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "2" : "")}"" access=""public"">
-          <type native=""{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "int (int, int)" : "int (int)")}{nativeCallConv}"">delegate* unmanaged[{callConv}]&lt;MyStruct*, int, int{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ", int" : "")}&gt;</type>
+          <type native=""{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "int (int, int)" : "int (int)")}{nativeCallConv}"">delegate* unmanaged[Thiscall]&lt;MyStruct*, int, int{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ", int" : "")}&gt;</type>
         </field>
         <field name=""GetType1"" access=""public"">
-          <type native=""int (){nativeCallConv}"">delegate* unmanaged[{callConv}]&lt;MyStruct*, int&gt;</type>
+          <type native=""int (){nativeCallConv}"">delegate* unmanaged[Thiscall]&lt;MyStruct*, int&gt;</type>
         </field>
         <field name=""GetType{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : "2")}"" access=""public"">
-          <type native=""{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "int (int)" : "int (int, int)")}{nativeCallConv}"">delegate* unmanaged[{callConv}]&lt;MyStruct*, int, int{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : ", int")}&gt;</type>
+          <type native=""{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "int (int)" : "int (int, int)")}{nativeCallConv}"">delegate* unmanaged[Thiscall]&lt;MyStruct*, int, int{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : ", int")}&gt;</type>
         </field>
       </vtbl>
     </struct>
@@ -883,13 +872,6 @@ extern ""C"" void MyFunction();";
 };
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "Thiscall";
-            }
-
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
@@ -900,25 +882,25 @@ extern ""C"" void MyFunction();";
       <function name=""MyVoidMethod"" access=""public"" unsafe=""true"">
         <type>void</type>
         <body>
-          <code>((delegate* unmanaged[{callConv}]&lt;MyStruct*, void&gt;)(lpVtbl[<vtbl explicit=""False"">0</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>((delegate* unmanaged[Thiscall]&lt;MyStruct*, void&gt;)(lpVtbl[<vtbl explicit=""False"">0</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
       <function name=""MyInt8Method"" access=""public"" unsafe=""true"">
         <type native=""char"">sbyte</type>
         <body>
-          <code>return ((delegate* unmanaged[{callConv}]&lt;MyStruct*, sbyte&gt;)(lpVtbl[<vtbl explicit=""False"">1</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;MyStruct*, sbyte&gt;)(lpVtbl[<vtbl explicit=""False"">1</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
       <function name=""MyInt32Method"" access=""public"" unsafe=""true"">
         <type>int</type>
         <body>
-          <code>return ((delegate* unmanaged[{callConv}]&lt;MyStruct*, int&gt;)(lpVtbl[<vtbl explicit=""False"">2</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;MyStruct*, int&gt;)(lpVtbl[<vtbl explicit=""False"">2</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
       <function name=""MyVoidStarMethod"" access=""public"" unsafe=""true"">
         <type>void*</type>
         <body>
-          <code>return ((delegate* unmanaged[{callConv}]&lt;MyStruct*, void*&gt;)(lpVtbl[<vtbl explicit=""False"">3</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;MyStruct*, void*&gt;)(lpVtbl[<vtbl explicit=""False"">3</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
     </struct>
@@ -946,13 +928,6 @@ extern ""C"" void MyFunction();";
 };
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "Thiscall";
-            }
-
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
@@ -963,25 +938,25 @@ extern ""C"" void MyFunction();";
       <function name=""MyVoidMethod"" access=""public"" unsafe=""true"" vtblindex=""0"">
         <type>void</type>
         <body>
-          <code>((delegate* unmanaged[{callConv}]&lt;MyStruct*, void&gt;)(lpVtbl[<vtbl explicit=""False"">0</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>((delegate* unmanaged[Thiscall]&lt;MyStruct*, void&gt;)(lpVtbl[<vtbl explicit=""False"">0</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
       <function name=""MyInt8Method"" access=""public"" unsafe=""true"" vtblindex=""1"">
         <type native=""char"">sbyte</type>
         <body>
-          <code>return ((delegate* unmanaged[{callConv}]&lt;MyStruct*, sbyte&gt;)(lpVtbl[<vtbl explicit=""False"">1</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;MyStruct*, sbyte&gt;)(lpVtbl[<vtbl explicit=""False"">1</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
       <function name=""MyInt32Method"" access=""public"" unsafe=""true"" vtblindex=""2"">
         <type>int</type>
         <body>
-          <code>return ((delegate* unmanaged[{callConv}]&lt;MyStruct*, int&gt;)(lpVtbl[<vtbl explicit=""False"">2</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;MyStruct*, int&gt;)(lpVtbl[<vtbl explicit=""False"">2</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
       <function name=""MyVoidStarMethod"" access=""public"" unsafe=""true"" vtblindex=""3"">
         <type>void*</type>
         <body>
-          <code>return ((delegate* unmanaged[{callConv}]&lt;MyStruct*, void*&gt;)(lpVtbl[<vtbl explicit=""False"">3</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;MyStruct*, void*&gt;)(lpVtbl[<vtbl explicit=""False"">3</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
     </struct>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/FunctionDeclarationBodyImportTest.cs
@@ -578,13 +578,6 @@ MyStructB* MyFunction(MyStructA* input)
 }
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "Thiscall";
-            }
-
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
@@ -595,7 +588,7 @@ MyStructB* MyFunction(MyStructA* input)
       <function name=""MyMethod"" access=""public"" unsafe=""true"">
         <type>void</type>
         <body>
-          <code>((delegate* unmanaged[{callConv}]&lt;MyStructA*, void&gt;)(lpVtbl[<vtbl explicit=""False"">0</vtbl>]))(<param special=""thisPtr"">(MyStructA*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>((delegate* unmanaged[Thiscall]&lt;MyStructA*, void&gt;)(lpVtbl[<vtbl explicit=""False"">0</vtbl>]))(<param special=""thisPtr"">(MyStructA*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
     </struct>
@@ -606,7 +599,7 @@ MyStructB* MyFunction(MyStructA* input)
       <function name=""MyMethod"" access=""public"" unsafe=""true"">
         <type>void</type>
         <body>
-          <code>((delegate* unmanaged[{callConv}]&lt;MyStructB*, void&gt;)(lpVtbl[<vtbl explicit=""False"">0</vtbl>]))(<param special=""thisPtr"">(MyStructB*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>((delegate* unmanaged[Thiscall]&lt;MyStructB*, void&gt;)(lpVtbl[<vtbl explicit=""False"">0</vtbl>]))(<param special=""thisPtr"">(MyStructB*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
     </struct>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/StructDeclarationTest.cs
@@ -1264,6 +1264,58 @@ struct MyStruct
 ";
             return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents);
         }
+        public override Task PackTest()
+        {
+            const string InputContents = @"struct MyStruct1 {
+    unsigned Field1;
+
+    void* Field2;
+
+    unsigned Field3;
+};
+
+#pragma pack(4)
+
+struct MyStruct2 {
+    unsigned Field1;
+
+    void* Field2;
+
+    unsigned Field3;
+};
+";
+
+            const string ExpectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct1"" access=""public"" unsafe=""true"">
+      <field name=""Field1"" access=""public"">
+        <type native=""unsigned int"">uint</type>
+      </field>
+      <field name=""Field2"" access=""public"">
+        <type>void*</type>
+      </field>
+      <field name=""Field3"" access=""public"">
+        <type native=""unsigned int"">uint</type>
+      </field>
+    </struct>
+    <struct name=""MyStruct2"" access=""public"" unsafe=""true"" layout=""Sequential"" pack=""4"">
+      <field name=""Field1"" access=""public"">
+        <type native=""unsigned int"">uint</type>
+      </field>
+      <field name=""Field2"" access=""public"">
+        <type>void*</type>
+      </field>
+      <field name=""Field3"" access=""public"">
+        <type native=""unsigned int"">uint</type>
+      </field>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlLatestUnixBindingsAsync(InputContents, ExpectedOutputContents);
+        }
 
         public override Task PointerToSelfTest()
         {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/UnionDeclarationTest.cs
@@ -128,12 +128,10 @@ union MyUnion3
 };
 ";
 
-            var expectedPack = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @" pack=""1""" : "";
-
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
-    <struct name=""MyUnion1"" access=""public"" layout=""Explicit""{expectedPack}>
+    <struct name=""MyUnion1"" access=""public"" layout=""Explicit"">
       <field name=""_bitfield1"" access=""public"" offset=""0"">
         <type>uint</type>
       </field>
@@ -242,7 +240,7 @@ union MyUnion3
         </set>
       </field>
     </struct>
-    <struct name=""MyUnion3"" access=""public"" layout=""Explicit""{expectedPack}>
+    <struct name=""MyUnion3"" access=""public"" layout=""Explicit"">
       <field name=""_bitfield"" access=""public"" offset=""0"">
         <type>uint</type>
       </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
@@ -206,14 +206,12 @@ namespace ClangSharp.UnitTests
     }
 };
 ";
-            var callConv = "Cdecl";
             var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "__ZN8MyStruct12MyVoidMethodEv" : "_ZN8MyStruct12MyVoidMethodEv";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 if (!Environment.Is64BitProcess)
                 {
-                    callConv = "ThisCall";
                     entryPoint = "?MyVoidMethod@MyStruct@@QAEXXZ";
                 }
                 else
@@ -226,7 +224,7 @@ namespace ClangSharp.UnitTests
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""MyStruct"" access=""public"">
-      <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""{callConv}"" entrypoint=""{entryPoint}"" static=""true"">
+      <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
         <type>void</type>
       </function>
       <function name=""MyInt32Method"" access=""public"">
@@ -471,13 +469,6 @@ int MyFunctionB(MyStruct* x)
     virtual int GetType(int objA, int objB) = 0;
 };";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "Thiscall";
-            }
-
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
@@ -491,13 +482,13 @@ int MyFunctionB(MyStruct* x)
           <type>int</type>
         </param>
         <body>
-          <code>return ((delegate* unmanaged[{callConv}]&lt;MyStruct*, int, int&gt;)(lpVtbl[<vtbl explicit=""False"">{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 2 : 0)}</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>, <param name=""obj"">obj</param>);</code>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;MyStruct*, int, int&gt;)(lpVtbl[<vtbl explicit=""False"">{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 2 : 0)}</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>, <param name=""obj"">obj</param>);</code>
         </body>
       </function>
       <function name=""GetType"" access=""public"" unsafe=""true"">
         <type>int</type>
         <body>
-          <code>return ((delegate* unmanaged[{callConv}]&lt;MyStruct*, int&gt;)(lpVtbl[<vtbl explicit=""False"">1</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;MyStruct*, int&gt;)(lpVtbl[<vtbl explicit=""False"">1</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
       <function name=""GetType"" access=""public"" unsafe=""true"">
@@ -509,7 +500,7 @@ int MyFunctionB(MyStruct* x)
           <type>int</type>
         </param>
         <body>
-          <code>return ((delegate* unmanaged[{callConv}]&lt;MyStruct*, int, int, int&gt;)(lpVtbl[<vtbl explicit=""False"">{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 0 : 2)}</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>, <param name=""objA"">objA</param>, <param name=""objB"">objB</param>);</code>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;MyStruct*, int, int, int&gt;)(lpVtbl[<vtbl explicit=""False"">{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 0 : 2)}</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>, <param name=""objA"">objA</param>, <param name=""objB"">objB</param>);</code>
         </body>
       </function>
     </struct>
@@ -529,12 +520,10 @@ int MyFunctionB(MyStruct* x)
     virtual int GetType(int objA, int objB) = 0;
 };";
 
-            var callConv = "Cdecl";
             var nativeCallConv = "";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
             {
-                callConv = "Thiscall";
                 nativeCallConv = " __attribute__((thiscall))";
             }
 
@@ -574,13 +563,13 @@ int MyFunctionB(MyStruct* x)
       </function>
       <vtbl>
         <field name=""GetType{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "2" : "")}"" access=""public"">
-          <type native=""{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "int (int, int)" : "int (int)")}{nativeCallConv}"">delegate* unmanaged[{callConv}]&lt;MyStruct*, int, int{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ", int" : "")}&gt;</type>
+          <type native=""{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "int (int, int)" : "int (int)")}{nativeCallConv}"">delegate* unmanaged[Thiscall]&lt;MyStruct*, int, int{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ", int" : "")}&gt;</type>
         </field>
         <field name=""GetType1"" access=""public"">
-          <type native=""int (){nativeCallConv}"">delegate* unmanaged[{callConv}]&lt;MyStruct*, int&gt;</type>
+          <type native=""int (){nativeCallConv}"">delegate* unmanaged[Thiscall]&lt;MyStruct*, int&gt;</type>
         </field>
         <field name=""GetType{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : "2")}"" access=""public"">
-          <type native=""{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "int (int)" : "int (int, int)")}{nativeCallConv}"">delegate* unmanaged[{callConv}]&lt;MyStruct*, int, int{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : ", int")}&gt;</type>
+          <type native=""{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "int (int)" : "int (int, int)")}{nativeCallConv}"">delegate* unmanaged[Thiscall]&lt;MyStruct*, int, int{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : ", int")}&gt;</type>
         </field>
       </vtbl>
     </struct>
@@ -883,13 +872,6 @@ extern ""C"" void MyFunction();";
 };
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "Thiscall";
-            }
-
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
@@ -900,25 +882,25 @@ extern ""C"" void MyFunction();";
       <function name=""MyVoidMethod"" access=""public"" unsafe=""true"">
         <type>void</type>
         <body>
-          <code>((delegate* unmanaged[{callConv}]&lt;MyStruct*, void&gt;)(lpVtbl[<vtbl explicit=""False"">0</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>((delegate* unmanaged[Thiscall]&lt;MyStruct*, void&gt;)(lpVtbl[<vtbl explicit=""False"">0</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
       <function name=""MyInt8Method"" access=""public"" unsafe=""true"">
         <type native=""char"">sbyte</type>
         <body>
-          <code>return ((delegate* unmanaged[{callConv}]&lt;MyStruct*, sbyte&gt;)(lpVtbl[<vtbl explicit=""False"">1</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;MyStruct*, sbyte&gt;)(lpVtbl[<vtbl explicit=""False"">1</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
       <function name=""MyInt32Method"" access=""public"" unsafe=""true"">
         <type>int</type>
         <body>
-          <code>return ((delegate* unmanaged[{callConv}]&lt;MyStruct*, int&gt;)(lpVtbl[<vtbl explicit=""False"">2</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;MyStruct*, int&gt;)(lpVtbl[<vtbl explicit=""False"">2</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
       <function name=""MyVoidStarMethod"" access=""public"" unsafe=""true"">
         <type>void*</type>
         <body>
-          <code>return ((delegate* unmanaged[{callConv}]&lt;MyStruct*, void*&gt;)(lpVtbl[<vtbl explicit=""False"">3</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;MyStruct*, void*&gt;)(lpVtbl[<vtbl explicit=""False"">3</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
     </struct>
@@ -946,13 +928,6 @@ extern ""C"" void MyFunction();";
 };
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "Thiscall";
-            }
-
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
@@ -963,25 +938,25 @@ extern ""C"" void MyFunction();";
       <function name=""MyVoidMethod"" access=""public"" unsafe=""true"" vtblindex=""0"">
         <type>void</type>
         <body>
-          <code>((delegate* unmanaged[{callConv}]&lt;MyStruct*, void&gt;)(lpVtbl[<vtbl explicit=""False"">0</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>((delegate* unmanaged[Thiscall]&lt;MyStruct*, void&gt;)(lpVtbl[<vtbl explicit=""False"">0</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
       <function name=""MyInt8Method"" access=""public"" unsafe=""true"" vtblindex=""1"">
         <type native=""char"">sbyte</type>
         <body>
-          <code>return ((delegate* unmanaged[{callConv}]&lt;MyStruct*, sbyte&gt;)(lpVtbl[<vtbl explicit=""False"">1</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;MyStruct*, sbyte&gt;)(lpVtbl[<vtbl explicit=""False"">1</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
       <function name=""MyInt32Method"" access=""public"" unsafe=""true"" vtblindex=""2"">
         <type>int</type>
         <body>
-          <code>return ((delegate* unmanaged[{callConv}]&lt;MyStruct*, int&gt;)(lpVtbl[<vtbl explicit=""False"">2</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;MyStruct*, int&gt;)(lpVtbl[<vtbl explicit=""False"">2</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
       <function name=""MyVoidStarMethod"" access=""public"" unsafe=""true"" vtblindex=""3"">
         <type>void*</type>
         <body>
-          <code>return ((delegate* unmanaged[{callConv}]&lt;MyStruct*, void*&gt;)(lpVtbl[<vtbl explicit=""False"">3</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;MyStruct*, void*&gt;)(lpVtbl[<vtbl explicit=""False"">3</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
     </struct>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/FunctionDeclarationBodyImportTest.cs
@@ -578,13 +578,6 @@ MyStructB* MyFunction(MyStructA* input)
 }
 ";
 
-            var callConv = "Cdecl";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-            {
-                callConv = "Thiscall";
-            }
-
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
@@ -595,7 +588,7 @@ MyStructB* MyFunction(MyStructA* input)
       <function name=""MyMethod"" access=""public"" unsafe=""true"">
         <type>void</type>
         <body>
-          <code>((delegate* unmanaged[{callConv}]&lt;MyStructA*, void&gt;)(lpVtbl[<vtbl explicit=""False"">0</vtbl>]))(<param special=""thisPtr"">(MyStructA*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>((delegate* unmanaged[Thiscall]&lt;MyStructA*, void&gt;)(lpVtbl[<vtbl explicit=""False"">0</vtbl>]))(<param special=""thisPtr"">(MyStructA*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
     </struct>
@@ -606,7 +599,7 @@ MyStructB* MyFunction(MyStructA* input)
       <function name=""MyMethod"" access=""public"" unsafe=""true"">
         <type>void</type>
         <body>
-          <code>((delegate* unmanaged[{callConv}]&lt;MyStructB*, void&gt;)(lpVtbl[<vtbl explicit=""False"">0</vtbl>]))(<param special=""thisPtr"">(MyStructB*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>((delegate* unmanaged[Thiscall]&lt;MyStructB*, void&gt;)(lpVtbl[<vtbl explicit=""False"">0</vtbl>]))(<param special=""thisPtr"">(MyStructB*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
     </struct>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/StructDeclarationTest.cs
@@ -1270,6 +1270,58 @@ struct MyStruct
 ";
             return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
         }
+        public override Task PackTest()
+        {
+            const string InputContents = @"struct MyStruct1 {
+    unsigned Field1;
+
+    void* Field2;
+
+    unsigned Field3;
+};
+
+#pragma pack(4)
+
+struct MyStruct2 {
+    unsigned Field1;
+
+    void* Field2;
+
+    unsigned Field3;
+};
+";
+
+            const string ExpectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct1"" access=""public"" unsafe=""true"">
+      <field name=""Field1"" access=""public"">
+        <type native=""unsigned int"">uint</type>
+      </field>
+      <field name=""Field2"" access=""public"">
+        <type>void*</type>
+      </field>
+      <field name=""Field3"" access=""public"">
+        <type native=""unsigned int"">uint</type>
+      </field>
+    </struct>
+    <struct name=""MyStruct2"" access=""public"" unsafe=""true"" layout=""Sequential"" pack=""4"">
+      <field name=""Field1"" access=""public"">
+        <type native=""unsigned int"">uint</type>
+      </field>
+      <field name=""Field2"" access=""public"">
+        <type>void*</type>
+      </field>
+      <field name=""Field3"" access=""public"">
+        <type native=""unsigned int"">uint</type>
+      </field>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlLatestWindowsBindingsAsync(InputContents, ExpectedOutputContents);
+        }
 
         public override Task PointerToSelfTest()
         {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/UnionDeclarationTest.cs
@@ -128,12 +128,10 @@ union MyUnion3
 };
 ";
 
-            var expectedPack = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @" pack=""1""" : "";
-
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
-    <struct name=""MyUnion1"" access=""public"" layout=""Explicit""{expectedPack}>
+    <struct name=""MyUnion1"" access=""public"" layout=""Explicit"">
       <field name=""_bitfield1"" access=""public"" offset=""0"">
         <type>uint</type>
       </field>
@@ -248,7 +246,7 @@ union MyUnion3
         </set>
       </field>
     </struct>
-    <struct name=""MyUnion3"" access=""public"" layout=""Explicit""{expectedPack}>
+    <struct name=""MyUnion3"" access=""public"" layout=""Explicit"">
       <field name=""_bitfield"" access=""public"" offset=""0"">
         <type>uint</type>
       </field>


### PR DESCRIPTION
This resolves https://github.com/microsoft/ClangSharp/issues/233

ClangSharpPInvokeGenerator was attempting to be "smart" by calculating the alignment itself, but this is potentially problematic for scenarios that differ between 32-bit and 64-bit as the Clang AST will only expose one.

This updates the generator to check for and use the attribute added to records that are under a `#pragma pack` directive and rely on that if it exists. This avoids issues like in #233 that were arising when a struct contained pointer types and was `#pragma pack 4` (which meant "expected packing matches specified packing", when in actuality it differed for 64-bit targets).