### PR TITLE
Add a few more options to help with "feature-completing" a set of bindings

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -36,8 +36,8 @@
     <PackageReference Update="libClang" Version="13.0.1" />
     <PackageReference Update="libClangSharp" Version="13.0.0-beta1" />
     <PackageReference Update="Microsoft.Bcl.HashCode" Version="1.1.1" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageReference Update="System.CommandLine" Version="2.0.0-beta1.21308.1" />
     <PackageReference Update="System.Memory" Version="4.5.4" />
     <PackageReference Update="xunit" Version="2.4.1" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -36,7 +36,7 @@
     <PackageReference Update="libClang" Version="13.0.1" />
     <PackageReference Update="libClangSharp" Version="13.0.0-beta1" />
     <PackageReference Update="Microsoft.Bcl.HashCode" Version="1.1.1" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageReference Update="System.CommandLine" Version="2.0.0-beta1.21308.1" />
     <PackageReference Update="System.Memory" Version="4.5.4" />

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Options:
   generate-tests-xunit                   Basic tests validating size, blittability, and associated metadata should be generated for XUnit.
   generate-aggressive-inlining           [MethodImpl(MethodImplOptions.AggressiveInlining)] should be added to generated helper functions.
   generate-cpp-attributes                [CppAttributeList("")] should be generated to document the encountered C++ attributes.
+  generate-doc-includes                  &lt;include&gt; xml documentation tags should be generated for declarations.
   generate-file-scoped-namespaces        Namespaces should be scoped to the file to reduce nesting.
   generate-helper-types                  Code files should be generated for various helper attributes and declared transparent structs.
   generate-macro-bindings                Bindings for macro-definitions should be generated. This currently only works with value like macros and not function-like ones.

--- a/sources/ClangSharp.PInvokeGenerator/Abstractions/FieldDesc.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Abstractions/FieldDesc.cs
@@ -10,6 +10,7 @@ namespace ClangSharp.Abstractions
         public AccessSpecifier AccessSpecifier { get; set; }
         public string NativeTypeName { get; set; }
         public string EscapedName { get; set; }
+        public string ParentName { get; set; }
         public int? Offset { get; set; }
         public bool NeedsNewKeyword { get; set; }
         public bool HasBody { get; set; }

--- a/sources/ClangSharp.PInvokeGenerator/Abstractions/FunctionOrDelegateDesc.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Abstractions/FunctionOrDelegateDesc.cs
@@ -12,6 +12,7 @@ namespace ClangSharp.Abstractions
         public string NativeTypeName { get; set; }
         public string EscapedName { get; set; }
         public string EntryPoint { get; set; }
+        public string ParentName { get; set; }
         public string LibraryPath { get; set; }
         public string ReturnType { get; set; }
         public CallingConvention CallingConvention { get; set; }
@@ -19,6 +20,7 @@ namespace ClangSharp.Abstractions
         public long? VtblIndex { get; set; }
         public CXSourceLocation? Location { get; set; }
         public bool HasBody { get; set; }
+        public bool IsInherited { get; set; }
 
         public bool IsVirtual
         {

--- a/sources/ClangSharp.PInvokeGenerator/Abstractions/ValueDesc.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Abstractions/ValueDesc.cs
@@ -11,6 +11,8 @@ namespace ClangSharp.Abstractions
         public string TypeName { get; set; }
         public string EscapedName { get; set; }
         public string NativeTypeName { get; set; }
+
+        public string ParentName { get; set; }
         public ValueKind Kind { get; set; }
         public ValueFlags Flags { get; set; }
         public CXSourceLocation? Location { get; set; }

--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
@@ -31,6 +31,17 @@ namespace ClangSharp.CSharp
 
         public void BeginValue(in ValueDesc desc)
         {
+            if (_config.GenerateDocIncludes && (desc.Kind == ValueKind.Enumerator))
+            {
+                WriteIndented("/// <include file='");
+                Write(desc.ParentName);
+                Write(".xml' path='doc/member[@name=\"");
+                Write(desc.ParentName);
+                Write('.');
+                Write(desc.EscapedName);
+                WriteLine("\"]/*' />");
+            }
+
             if (desc.NativeTypeName is not null)
             {
                 AddNativeTypeNameAttribute(desc.NativeTypeName);
@@ -174,6 +185,11 @@ namespace ClangSharp.CSharp
                 case ValueKind.Enumerator:
                 {
                     WriteLine(',');
+
+                    if (_config.GenerateDocIncludes)
+                    {
+                        NeedsNewline = true;
+                    }
                     break;
                 }
 
@@ -204,6 +220,15 @@ namespace ClangSharp.CSharp
 
         public void BeginEnum(in EnumDesc desc)
         {
+            if (_config.GenerateDocIncludes)
+            {
+                WriteIndented("/// <include file='");
+                Write(desc.EscapedName);
+                Write(".xml' path='doc/member[@name=\"");
+                Write(desc.EscapedName);
+                WriteLine("\"]/*' />");
+            }
+
             if (desc.NativeType is not null)
             {
                 AddNativeTypeNameAttribute(desc.NativeType);
@@ -234,6 +259,17 @@ namespace ClangSharp.CSharp
 
         public void BeginField(in FieldDesc desc)
         {
+            if (_config.GenerateDocIncludes && !string.IsNullOrWhiteSpace(desc.ParentName))
+            {
+                WriteIndented("/// <include file='");
+                Write(desc.ParentName);
+                Write(".xml' path='doc/member[@name=\"");
+                Write(desc.ParentName);
+                Write('.');
+                Write(desc.EscapedName);
+                WriteLine("\"]/*' />");
+            }
+
             if (desc.Offset is not null)
             {
                 WriteIndentedLine($"[FieldOffset({desc.Offset})]");
@@ -299,6 +335,28 @@ namespace ClangSharp.CSharp
 
         public void BeginFunctionOrDelegate(in FunctionOrDelegateDesc desc, ref bool isMethodClassUnsafe)
         {
+            if (_config.GenerateDocIncludes && !string.IsNullOrEmpty(desc.ParentName))
+            {
+                if (desc.IsInherited)
+                {
+                    WriteIndented("/// <inheritdoc cref=\"");
+                    Write(desc.ParentName);
+                    Write('.');
+                    Write(desc.EscapedName);
+                    WriteLine("\" />");
+                }
+                else
+                {
+                    WriteIndented("/// <include file='");
+                    Write(desc.ParentName);
+                    Write(".xml' path='doc/member[@name=\"");
+                    Write(desc.ParentName);
+                    Write('.');
+                    Write(desc.EscapedName);
+                    WriteLine("\"]/*' />");
+                }
+            }
+
             if (desc.IsVirtual)
             {
                 Debug.Assert(!desc.HasFnPtrCodeGen);
@@ -599,6 +657,15 @@ namespace ClangSharp.CSharp
 
         public void BeginStruct(in StructDesc desc)
         {
+            if (_config.GenerateDocIncludes)
+            {
+                WriteIndented("/// <include file='");
+                Write(desc.EscapedName);
+                Write(".xml' path='doc/member[@name=\"");
+                Write(desc.EscapedName);
+                WriteLine("\"]/*' />");
+            }
+
             if (desc.LayoutAttribute is not null)
             {
                 AddUsingDirective("System.Runtime.InteropServices");

--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
@@ -763,6 +763,10 @@ namespace ClangSharp.CSharp
                 WriteIndentedLine("where TSelf : unmanaged, Interface");
                 DecreaseIndentation();
             }
+            else
+            {
+                WriteNewline();
+            }
 
             WriteBlockStart();
         }

--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
@@ -687,7 +687,16 @@ namespace ClangSharp.CSharp
 
         public void BeginExplicitVtbl()
         {
-            WriteIndentedLine("public partial struct Vtbl");
+            WriteIndented("public partial struct Vtbl");
+
+            if (_config.GenerateMarkerInterfaces && !_config.ExcludeFnptrCodegen)
+            {
+                WriteLine("<TSelf>");
+                IncreaseIndentation();
+                WriteIndentedLine("where TSelf : unmanaged, Interface");
+                DecreaseIndentation();
+            }
+
             WriteBlockStart();
         }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -287,13 +287,12 @@ namespace ClangSharp
                 Flags = flags,
                 Location = enumConstantDecl.Location,
                 WriteCustomAttrs = static context => {
-                    (var name, var generator) = ((string, PInvokeGenerator))context;
-                    generator.WithAttributes(name);
+                    (var enumConstantDecl, var generator) = ((EnumConstantDecl, PInvokeGenerator))context;
 
-                    generator.WithUsings("*");
-                    generator.WithUsings(name);
+                    generator.WithAttributes(enumConstantDecl);
+                    generator.WithUsings(enumConstantDecl);
                 },
-                CustomAttrGeneratorData = (name, this),
+                CustomAttrGeneratorData = (enumConstantDecl, this),
             };
 
             _outputBuilder.BeginValue(in desc);
@@ -354,13 +353,12 @@ namespace ClangSharp
                         Location = enumDecl.Location,
                         IsNested = enumDecl.DeclContext is TagDecl,
                         WriteCustomAttrs = static context => {
-                            (var name, var generator) = ((string, PInvokeGenerator))context;
-                            generator.WithAttributes(name);
+                            (var enumDecl, var generator) = ((EnumDecl, PInvokeGenerator))context;
 
-                            generator.WithUsings("*");
-                            generator.WithUsings(name);
+                            generator.WithAttributes(enumDecl);
+                            generator.WithUsings(enumDecl);
                         },
-                        CustomAttrGeneratorData = (name, this),
+                        CustomAttrGeneratorData = (enumDecl, this),
                     };
 
                     _outputBuilder.BeginEnum(in desc);
@@ -405,13 +403,12 @@ namespace ClangSharp
                 NeedsNewKeyword = NeedsNewKeyword(name),
                 Location = fieldDecl.Location,
                 WriteCustomAttrs = static context => {
-                    (var name, var generator) = ((string, PInvokeGenerator))context;
-                    generator.WithAttributes(name);
+                    (var fieldDecl, var generator) = ((FieldDecl, PInvokeGenerator))context;
 
-                    generator.WithUsings("*");
-                    generator.WithUsings(name);
+                    generator.WithAttributes(fieldDecl);
+                    generator.WithUsings(fieldDecl);
                 },
-                CustomAttrGeneratorData = (name, this),
+                CustomAttrGeneratorData = (fieldDecl, this),
             };
 
             _outputBuilder.BeginField(in desc);
@@ -506,7 +503,7 @@ namespace ClangSharp
                 IsVirtual = isVirtual,
                 IsDllImport = isDllImport,
                 HasFnPtrCodeGen = !_config.ExcludeFnptrCodegen,
-                SetLastError = GetSetLastError(name),
+                SetLastError = GetSetLastError(functionDecl),
                 IsCxx = cxxMethodDecl is not null,
                 IsStatic = isDllImport || (cxxMethodDecl?.IsStatic ?? true),
                 NeedsNewKeyword = NeedsNewKeyword(escapedName, functionDecl.Parameters),
@@ -519,13 +516,17 @@ namespace ClangSharp
                 Location = functionDecl.Location,
                 HasBody = body is not null,
                 WriteCustomAttrs = static context => {
-                    (var name, var generator) = ((string, PInvokeGenerator))context;
-                    generator.WithAttributes(name);
+                    (var functionDecl, var outputBuilder, var generator) = ((FunctionDecl, IOutputBuilder, PInvokeGenerator))context;
 
-                    generator.WithUsings("*");
-                    generator.WithUsings(name);
+                    generator.WithAttributes(functionDecl);
+                    generator.WithUsings(functionDecl);
+
+                    if (generator.HasSuppressGCTransition(functionDecl))
+                    {
+                        outputBuilder.WriteCustomAttribute("SuppressGCTransition");
+                    }
                 },
-                CustomAttrGeneratorData = (name, this),
+                CustomAttrGeneratorData = (functionDecl, _outputBuilder, this),
             };
 
             _ = _isTopLevelClassUnsafe.TryGetValue(className, out var isUnsafe);
@@ -548,14 +549,6 @@ namespace ClangSharp
                 var parameterDesc = new ParameterDesc {
                     Name = "pThis",
                     Type = $"{cxxRecordEscapedName}*",
-                    WriteCustomAttrs = static context => {
-                        (var name, var generator) = ((string, PInvokeGenerator))context;
-                        generator.WithAttributes(name);
-
-                        generator.WithUsings("*");
-                        generator.WithUsings(name);
-                    },
-                    CustomAttrGeneratorData = ("pThis", this),
                 };
 
                 _outputBuilder.BeginParameter(in parameterDesc);
@@ -753,13 +746,12 @@ namespace ClangSharp
                 Location = fieldDecl.Location,
                 HasBody = true,
                 WriteCustomAttrs = static context => {
-                    (var name, var generator) = ((string, PInvokeGenerator))context;
-                    generator.WithAttributes(name);
+                    (var fieldDecl, var generator) = ((FieldDecl, PInvokeGenerator))context;
 
-                    generator.WithUsings("*");
-                    generator.WithUsings(name);
+                    generator.WithAttributes(fieldDecl);
+                    generator.WithUsings(fieldDecl);
                 },
-                CustomAttrGeneratorData = (name, this),
+                CustomAttrGeneratorData = (fieldDecl, this),
             };
 
             _outputBuilder.WriteDivider(true);
@@ -1002,11 +994,10 @@ namespace ClangSharp
                         : null,
                     Location = parmVarDecl.Location,
                     WriteCustomAttrs = static context => {
-                        (var name, var generator, var csharpOutputBuilder, var defaultArg) = ((string, PInvokeGenerator, CSharp.CSharpOutputBuilder, Expr))context;
-                        generator.WithAttributes(name);
+                        (var parmVarDecl, var generator, var csharpOutputBuilder, var defaultArg) = ((ParmVarDecl, PInvokeGenerator, CSharp.CSharpOutputBuilder, Expr))context;
 
-                        generator.WithUsings("*");
-                        generator.WithUsings(name);
+                        generator.WithAttributes(parmVarDecl);
+                        generator.WithUsings(parmVarDecl);
 
                         if (defaultArg is not null)
                         {
@@ -1020,7 +1011,7 @@ namespace ClangSharp
                             csharpOutputBuilder.WriteCustomAttribute("Optional", null);
                         }
                     },
-                    CustomAttrGeneratorData = (name, this, null as CSharp.CSharpOutputBuilder, null as Expr),
+                    CustomAttrGeneratorData = (parmVarDecl, this, null as CSharp.CSharpOutputBuilder, null as Expr),
                 };
 
                 var handledDefaultArg = false;
@@ -1036,7 +1027,7 @@ namespace ClangSharp
                         return _config.WithTransparentStructs.ContainsKey(typeName);
                     })))
                     {
-                        desc.CustomAttrGeneratorData = (name, this, csharpOutputBuilder, isExprDefaultValue ? null : parmVarDecl.DefaultArg);
+                        desc.CustomAttrGeneratorData = (parmVarDecl, this, csharpOutputBuilder, isExprDefaultValue ? null : parmVarDecl.DefaultArg);
                         handledDefaultArg = true;
                     }
                 }
@@ -1103,13 +1094,12 @@ namespace ClangSharp
                         : null,
                     Location = parmVarDecl.Location,
                     WriteCustomAttrs = static context => {
-                        (var name, var generator) = ((string, PInvokeGenerator))context;
-                        generator.WithAttributes(name);
+                        (var parmVarDecl, var generator) = ((ParmVarDecl, PInvokeGenerator))context;
 
-                        generator.WithUsings("*");
-                        generator.WithUsings(name);
+                        generator.WithAttributes(parmVarDecl);
+                        generator.WithUsings(parmVarDecl);
                     },
-                    CustomAttrGeneratorData = (name, this),
+                    CustomAttrGeneratorData = (parmVarDecl, this),
                 };
 
                 _outputBuilder.BeginParameter(in desc);
@@ -1171,8 +1161,7 @@ namespace ClangSharp
                     _testOutputBuilder.Write(escapedName);
                     _testOutputBuilder.WriteLine("\" /> struct.</summary>");
 
-                    WithAttributes("*", onlySupportedOSPlatform: true, isTestOutput: true);
-                    WithAttributes(name, onlySupportedOSPlatform: true, isTestOutput: true);
+                    WithAttributes(recordDecl, onlySupportedOSPlatform: true, isTestOutput: true);
 
                     _testOutputBuilder.WriteIndented("public static unsafe partial class ");
                     _testOutputBuilder.Write(escapedName);
@@ -1298,13 +1287,12 @@ namespace ClangSharp
                     Location = recordDecl.Location,
                     IsNested = recordDecl.DeclContext is TagDecl,
                     WriteCustomAttrs = static context => {
-                        (var name, var generator) = ((string, PInvokeGenerator))context;
-                        generator.WithAttributes(name);
+                        (var recordDecl, var generator) = ((RecordDecl, PInvokeGenerator))context;
 
-                        generator.WithUsings("*");
-                        generator.WithUsings(name);
+                        generator.WithAttributes(recordDecl);
+                        generator.WithUsings(recordDecl);
                     },
-                    CustomAttrGeneratorData = (name, this),
+                    CustomAttrGeneratorData = (recordDecl, this),
                 };
 
                 if (!isTopLevelStruct)
@@ -1378,14 +1366,6 @@ namespace ClangSharp
                         EscapedName = "lpVtbl",
                         Offset = null,
                         NeedsNewKeyword = false,
-                        WriteCustomAttrs = static context => {
-                            (var name, var generator) = ((string, PInvokeGenerator))context;
-                            generator.WithAttributes(name);
-
-                            generator.WithUsings("*");
-                            generator.WithUsings(name);
-                        },
-                        CustomAttrGeneratorData = ("lpVtbl", this),
                     };
 
                     _outputBuilder.BeginField(in fieldDesc);
@@ -1422,14 +1402,6 @@ namespace ClangSharp
                                 NeedsNewKeyword = false,
                                 InheritedFrom = parent,
                                 Location = cxxBaseSpecifier.Location,
-                                WriteCustomAttrs = static context => {
-                                    (var name, var generator) = ((string, PInvokeGenerator))context;
-                                    generator.WithAttributes(name);
-
-                                    generator.WithUsings("*");
-                                    generator.WithUsings(name);
-                                },
-                                CustomAttrGeneratorData = (baseFieldName, this),
                             };
 
                             _outputBuilder.BeginField(in fieldDesc);
@@ -1789,13 +1761,12 @@ namespace ClangSharp
                     VtblIndex = _config.GenerateVtblIndexAttribute ? cxxMethodDecl.VtblIndex : -1,
                     Location = cxxMethodDecl.Location,
                     WriteCustomAttrs = static context => {
-                        (var name, var generator) = ((string, PInvokeGenerator))context;
-                        generator.WithAttributes(name);
+                        (var cxxMethodDecl, var generator) = ((CXXMethodDecl, PInvokeGenerator))context;
 
-                        generator.WithUsings("*");
-                        generator.WithUsings(name);
+                        generator.WithAttributes(cxxMethodDecl);
+                        generator.WithUsings(cxxMethodDecl);
                     },
-                    CustomAttrGeneratorData = (name, this),
+                    CustomAttrGeneratorData = (cxxMethodDecl, this),
                 };
 
                 var isUnsafe = true;
@@ -1871,13 +1842,12 @@ namespace ClangSharp
                     NeedsNewKeyword = NeedsNewKeyword(remappedName),
                     Location = cxxMethodDecl.Location,
                     WriteCustomAttrs = static context => {
-                        (var name, var generator) = ((string, PInvokeGenerator))context;
-                        generator.WithAttributes(name);
+                        (var cxxMethodDecl, var generator) = ((CXXMethodDecl, PInvokeGenerator))context;
 
-                        generator.WithUsings("*");
-                        generator.WithUsings(name);
+                        generator.WithAttributes(cxxMethodDecl);
+                        generator.WithUsings(cxxMethodDecl);
                     },
-                    CustomAttrGeneratorData = (remappedName, this),
+                    CustomAttrGeneratorData = (cxxMethodDecl, this),
                 };
 
                 _outputBuilder.BeginField(in desc);
@@ -1932,13 +1902,12 @@ namespace ClangSharp
                     Location = cxxMethodDecl.Location,
                     HasBody = true,
                     WriteCustomAttrs = static context => {
-                        (var name, var generator) = ((string, PInvokeGenerator))context;
-                        generator.WithAttributes(name);
+                        (var cxxMethodDecl, var generator) = ((CXXMethodDecl, PInvokeGenerator))context;
 
-                        generator.WithUsings("*");
-                        generator.WithUsings(name);
+                        generator.WithAttributes(cxxMethodDecl);
+                        generator.WithUsings(cxxMethodDecl);
                     },
-                    CustomAttrGeneratorData = (name, this),
+                    CustomAttrGeneratorData = (cxxMethodDecl, this),
                 };
 
                 var isUnsafe = true;
@@ -2171,14 +2140,6 @@ namespace ClangSharp
                             Offset = fieldDecl.Parent.IsUnion ? 0 : null,
                             NeedsNewKeyword = false,
                             Location = fieldDecl.Location,
-                            WriteCustomAttrs = static context => {
-                                (var name, var generator) = ((string, PInvokeGenerator))context;
-                                generator.WithAttributes(name);
-
-                                generator.WithUsings("*");
-                                generator.WithUsings(name);
-                            },
-                            CustomAttrGeneratorData = (bitfieldName, this),
                         };
                         _outputBuilder.BeginField(in fieldDesc);
                         _outputBuilder.WriteRegularField(typeNameBacking, bitfieldName);
@@ -2368,13 +2329,12 @@ namespace ClangSharp
                     Location = fieldDecl.Location,
                     HasBody = true,
                     WriteCustomAttrs = static context => {
-                        (var name, var generator) = ((string, PInvokeGenerator))context;
-                        generator.WithAttributes(name);
+                        (var fieldDecl, var generator) = ((FieldDecl, PInvokeGenerator))context;
 
-                        generator.WithUsings("*");
-                        generator.WithUsings(name);
+                        generator.WithAttributes(fieldDecl);
+                        generator.WithUsings(fieldDecl);
                     },
-                    CustomAttrGeneratorData = (name, this),
+                    CustomAttrGeneratorData = (fieldDecl, this),
                 };
 
                 _outputBuilder.WriteDivider();
@@ -2621,13 +2581,12 @@ namespace ClangSharp
                     Location = constantArray.Location,
                     IsNested = true,
                     WriteCustomAttrs = static context => {
-                        (var name, var generator) = ((string, PInvokeGenerator))context;
-                        generator.WithAttributes(name);
+                        (var fieldDecl, var generator) = ((FieldDecl, PInvokeGenerator))context;
 
-                        generator.WithUsings("*");
-                        generator.WithUsings(name);
+                        generator.WithAttributes(fieldDecl);
+                        generator.WithUsings(fieldDecl);
                     },
-                    CustomAttrGeneratorData = (name, this),
+                    CustomAttrGeneratorData = (constantArray, this),
                 };
 
                 _outputBuilder.BeginStruct(in desc);
@@ -2673,14 +2632,6 @@ namespace ClangSharp
                         Offset = null,
                         NeedsNewKeyword = false,
                         Location = constantArray.Location,
-                        WriteCustomAttrs = static context => {
-                            (var name, var generator) = ((string, PInvokeGenerator))context;
-                            generator.WithAttributes(name);
-
-                            generator.WithUsings("*");
-                            generator.WithUsings(name);
-                        },
-                        CustomAttrGeneratorData = (fieldName, this),
                     };
 
                     _outputBuilder.BeginField(in fieldDesc);
@@ -2702,14 +2653,6 @@ namespace ClangSharp
                     var param = new ParameterDesc {
                         Name = "index",
                         Type = "int",
-                        WriteCustomAttrs = static context => {
-                            (var name, var generator) = ((string, PInvokeGenerator))context;
-                            generator.WithAttributes(name);
-
-                            generator.WithUsings("*");
-                            generator.WithUsings(name);
-                        },
-                        CustomAttrGeneratorData = ("index", this),
                     };
                     _outputBuilder.BeginParameter(in param);
                     _outputBuilder.EndParameter(in param);
@@ -2743,14 +2686,6 @@ namespace ClangSharp
                     var param = new ParameterDesc {
                         Name = "index",
                         Type = "int",
-                        WriteCustomAttrs = static context => {
-                            (var name, var generator) = ((string, PInvokeGenerator))context;
-                            generator.WithAttributes(name);
-
-                            generator.WithUsings("*");
-                            generator.WithUsings(name);
-                        },
-                        CustomAttrGeneratorData = ("index", this),
                     };
                     _outputBuilder.BeginParameter(in param);
                     _outputBuilder.EndParameter(in param);
@@ -2787,14 +2722,6 @@ namespace ClangSharp
                         ReturnType = $"Span<{typeName}>",
                         Location = constantArray.Location,
                         HasBody = true,
-                        WriteCustomAttrs = static context => {
-                            (var name, var generator) = ((string, PInvokeGenerator))context;
-                            generator.WithAttributes(name);
-
-                            generator.WithUsings("*");
-                            generator.WithUsings(name);
-                        },
-                        CustomAttrGeneratorData = ("AsSpan", this),
                     };
 
                     var isUnsafe = false;
@@ -2807,14 +2734,6 @@ namespace ClangSharp
                         param = new ParameterDesc {
                             Name = "length",
                             Type = "int",
-                            WriteCustomAttrs = static context => {
-                                (var name, var generator) = ((string, PInvokeGenerator))context;
-                                generator.WithAttributes(name);
-
-                                generator.WithUsings("*");
-                                generator.WithUsings(name);
-                            },
-                            CustomAttrGeneratorData = ("length", this),
                         };
 
                         _outputBuilder.BeginParameter(in param);
@@ -2892,13 +2811,12 @@ namespace ClangSharp
                         Location = typedefDecl.Location,
                         HasBody = true,
                         WriteCustomAttrs = static context => {
-                            (var name, var generator) = ((string, PInvokeGenerator))context;
-                            generator.WithAttributes(name);
+                            (var typedefDecl, var generator) = ((TypedefDecl, PInvokeGenerator))context;
 
-                            generator.WithUsings("*");
-                            generator.WithUsings(name);
+                            generator.WithAttributes(typedefDecl);
+                            generator.WithUsings(typedefDecl);
                         },
-                        CustomAttrGeneratorData = (name, this),
+                        CustomAttrGeneratorData = (typedefDecl, this),
                     };
 
                     var isUnsafe = desc.IsUnsafe;
@@ -3211,13 +3129,12 @@ namespace ClangSharp
                     Flags = flags,
                     Location = varDecl.Location,
                     WriteCustomAttrs = static context => {
-                        (var name, var generator) = ((string, PInvokeGenerator))context;
-                        generator.WithAttributes(name);
+                        (var varDecl, var generator) = ((VarDecl, PInvokeGenerator))context;
 
-                        generator.WithUsings("*");
-                        generator.WithUsings(name);
+                        generator.WithAttributes(varDecl);
+                        generator.WithUsings(varDecl);
                     },
-                    CustomAttrGeneratorData = (name, this),
+                    CustomAttrGeneratorData = (varDecl, this),
                 };
 
                 if (openedOutputBuilder)

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -1830,6 +1830,12 @@ namespace ClangSharp
 
                 var cxxMethodDeclTypeName = GetRemappedTypeName(cxxMethodDecl, cxxRecordDecl, cxxMethodDecl.Type, out var nativeTypeName, skipUsing: false, ignoreTransparentStructsWhereRequired: true);
 
+                if (_config.GenerateMarkerInterfaces && !_config.ExcludeFnptrCodegen)
+                {
+                    var cxxRecordDeclName = GetRemappedCursorName(cxxRecordDecl);
+                    cxxMethodDeclTypeName = cxxMethodDeclTypeName.Replace($"<{cxxRecordDeclName}*,", "<TSelf*,");
+                }
+
                 var remappedName = FixupNameForMultipleHits(cxxMethodDecl);
                 var escapedName = EscapeAndStripName(remappedName);
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -12,32 +12,28 @@ namespace ClangSharp
     {
         private const string DefaultMethodClassName = "Methods";
 
-        private readonly HashSet<string> _forceRemappedNames;
-        private readonly Dictionary<string, string> _remappedNames;
-        private readonly Dictionary<string, AccessSpecifier> _withAccessSpecifiers;
-        private readonly Dictionary<string, IReadOnlyList<string>> _withAttributes;
-        private readonly Dictionary<string, string> _withCallConvs;
-        private readonly Dictionary<string, string> _withClasses;
-        private readonly Dictionary<string, string> _withLibraryPaths;
-        private readonly Dictionary<string, string> _withNamespaces;
-        private readonly Dictionary<string, (string, PInvokeGeneratorTransparentStructKind)> _withTransparentStructs;
-        private readonly Dictionary<string, string> _withTypes;
-        private readonly Dictionary<string, IReadOnlyList<string>> _withUsings;
+        private readonly SortedSet<string> _excludedNames;
+        private readonly SortedSet<string> _forceRemappedNames;
+        private readonly SortedSet<string> _includedNames;
+        private readonly SortedSet<string> _traversalNames;
+        private readonly SortedSet<string> _withSetLastErrors;
+        private readonly SortedSet<string> _withSuppressGCTransitions;
+
+        private readonly SortedDictionary<string, string> _remappedNames;
+        private readonly SortedDictionary<string, AccessSpecifier> _withAccessSpecifiers;
+        private readonly SortedDictionary<string, IReadOnlyList<string>> _withAttributes;
+        private readonly SortedDictionary<string, string> _withCallConvs;
+        private readonly SortedDictionary<string, string> _withClasses;
+        private readonly SortedDictionary<string, string> _withLibraryPaths;
+        private readonly SortedDictionary<string, string> _withNamespaces;
+        private readonly SortedDictionary<string, (string, PInvokeGeneratorTransparentStructKind)> _withTransparentStructs;
+        private readonly SortedDictionary<string, string> _withTypes;
+        private readonly SortedDictionary<string, IReadOnlyList<string>> _withUsings;
 
         private PInvokeGeneratorConfigurationOptions _options;
 
-        public PInvokeGeneratorConfiguration(string libraryPath, string namespaceName, string outputLocation, string testOutputLocation, PInvokeGeneratorOutputMode outputMode = PInvokeGeneratorOutputMode.CSharp, PInvokeGeneratorConfigurationOptions options = PInvokeGeneratorConfigurationOptions.None, string[] excludedNames = null, string[] includedNames = null, string headerFile = null, string methodClassName = null, string methodPrefixToStrip = null, IReadOnlyDictionary<string, string> remappedNames = null, string[] traversalNames = null, IReadOnlyDictionary<string, string> withAccessSpecifiers = null, IReadOnlyDictionary<string, IReadOnlyList<string>> withAttributes = null, IReadOnlyDictionary<string, string> withCallConvs = null, IReadOnlyDictionary<string, string> withClasses = null, IReadOnlyDictionary<string, string> withLibraryPaths = null, IReadOnlyDictionary<string, string> withNamespaces = null, string[] withSetLastErrors = null, IReadOnlyDictionary<string, (string, PInvokeGeneratorTransparentStructKind)> withTransparentStructs = null, IReadOnlyDictionary<string, string> withTypes = null, IReadOnlyDictionary<string, IReadOnlyList<string>> withUsings = null)
+        public PInvokeGeneratorConfiguration(string libraryPath, string namespaceName, string outputLocation, string testOutputLocation, PInvokeGeneratorOutputMode outputMode = PInvokeGeneratorOutputMode.CSharp, PInvokeGeneratorConfigurationOptions options = PInvokeGeneratorConfigurationOptions.None, IReadOnlyCollection<string> excludedNames = null, IReadOnlyCollection<string> includedNames = null, string headerFile = null, string methodClassName = null, string methodPrefixToStrip = null, IReadOnlyDictionary<string, string> remappedNames = null, IReadOnlyCollection<string> traversalNames = null, IReadOnlyDictionary<string, string> withAccessSpecifiers = null, IReadOnlyDictionary<string, IReadOnlyList<string>> withAttributes = null, IReadOnlyDictionary<string, string> withCallConvs = null, IReadOnlyDictionary<string, string> withClasses = null, IReadOnlyDictionary<string, string> withLibraryPaths = null, IReadOnlyDictionary<string, string> withNamespaces = null, IReadOnlyCollection<string> withSetLastErrors = null, IReadOnlyCollection<string> withSuppressGCTransitions = null, IReadOnlyDictionary<string, (string, PInvokeGeneratorTransparentStructKind)> withTransparentStructs = null, IReadOnlyDictionary<string, string> withTypes = null, IReadOnlyDictionary<string, IReadOnlyList<string>> withUsings = null)
         {
-            if (excludedNames is null)
-            {
-                excludedNames = Array.Empty<string>();
-            }
-
-            if (includedNames is null)
-            {
-                includedNames = Array.Empty<string>();
-            }
-
             if (string.IsNullOrWhiteSpace(libraryPath))
             {
                 libraryPath = string.Empty;
@@ -83,32 +79,27 @@ namespace ClangSharp
                 throw new ArgumentNullException(nameof(outputLocation));
             }
 
-            if (traversalNames is null)
-            {
-                traversalNames = Array.Empty<string>();
-            }
-
-            if (withSetLastErrors is null)
-            {
-                withSetLastErrors = Array.Empty<string>();
-            }
-
             _options = options;
-            _forceRemappedNames = new HashSet<string>();
-            _remappedNames = new Dictionary<string, string>();
-            _withAccessSpecifiers = new Dictionary<string, AccessSpecifier>();
-            _withAttributes = new Dictionary<string, IReadOnlyList<string>>();
-            _withCallConvs = new Dictionary<string, string>();
-            _withClasses = new Dictionary<string, string>();
-            _withLibraryPaths = new Dictionary<string, string>();
-            _withNamespaces = new Dictionary<string, string>();
-            _withTransparentStructs = new Dictionary<string, (string, PInvokeGeneratorTransparentStructKind)>();
-            _withTypes = new Dictionary<string, string>();
-            _withUsings = new Dictionary<string, IReadOnlyList<string>>();
 
-            ExcludedNames = excludedNames;
+            _excludedNames = new SortedSet<string>();
+            _forceRemappedNames = new SortedSet<string>();
+            _includedNames = new SortedSet<string>();
+            _traversalNames = new SortedSet<string>();
+            _withSetLastErrors = new SortedSet<string>();
+            _withSuppressGCTransitions = new SortedSet<string>();
+
+            _remappedNames = new SortedDictionary<string, string>();
+            _withAccessSpecifiers = new SortedDictionary<string, AccessSpecifier>();
+            _withAttributes = new SortedDictionary<string, IReadOnlyList<string>>();
+            _withCallConvs = new SortedDictionary<string, string>();
+            _withClasses = new SortedDictionary<string, string>();
+            _withLibraryPaths = new SortedDictionary<string, string>();
+            _withNamespaces = new SortedDictionary<string, string>();
+            _withTransparentStructs = new SortedDictionary<string, (string, PInvokeGeneratorTransparentStructKind)>();
+            _withTypes = new SortedDictionary<string, string>();
+            _withUsings = new SortedDictionary<string, IReadOnlyList<string>>();
+
             HeaderText = string.IsNullOrWhiteSpace(headerFile) ? string.Empty : File.ReadAllText(headerFile);
-            IncludedNames = includedNames;
             LibraryPath = $@"""{libraryPath}""";
             DefaultClass = methodClassName;
             MethodPrefixToStrip = methodPrefixToStrip;
@@ -116,10 +107,6 @@ namespace ClangSharp
             OutputMode = outputMode;
             OutputLocation = Path.GetFullPath(outputLocation);
             TestOutputLocation = !string.IsNullOrWhiteSpace(testOutputLocation) ? Path.GetFullPath(testOutputLocation) : string.Empty;
-
-            // Normalize the traversal names to use \ rather than / so path comparisons are simpler
-            TraversalNames = traversalNames.Select(traversalName => traversalName.Replace('\\', '/')).ToArray();
-            WithSetLastErrors = withSetLastErrors;
 
             if (!_options.HasFlag(PInvokeGeneratorConfigurationOptions.NoDefaultRemappings))
             {
@@ -139,7 +126,13 @@ namespace ClangSharp
                 }
             }
 
+            AddRange(_excludedNames, excludedNames);
             AddRange(_forceRemappedNames, remappedNames, ValueStartsWithAt);
+            AddRange(_includedNames, includedNames);
+            AddRange(_traversalNames, traversalNames, NormalizePathSeparators);
+            AddRange(_withSetLastErrors, withSetLastErrors);
+            AddRange(_withSuppressGCTransitions, withSuppressGCTransitions);
+
             AddRange(_remappedNames, remappedNames, RemoveAtPrefix);
             AddRange(_withAccessSpecifiers, withAccessSpecifiers, ConvertStringToAccessSpecifier);
             AddRange(_withAttributes, withAttributes);
@@ -160,9 +153,9 @@ namespace ClangSharp
 
         public bool ExcludeEnumOperators => _options.HasFlag(PInvokeGeneratorConfigurationOptions.ExcludeEnumOperators);
 
-        public string[] ExcludedNames { get; }
+        public IReadOnlyCollection<string> ExcludedNames => _excludedNames;
 
-        public string[] IncludedNames { get; }
+        public IReadOnlyCollection<string> IncludedNames => _includedNames;
 
         public bool GenerateAggressiveInlining => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateAggressiveInlining);
 
@@ -254,7 +247,7 @@ namespace ClangSharp
 
         public string TestOutputLocation { get; }
 
-        public string[] TraversalNames { get; }
+        public IReadOnlyCollection<string> TraversalNames => _traversalNames;
 
         public IReadOnlyDictionary<string, AccessSpecifier> WithAccessSpcifier => _withAccessSpecifiers;
 
@@ -268,7 +261,9 @@ namespace ClangSharp
 
         public IReadOnlyDictionary<string, string> WithNamespaces => _withNamespaces;
 
-        public string[] WithSetLastErrors { get; }
+        public IReadOnlyCollection<string> WithSetLastErrors => _withSetLastErrors;
+
+        public IReadOnlyCollection<string> WithSuppressGCTransitions => _withSuppressGCTransitions;
 
         public IReadOnlyDictionary<string, (string Name, PInvokeGeneratorTransparentStructKind Kind)> WithTransparentStructs => _withTransparentStructs;
 
@@ -276,7 +271,7 @@ namespace ClangSharp
 
         public IReadOnlyDictionary<string, IReadOnlyList<string>> WithUsings => _withUsings;
 
-        private static void AddRange<TValue>(Dictionary<string, TValue> dictionary, IEnumerable<KeyValuePair<string, TValue>> keyValuePairs)
+        private static void AddRange<TValue>(SortedDictionary<string, TValue> dictionary, IEnumerable<KeyValuePair<string, TValue>> keyValuePairs)
         {
             if (keyValuePairs != null)
             {
@@ -289,7 +284,42 @@ namespace ClangSharp
             }
         }
 
-        private static void AddRange<TInput>(HashSet<string> hashSet, IEnumerable<KeyValuePair<string, TInput>> keyValuePairs, Func<TInput, bool> shouldAdd)
+        private static void AddRange<TInput, TValue>(SortedDictionary<string, TValue> dictionary, IEnumerable<KeyValuePair<string, TInput>> keyValuePairs, Func<TInput, TValue> convert)
+        {
+            if (keyValuePairs != null)
+            {
+                foreach (var keyValuePair in keyValuePairs)
+                {
+                    // Use the indexer, rather than Add, so that any
+                    // default mappings can be overwritten if desired.
+                    dictionary[keyValuePair.Key] = convert(keyValuePair.Value);
+                }
+            }
+        }
+
+        private static void AddRange<TInput>(SortedSet<TInput> hashSet, IEnumerable<TInput> keys)
+        {
+            if (keys != null)
+            {
+                foreach (var key in keys)
+                {
+                    _ = hashSet.Add(key);
+                }
+            }
+        }
+
+        private static void AddRange<TInput, TValue>(SortedSet<TValue> hashSet, IEnumerable<TInput> keys, Func<TInput, TValue> convert)
+        {
+            if (keys != null)
+            {
+                foreach (var key in keys)
+                {
+                    _ = hashSet.Add(convert(key));
+                }
+            }
+        }
+
+        private static void AddRange<TInput>(SortedSet<string> hashSet, IEnumerable<KeyValuePair<string, TInput>> keyValuePairs, Func<TInput, bool> shouldAdd)
         {
             if (keyValuePairs != null)
             {
@@ -299,19 +329,6 @@ namespace ClangSharp
                     {
                         _ = hashSet.Add(keyValuePair.Key);
                     }
-                }
-            }
-        }
-
-        private static void AddRange<TInput, TValue>(Dictionary<string, TValue> dictionary, IEnumerable<KeyValuePair<string, TInput>> keyValuePairs, Func<TInput, TValue> convert)
-        {
-            if (keyValuePairs != null)
-            {
-                foreach (var keyValuePair in keyValuePairs)
-                {
-                    // Use the indexer, rather than Add, so that any
-                    // default mappings can be overwritten if desired.
-                    dictionary[keyValuePair.Key] = convert(keyValuePair.Value);
                 }
             }
         }
@@ -347,6 +364,8 @@ namespace ClangSharp
                 return AccessSpecifier.None;
             }
         }
+
+        private static string NormalizePathSeparators(string value) => value.Replace('\\', '/');
 
         private static string RemoveAtPrefix(string value) => ValueStartsWithAt(value) ? value[1..] : value;
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -161,6 +161,8 @@ namespace ClangSharp
 
         public bool GenerateCompatibleCode => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateCompatibleCode);
 
+        public bool GenerateDocIncludes => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateDocIncludes);
+
         public bool GenerateExplicitVtbls => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateExplicitVtbls);
 
         public bool GenerateFileScopedNamespaces => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateFileScopedNamespaces);

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
@@ -72,5 +72,7 @@ namespace ClangSharp
         GenerateFileScopedNamespaces = 1UL << 30,
 
         GenerateSetsLastSystemErrorAttribute = 1UL << 31,
+
+        GenerateDocIncludes = 1UL << 32,
     }
 }

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -119,6 +119,7 @@ namespace ClangSharp
             AddWithLibraryPathOption(s_rootCommand);
             AddWithNamespaceOption(s_rootCommand);
             AddWithSetLastErrorOption(s_rootCommand);
+            AddWithSuppressGCTransitionOption(s_rootCommand);
             AddWithTransparentStructOption(s_rootCommand);
             AddWithTypeOption(s_rootCommand);
             AddWithUsingOption(s_rootCommand);
@@ -156,6 +157,7 @@ namespace ClangSharp
             var withLibraryPathNameValuePairs = context.ParseResult.ValueForOption<string[]>("--with-librarypath");
             var withNamespaceNameValuePairs = context.ParseResult.ValueForOption<string[]>("--with-namespace");
             var withSetLastErrors = context.ParseResult.ValueForOption<string[]>("--with-setlasterror");
+            var withSuppressGCTransitions = context.ParseResult.ValueForOption<string[]>("--with-suppressgctransition");
             var withTransparentStructNameValuePairs = context.ParseResult.ValueForOption<string[]>("--with-transparent-struct");
             var withTypeNameValuePairs = context.ParseResult.ValueForOption<string[]>("--with-type");
             var withUsingNameValuePairs = context.ParseResult.ValueForOption<string[]>("--with-using");
@@ -548,7 +550,7 @@ namespace ClangSharp
             translationFlags |= CXTranslationUnit_Flags.CXTranslationUnit_IncludeAttributedTypes;               // Include attributed types in CXType
             translationFlags |= CXTranslationUnit_Flags.CXTranslationUnit_VisitImplicitAttributes;              // Implicit attributes should be visited
 
-            var config = new PInvokeGeneratorConfiguration(libraryPath, namespaceName, outputLocation, testOutputLocation, outputMode, configOptions, excludedNames, includedNames, headerFile, methodClassName, methodPrefixToStrip, remappedNames, traversalNames, withAccessSpecifiers, withAttributes, withCallConvs, withClasses, withLibraryPath, withNamespaces, withSetLastErrors, withTransparentStructs, withTypes, withUsings);
+            var config = new PInvokeGeneratorConfiguration(libraryPath, namespaceName, outputLocation, testOutputLocation, outputMode, configOptions, excludedNames, includedNames, headerFile, methodClassName, methodPrefixToStrip, remappedNames, traversalNames, withAccessSpecifiers, withAttributes, withCallConvs, withClasses, withLibraryPath, withNamespaces, withSetLastErrors, withSuppressGCTransitions, withTransparentStructs, withTypes, withUsings);
 
             if (config.GenerateMacroBindings)
             {
@@ -1092,7 +1094,20 @@ namespace ClangSharp
         {
             var option = new Option(
                 aliases: new string[] { "--with-setlasterror", "-wsle" },
-                description: "Add the SetLastError=true modifier to a given DllImport or UnmanagedFunctionPointer.",
+                description: "Add the SetLastError=true modifier or SetsSystemLastError attribute to a given DllImport or UnmanagedFunctionPointer.",
+                argumentType: typeof(string),
+                getDefaultValue: Array.Empty<string>,
+                arity: ArgumentArity.OneOrMore
+            );
+
+            rootCommand.AddOption(option);
+        }
+
+        private static void AddWithSuppressGCTransitionOption(RootCommand rootCommand)
+        {
+            var option = new Option(
+                aliases: new string[] { "--with-suppressgctransition", "-wsgct" },
+                description: "Add the SuppressGCTransition calling convention to a given DllImport or UnmanagedFunctionPointer.",
                 argumentType: typeof(string),
                 getDefaultValue: Array.Empty<string>,
                 arity: ArgumentArity.OneOrMore

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Help;
 using System.CommandLine.Invocation;
-using System.CommandLine.IO;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -66,6 +65,7 @@ namespace ClangSharp
 
             new HelpItem("generate-aggressive-inlining", "[MethodImpl(MethodImplOptions.AggressiveInlining)] should be added to generated helper functions."),
             new HelpItem("generate-cpp-attributes", "[CppAttributeList(\"\")] should be generated to document the encountered C++ attributes."),
+            new HelpItem("generate-doc-includes", "<include> xml documentation tags should be generated for declarations."),
             new HelpItem("generate-file-scoped-namespaces", "Namespaces should be scoped to the file to reduce nesting."),
             new HelpItem("generate-helper-types", "Code files should be generated for various helper attributes and declared transparent structs."),
             new HelpItem("generate-macro-bindings", "Bindings for macro-definitions should be generated. This currently only works with value like macros and not function-like ones."),
@@ -398,6 +398,12 @@ namespace ClangSharp
                     case "generate-cpp-attributes":
                     {
                         configOptions |= PInvokeGeneratorConfigurationOptions.GenerateCppAttributes;
+                        break;
+                    }
+
+                    case "generate-doc-includes":
+                    {
+                        configOptions |= PInvokeGeneratorConfigurationOptions.GenerateDocIncludes;
                         break;
                     }
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/PInvokeGeneratorTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/PInvokeGeneratorTest.cs
@@ -64,7 +64,7 @@ namespace ClangSharp.UnitTests
             using var unsavedFile = CXUnsavedFile.Create(DefaultInputFileName, inputContents);
 
             var unsavedFiles = new CXUnsavedFile[] { unsavedFile };
-            var config = new PInvokeGeneratorConfiguration(libraryPath, DefaultNamespaceName, Path.GetRandomFileName(), testOutputLocation: null, outputMode, configOptions, excludedNames, includedNames: null, headerFile: null, methodClassName: null, methodPrefixToStrip: null, remappedNames, traversalNames: null, withAccessSpecifiers, withAttributes, withCallConvs, withClasses, withLibraryPaths, withNamespaces, withSetLastErrors, withTransparentStructs, withTypes, withUsings);
+            var config = new PInvokeGeneratorConfiguration(libraryPath, DefaultNamespaceName, Path.GetRandomFileName(), testOutputLocation: null, outputMode, configOptions, excludedNames, includedNames: null, headerFile: null, methodClassName: null, methodPrefixToStrip: null, remappedNames, traversalNames: null, withAccessSpecifiers, withAttributes, withCallConvs, withClasses, withLibraryPaths, withNamespaces, withSetLastErrors, withSuppressGCTransitions: null, withTransparentStructs, withTypes, withUsings);
 
             using (var pinvokeGenerator = new PInvokeGenerator(config, (path) => outputStream))
             {


### PR DESCRIPTION
This includes adding `SuppressGCTransition`, havin generated VTBLs be generic to assist with writing CCWs, and adding documentation comment links so that they can be provided without requiring ClangSharp to understand how to add them in.