### PR TITLE
Fix std::nullptr_t

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -1541,7 +1541,7 @@ namespace ClangSharp
 
                     case CXTypeKind.CXType_NullPtr:
                     {
-                        name = "null";
+                        name = "IntPtr";
                         break;
                     }
 
@@ -1594,6 +1594,10 @@ namespace ClangSharp
             else if (type is SubstTemplateTypeParmType substTemplateTypeParmType)
             {
                 name = GetTypeName(cursor, context, rootType, substTemplateTypeParmType.ReplacementType, out _);
+            }
+            else if (type is DecltypeType decltypeType)
+            {
+                name = GetTypeName(cursor, context, rootType, decltypeType.UnderlyingType, out _);
             }
             else if (type is TagType tagType)
             {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/VarDeclarationTest.cs
@@ -77,5 +77,8 @@ namespace ClangSharp.UnitTests
 
         [Fact]
         public abstract Task ConditionalDefineConstTest();
+
+        [Fact]
+        public abstract Task NullptrTest();
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/VarDeclarationTest.cs
@@ -318,5 +318,25 @@ namespace ClangSharp.Test
 
             return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
         }
+
+        public override Task NullptrTest()
+        {
+            var inputContents = @"#include <cstddef>
+std::nullptr_t v = nullptr;";
+
+            var expectedOutputContents = @"using System;
+
+namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        [NativeTypeName(""std::nullptr_t"")]
+        public static IntPtr v = null;
+    }
+}
+";
+
+            return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/VarDeclarationTest.cs
@@ -327,5 +327,25 @@ namespace ClangSharp.Test
 
             return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
         }
+
+        public override Task NullptrTest()
+        {
+            var inputContents = @"#include <cstddef>
+std::nullptr_t v = nullptr;";
+
+            var expectedOutputContents = @"using System;
+
+namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        [NativeTypeName(""std::nullptr_t"")]
+        public static IntPtr v = null;
+    }
+}
+";
+
+            return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/VarDeclarationTest.cs
@@ -314,5 +314,25 @@ namespace ClangSharp.Test
 
             return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
         }
+
+        public override Task NullptrTest()
+        {
+            var inputContents = @"#include <cstddef>
+std::nullptr_t v = nullptr;";
+
+            var expectedOutputContents = @"using System;
+
+namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        [NativeTypeName(""std::nullptr_t"")]
+        public static IntPtr v = null;
+    }
+}
+";
+
+            return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/VarDeclarationTest.cs
@@ -327,5 +327,25 @@ namespace ClangSharp.Test
 
             return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
         }
+
+        public override Task NullptrTest()
+        {
+            var inputContents = @"#include <cstddef>
+std::nullptr_t v = nullptr;";
+
+            var expectedOutputContents = @"using System;
+
+namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        [NativeTypeName(""std::nullptr_t"")]
+        public static IntPtr v = null;
+    }
+}
+";
+
+            return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/VarDeclarationTest.cs
@@ -408,5 +408,28 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
             return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
         }
+
+        public override Task NullptrTest()
+        {
+            var inputContents = @"#include <cstddef>
+std::nullptr_t v = nullptr;";
+
+            var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"">
+      <constant name=""v"" access=""public"">
+        <type primitive=""False"">IntPtr</type>
+        <value>
+          <code>null</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/VarDeclarationTest.cs
@@ -430,5 +430,28 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
             return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
         }
+
+        public override Task NullptrTest()
+        {
+            var inputContents = @"#include <cstddef>
+std::nullptr_t v = nullptr;";
+
+            var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"">
+      <constant name=""v"" access=""public"">
+        <type primitive=""False"">IntPtr</type>
+        <value>
+          <code>null</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/VarDeclarationTest.cs
@@ -412,5 +412,28 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
             return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
         }
+
+        public override Task NullptrTest()
+        {
+            var inputContents = @"#include <cstddef>
+std::nullptr_t v = nullptr;";
+
+            var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"">
+      <constant name=""v"" access=""public"">
+        <type primitive=""False"">IntPtr</type>
+        <value>
+          <code>null</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/VarDeclarationTest.cs
@@ -430,5 +430,28 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
             return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
         }
+
+        public override Task NullptrTest()
+        {
+            var inputContents = @"#include <cstddef>
+std::nullptr_t v = nullptr;";
+
+            var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"">
+      <constant name=""v"" access=""public"">
+        <type primitive=""False"">IntPtr</type>
+        <value>
+          <code>null</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
     }
 }


### PR DESCRIPTION
The usual way of using the nullptr type of C++ is by using the STL provided `std::nullptr_t` which translates into `typedef decltype(nullptr) nullptr_t;`. Previously this would have produced a diagnostic from ClangSharp and `decltype(nullptr)` would be used in the output. 
Although this will surely not work for every possible of usage of `decltype` I have added a simple forwarding to the underlying type as reported by Clang which will then map to the built-in `CXType_NullPtr` type. But this would have produced declarations like `null myVariable` which is incorrect thus I have changed this to `IntPtr`. 

Alternatively we could output (or relay to the user) an additional type which would better represent the C++ nature of `std::nullptr_t` like the following:

```csharp
public readonly struct Nullptr
{
	private readonly IntPtr @value;
	public static readonly Nullptr Null = default;
}
					
public class Program
{
	static extern void A(Nullptr p);
	
	public static void Main()
	{
		A(new Nullptr());
		A(Nullptr.Null);
		A(default);
	}
}
```