### PR TITLE
Fix extraneous `using System;`

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -1843,7 +1843,7 @@ namespace ClangSharp
                 // can be treated correctly. Otherwise, they will resolve to a particular
                 // platform size, based on whatever parameters were passed into clang.
 
-                var remappedName = GetRemappedName(name, cursor, tryRemapOperatorName: false, out var wasRemapped);
+                var remappedName = GetRemappedName(name, cursor, tryRemapOperatorName: false, out var wasRemapped, skipUsing: true);
                 name = wasRemapped ? remappedName : GetTypeName(cursor, context, rootType, typedefType.Decl.UnderlyingType, out _);
             }
             else


### PR DESCRIPTION
The value returned from this function is never directly inserted into the source. For example, this function is called when calculating type size, meaning that any structure that transitively included an `IntPtr` field would insert a `using System;` into the generated file for that type, regardless of whether the file itself used `IntPtr`. Avoid inserting using statements in this function.